### PR TITLE
fix: Invert condition for lifecycle method calls

### DIFF
--- a/src/com/android/launcher3/BaseActivity.java
+++ b/src/com/android/launcher3/BaseActivity.java
@@ -261,7 +261,7 @@ public abstract class BaseActivity extends Activity implements ActivityContext,
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        if (Utilities.ATLEAST_Q) {
+        if (!Utilities.ATLEAST_Q) {
             mLifecycleHelper.onActivityCreated(this, savedInstanceState);
         }
         registerBackDispatcher();
@@ -272,7 +272,7 @@ public abstract class BaseActivity extends Activity implements ActivityContext,
     protected void onStart() {
         addActivityFlags(ACTIVITY_STATE_STARTED);
         super.onStart();
-        if (Utilities.ATLEAST_Q) {
+        if (!Utilities.ATLEAST_Q) {
             mLifecycleHelper.onActivityStarted(this);
         }
         mEventCallbacks[EVENT_STARTED].executeAllAndClear();
@@ -282,7 +282,7 @@ public abstract class BaseActivity extends Activity implements ActivityContext,
     protected void onResume() {
         setResumed();
         super.onResume();
-        if (Utilities.ATLEAST_Q) {
+        if (!Utilities.ATLEAST_Q) {
             mLifecycleHelper.onActivityResumed(this);
         }
         mEventCallbacks[EVENT_RESUMED].executeAllAndClear();
@@ -307,7 +307,7 @@ public abstract class BaseActivity extends Activity implements ActivityContext,
         removeActivityFlags(ACTIVITY_STATE_STARTED | ACTIVITY_STATE_USER_ACTIVE);
         mForceInvisible = 0;
         super.onStop();
-        if (Utilities.ATLEAST_Q) {
+        if (!Utilities.ATLEAST_Q) {
             mLifecycleHelper.onActivityStopped(this);
         }
         mEventCallbacks[EVENT_STOPPED].executeAllAndClear();
@@ -321,7 +321,7 @@ public abstract class BaseActivity extends Activity implements ActivityContext,
     @Override
     protected void onDestroy() {
         super.onDestroy();
-        if (Utilities.ATLEAST_Q) {
+        if (!Utilities.ATLEAST_Q) {
             mLifecycleHelper.onActivityDestroyed(this);
         }
         mEventCallbacks[EVENT_DESTROYED].executeAllAndClear();
@@ -332,7 +332,7 @@ public abstract class BaseActivity extends Activity implements ActivityContext,
     protected void onPause() {
         setPaused();
         super.onPause();
-        if (Utilities.ATLEAST_Q) {
+        if (!Utilities.ATLEAST_Q) {
             mLifecycleHelper.onActivityPaused(this);
         }
 
@@ -346,7 +346,7 @@ public abstract class BaseActivity extends Activity implements ActivityContext,
     @Override
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
-        if (Utilities.ATLEAST_Q) {
+        if (!Utilities.ATLEAST_Q) {
             mLifecycleHelper.onActivitySaveInstanceState(this, outState);
         }
     }


### PR DESCRIPTION
Shouldn't mLifecycleHelper be called manually on versions OLDER than Q?

<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Fixes #(issue) <!-- optional -->

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->


### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
:x: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal lifecycle management logic to ensure correct behavior across different Android versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->