### PR TITLE
feat: Put widget to default page

### DIFF
--- a/lawnchair/res/xml/default_workspace_4x5.xml
+++ b/lawnchair/res/xml/default_workspace_4x5.xml
@@ -146,4 +146,22 @@
             launcher:packageName="com.android.settings" />
     </resolve>
 
+    <appwidget
+        launcher:className="com.android.calendar.widget.CalendarAppWidgetProvider"
+        launcher:packageName="com.google.android.calendar"
+        launcher:screen="0"
+        launcher:spanX="2"
+        launcher:spanY="2"
+        launcher:x="0"
+        launcher:y="4"/>
+
+    <appwidget
+        launcher:className="com.android.alarmclock.AnalogAppWidgetProvider"
+        launcher:packageName="com.google.android.deskclock"
+        launcher:screen="0"
+        launcher:spanX="2"
+        launcher:spanY="3"
+        launcher:x="2"
+        launcher:y="1"/>
+
 </favorites>

--- a/lawnchair/res/xml/default_workspace_4x5.xml
+++ b/lawnchair/res/xml/default_workspace_4x5.xml
@@ -147,15 +147,6 @@
     </resolve>
 
     <appwidget
-        launcher:className="com.android.calendar.widget.CalendarAppWidgetProvider"
-        launcher:packageName="com.google.android.calendar"
-        launcher:screen="0"
-        launcher:spanX="2"
-        launcher:spanY="2"
-        launcher:x="0"
-        launcher:y="4"/>
-
-    <appwidget
         launcher:className="com.android.alarmclock.AnalogAppWidgetProvider"
         launcher:packageName="com.google.android.deskclock"
         launcher:screen="0"


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

Showing widget(s) on first launch by default.

<details><summary>Screenshot</summary>
<p>

<img width="1080" height="2400" alt="Screenshot_20260330-170910" src="https://github.com/user-attachments/assets/ac261116-70a6-40c5-a9a2-3bdfd4b7b2ef" />

</p>
</details> 

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->

Match Pixel launcher first launch with our own touch, and it subjectively looks cool

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Delete data and open Lawnchair

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

Technically a new feature type of change?

✅ **New feature** (A non-breaking change that adds functionality)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Analog Clock widget from Google Clock (com.google.android.deskclock) is now included on the default home screen.

* **Changelog**
  * Updated default workspace to add the Analog Clock widget; no existing favorites or folders were removed or altered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->