### PR TITLE
feat: add EU version of Startpage as search engine

### DIFF
--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -732,6 +732,7 @@
     <!-- Search providers -->
     <string name="search_provider_app_search">App search</string>
     <string name="search_provider_startpage" translatable="false">Startpage</string>
+    <string name="search_provider_startpage_eu" translatable="false">Startpage (EU)</string>
     <string name="search_provider_google" translatable="false">Google</string>
     <string name="search_provider_google_go" translatable="false">Google Go</string>
     <string name="search_provider_duckduckgo" translatable="false">DuckDuckGo</string>

--- a/lawnchair/src/app/lawnchair/qsb/providers/QsbSearchProvider.kt
+++ b/lawnchair/src/app/lawnchair/qsb/providers/QsbSearchProvider.kt
@@ -137,6 +137,7 @@ sealed class QsbSearchProvider(
             Firefox,
             Iceraven,
             Startpage,
+            StartpageEU,
             IronFox,
             Kagi,
             Cromite,

--- a/lawnchair/src/app/lawnchair/qsb/providers/StartpageEU.kt
+++ b/lawnchair/src/app/lawnchair/qsb/providers/StartpageEU.kt
@@ -1,0 +1,30 @@
+package app.lawnchair.qsb.providers
+
+import app.lawnchair.animateToAllApps
+import app.lawnchair.preferences.PreferenceManager
+import app.lawnchair.qsb.ThemingMethod
+import com.android.launcher3.Launcher
+import com.android.launcher3.R
+
+data object StartpageEU : QsbSearchProvider(
+    id = "startpage-eu",
+    name = R.string.search_provider_startpage_eu,
+    icon = R.drawable.ic_startpage,
+    themingMethod = ThemingMethod.TINT,
+    packageName = "",
+    website = "https://eu.startpage.com/?segment=startpage.lawnchair",
+    type = QsbSearchProviderType.LOCAL,
+    sponsored = false,
+) {
+    override suspend fun launch(launcher: Launcher, forceWebsite: Boolean) {
+        val prefs = PreferenceManager.getInstance(launcher)
+        val useWebSuggestions = prefs.searchResultStartPageSuggestion.get()
+
+        if (useWebSuggestions) {
+            launcher.animateToAllApps()
+            launcher.appsView.searchUiManager.editText?.showKeyboard()
+        } else {
+            super.launch(launcher, forceWebsite)
+        }
+    }
+}

--- a/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/web/BuiltInWebSearchProviders.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/web/BuiltInWebSearchProviders.kt
@@ -257,7 +257,7 @@ object StartPageWebSearchProvider : WebSearchProvider {
      * Parses the StartPage OpenSearch JSON response.
      * Example: `["query", ["suggestion1", "suggestion2"]]`
      */
-    private fun parseStartPageResponse(responseBody: String): List<String> {
+    internal fun parseStartPageResponse(responseBody: String): List<String> {
         return try {
             val jsonArray = JSONArray(responseBody)
             val suggestionsArray = jsonArray.getJSONArray(1) // Suggestions are the second element
@@ -269,6 +269,71 @@ object StartPageWebSearchProvider : WebSearchProvider {
     }
 
     private const val TAG = "StartPageWebSearchProvider"
+
+    override fun toString(): String = id
+}
+
+/**
+ * Provides web search suggestions from StartPage EU.
+ */
+object StartPageEUWebSearchProvider : WebSearchProvider {
+    override val label = R.string.search_provider_startpage_eu
+
+    override val iconRes = R.drawable.ic_startpage
+
+    override val id: String = "startpage-eu"
+
+    private val retrofit: Retrofit by lazy {
+        Retrofit.Builder()
+            .baseUrl("https://eu.startpage.com/")
+            .addConverterFactory(StringConverterFactory.create())
+            .build()
+    }
+
+    private val service: StartPageEUService by lazy {
+        retrofit.create(StartPageEUService::class.java)
+    }
+
+    private interface StartPageEUService {
+        @GET("suggestions")
+        suspend fun getSuggestions(
+            @Query("q") query: String,
+            @Query("segment") segment: String = "startpage.lawnchair",
+            @Query("partner") partner: String = "lawnchair",
+            @Query("format") format: String = "opensearch",
+        ): Response<String>
+    }
+
+    override fun getSuggestions(query: String): Flow<List<String>> = flow {
+        if (query.isBlank()) {
+            emit(emptyList())
+            return@flow
+        }
+
+        try {
+            val encodedQuery = Uri.encode(query)
+            val response = service.getSuggestions(query = encodedQuery)
+
+            if (response.isSuccessful) {
+                val responseBody = response.body() ?: ""
+                val suggestions = StartPageWebSearchProvider.parseStartPageResponse(responseBody)
+                emit(suggestions)
+            } else {
+                Log.w(TAG, "Failed to retrieve EU suggestions: ${response.code()}")
+                emit(emptyList())
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error during EU suggestion retrieval", e)
+            emit(emptyList())
+        }
+    }.flowOn(Dispatchers.IO)
+
+    override fun getSearchUrl(query: String): String {
+        val encodedQuery = Uri.encode(query)
+        return "https://eu.startpage.com/do/search?query=$encodedQuery&cat=web"
+    }
+
+    private const val TAG = "StartPageEUWebSearchProvider"
 
     override fun toString(): String = id
 }

--- a/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/web/WebSearchProvider.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/web/WebSearchProvider.kt
@@ -52,6 +52,7 @@ interface WebSearchProvider {
             GoogleWebSearchProvider,
             DuckDuckGoWebSearchProvider,
             StartPageWebSearchProvider,
+            StartPageEUWebSearchProvider,
             KagiWebSearchProvider,
             CustomWebSearchProvider,
         )
@@ -60,6 +61,7 @@ interface WebSearchProvider {
             "google" -> GoogleWebSearchProvider
             "duckduckgo" -> DuckDuckGoWebSearchProvider
             "startpage" -> StartPageWebSearchProvider
+            "startpage-eu" -> StartPageEUWebSearchProvider
             "kagi" -> KagiWebSearchProvider
             "custom" -> CustomWebSearchProvider
             else -> GoogleWebSearchProvider


### PR DESCRIPTION
Added `eu.startpage.com` as a separate search engine option alongside the existing Startpage provider.

- New `StartPageEUWebSearchProvider` with EU-specific base URL and search endpoint
- New `StartpageEU` QSB provider registered in the provider list
- Registered in `WebSearchProvider.fromId` as `"startpage-eu"`
- Made `parseStartPageResponse` internal so the EU variant can reuse the same parsing logic
- Reuses the existing `ic_startpage` icon

This routes searches through European servers for users who prefer EU-based privacy.

Closes #6507

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Startpage (EU) as a new search provider option
  * Enabled search suggestions from Startpage EU service

<!-- end of auto-generated comment: release notes by coderabbit.ai -->