### PR TITLE
fix: infinite scroll wrap animation direction

### DIFF
--- a/src/com/android/launcher3/PagedView.java
+++ b/src/com/android/launcher3/PagedView.java
@@ -1360,10 +1360,16 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
                     if (prefs.getInfiniteScrolling().get() && !mFreeScroll && getChildCount() > 1) {
                         boolean enableFeed = PreferenceExtensionsKt.firstBlocking(prefs2.getEnableFeed());
                         float pulledTo = oldScroll + delta;
-                        if (!isWrapScrolling() && mCurrentPage == getChildCount() - 1 && pulledTo > mMaxScroll) {
-                            startWrapDrag(0);
-                        } else if (!isWrapScrolling() && mCurrentPage == 0 && !enableFeed && pulledTo < mMinScroll) {
-                            startWrapDrag(getChildCount() - 1);
+                        if (!isWrapScrolling() && mCurrentPage == getChildCount() - 1) {
+                            boolean pastEnd = mIsRtl ? pulledTo < mMinScroll : pulledTo > mMaxScroll;
+                            if (pastEnd) {
+                                startWrapDrag(0);
+                            }
+                        } else if (!isWrapScrolling() && mCurrentPage == 0 && !enableFeed) {
+                            boolean pastStart = mIsRtl ? pulledTo > mMaxScroll : pulledTo < mMinScroll;
+                            if (pastStart) {
+                                startWrapDrag(getChildCount() - 1);
+                            }
                         }
                     }
 

--- a/src/com/android/launcher3/PagedView.java
+++ b/src/com/android/launcher3/PagedView.java
@@ -1208,7 +1208,7 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
 
     protected float getScrollProgress(int screenCenter, View v, int page) {
         final int halfScreenSize = getMeasuredWidth() / 2;
-        int delta = screenCenter - (getScrollForPage(page) + halfScreenSize);
+        int delta = screenCenter - (getVisualScrollForPage(page) + halfScreenSize);
         int panelCount = getPanelCount();
         int pageCount = getChildCount();
 
@@ -1221,7 +1221,8 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
         if (adjacentPage < 0 || adjacentPage > pageCount - 1) {
             totalDistance = (v.getMeasuredWidth() + mPageSpacing) * panelCount;
         } else {
-            totalDistance = Math.abs(getScrollForPage(adjacentPage) - getScrollForPage(page));
+            totalDistance = Math.abs(getVisualScrollForPage(adjacentPage)
+                    - getVisualScrollForPage(page));
         }
 
         float scrollProgress = delta / (totalDistance * 1.0f);
@@ -1233,9 +1234,26 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
     public int getScrollForPage(int index) {
         if (!isPageScrollsInitialized() || index >= mPageScrolls.length || index < 0) {
             return 0;
-        } else {
-            return mPageScrolls[index];
         }
+        return mPageScrolls[index];
+    }
+
+    /**
+     * Returns the visual scroll position for a page, accounting for wrap-scroll translation.
+     * Only used by getScrollProgress so that alpha/scroll-progress calculations see the
+     * correct on-screen location of the wrap target.
+     */
+    private int getVisualScrollForPage(int index) {
+        int scroll = getScrollForPage(index);
+        if (isWrapScrolling() && index == mWrapToPage) {
+            int totalWidth = mSavedMaxScroll - mSavedMinScroll + getOnePageDistance();
+            if ((mWrapToPage == 0) != mIsRtl) {
+                scroll += totalWidth;
+            } else {
+                scroll -= totalWidth;
+            }
+        }
+        return scroll;
     }
 
     // While layout transitions are occurring, a child's position may stray from its baseline
@@ -1457,11 +1475,17 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
 
                     if (((isSignificantMove && !isDeltaLeft && !isFling) ||
                             (isFling && !isVelocityLeft)) && mCurrentPage > 0) {
+                        if (isWrapScrolling()) {
+                            cancelWrapScroll();
+                        }
                         finalPage = returnToOriginalPage
                                 ? mCurrentPage : mCurrentPage - getPanelCount();
                         runOnPageScrollsInitialized(
                                 () -> snapToPageWithVelocity(finalPage, velocity));
                     } else if (((isSignificantMove && isDeltaLeft && !isFling) || (isFling && isVelocityLeft)) && mCurrentPage < getChildCount() - 1) {
+                        if (isWrapScrolling()) {
+                            cancelWrapScroll();
+                        }
                         finalPage = returnToOriginalPage ? mCurrentPage : mCurrentPage + getPanelCount();
                         runOnPageScrollsInitialized(() -> snapToPageWithVelocity(finalPage, velocity));
 					} else if (mCurrentPage == getChildCount() - 1 && infiniteScroll) {
@@ -1471,7 +1495,7 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
                                     () -> snapToPageWrapped(finalPage, velocity));
                         } else {
                             if (isWrapScrolling()) {
-                                finalizeWrapScroll();
+                                cancelWrapScroll();
                             }
                             runOnPageScrollsInitialized(
                                     () -> snapToPageWithVelocity(finalPage, velocity));
@@ -1483,14 +1507,14 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
                                     () -> snapToPageWrapped(finalPage, velocity));
                         } else {
                             if (isWrapScrolling()) {
-                                finalizeWrapScroll();
+                                cancelWrapScroll();
                             }
                             runOnPageScrollsInitialized(
                                     () -> snapToPageWithVelocity(finalPage, velocity));
                         }
                     } else {
                         if (isWrapScrolling()) {
-                            finalizeWrapScroll();
+                            cancelWrapScroll();
                         }
                         runOnPageScrollsInitialized(this::snapToDestination);
                     }
@@ -1542,7 +1566,7 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
         case MotionEvent.ACTION_CANCEL:
             if (mIsBeingDragged) {
                 if (isWrapScrolling()) {
-                    finalizeWrapScroll();
+                    cancelWrapScroll();
                 }
                 runOnPageScrollsInitialized(this::snapToDestination);
             }
@@ -1811,6 +1835,24 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
     }
 
     /**
+     * Cancels wrap-scroll state without jumping scroll position.
+     * Used when the user drags back or the gesture is cancelled, so the subsequent
+     * snapToPage animates from the current drag position instead of jumping first.
+     */
+    private void cancelWrapScroll() {
+        if (!isWrapScrolling()) {
+            return;
+        }
+        View targetView = getPageAt(mWrapToPage);
+        if (targetView != null) {
+            targetView.setTranslationX(0);
+        }
+        mWrapToPage = INVALID_PAGE;
+        mMinScroll = mSavedMinScroll;
+        mMaxScroll = mSavedMaxScroll;
+    }
+
+    /**
      * Returns the scroll value to use for the page indicator during wrap scrolling.
      * Maps out-of-bounds scroll values back into the normal range so dots animate correctly.
      */
@@ -1833,6 +1875,7 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
         return scroll;
     }
 
+    // Returns 0 on two-panel (foldable) workspaces, disabling wrap scroll.
     private int getOnePageDistance() {
         if (!isPageScrollsInitialized() || mPageScrolls.length < 2) {
             return 0;

--- a/src/com/android/launcher3/PagedView.java
+++ b/src/com/android/launcher3/PagedView.java
@@ -135,6 +135,14 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
     @Nullable protected int[] mPageScrolls = null;
     private boolean mIsBeingDragged;
 
+    private int mWrapToPage = INVALID_PAGE;
+    private int mSavedMinScroll;
+    private int mSavedMaxScroll;
+
+    private boolean isWrapScrolling() {
+        return mWrapToPage != INVALID_PAGE;
+    }
+
     // The amount of movement to begin scrolling
     protected int mTouchSlop;
     // The amount of movement to begin paging
@@ -279,6 +287,9 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
 
     private void abortScrollerAnimation(boolean resetNextPage) {
         mScroller.abortAnimation();
+        if (isWrapScrolling()) {
+            finalizeWrapScroll();
+        }
         onScrollerAnimationAborted();
         // We need to clean up the next page here to avoid computeScrollHelper from
         // updating current page on the pass.
@@ -294,6 +305,9 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
      */
     public void forceFinishScroller() {
         mScroller.forceFinished(true);
+        if (isWrapScrolling()) {
+            finalizeWrapScroll();
+        }
         // We need to clean up the next page here to avoid computeScrollHelper from
         // updating current page on the pass.
         mNextPage = INVALID_PAGE;
@@ -574,7 +588,7 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
                 mOrientationHandler.setPrimary(this, VIEW_SCROLL_TO, mScroller.getCurrX());
             }
 
-            if (mAllowOverScroll) {
+            if (mAllowOverScroll && !isWrapScrolling()) {
                 if (newPos < mMinScroll && oldPos >= mMinScroll) {
                     mEdgeGlowLeft.onAbsorb((int) mScroller.getCurrVelocity());
                     abortScrollerAnimation(false);
@@ -1343,9 +1357,19 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
                 mLastMotion = direction;
 
                 if (delta != 0) {
+                    if (prefs.getInfiniteScrolling().get() && !mFreeScroll && getChildCount() > 1) {
+                        boolean enableFeed = PreferenceExtensionsKt.firstBlocking(prefs2.getEnableFeed());
+                        float pulledTo = oldScroll + delta;
+                        if (!isWrapScrolling() && mCurrentPage == getChildCount() - 1 && pulledTo > mMaxScroll) {
+                            startWrapDrag(0);
+                        } else if (!isWrapScrolling() && mCurrentPage == 0 && !enableFeed && pulledTo < mMinScroll) {
+                            startWrapDrag(getChildCount() - 1);
+                        }
+                    }
+
                     mOrientationHandler.setPrimary(this, VIEW_SCROLL_BY, delta);
 
-                    if (mAllowOverScroll) {
+                    if (mAllowOverScroll && !isWrapScrolling()) {
                         final float pulledToX = oldScroll + delta;
 
                         if (pulledToX < mMinScroll) {
@@ -1436,12 +1460,32 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
                         runOnPageScrollsInitialized(() -> snapToPageWithVelocity(finalPage, velocity));
 					} else if (mCurrentPage == getChildCount() - 1 && infiniteScroll) {
                         finalPage = returnToOriginalPage ? mCurrentPage : 0;
-                        snapToPageWithVelocity(finalPage, velocity);
+                        if (!returnToOriginalPage) {
+                            runOnPageScrollsInitialized(
+                                    () -> snapToPageWrapped(finalPage, velocity));
+                        } else {
+                            if (isWrapScrolling()) {
+                                finalizeWrapScroll();
+                            }
+                            runOnPageScrollsInitialized(
+                                    () -> snapToPageWithVelocity(finalPage, velocity));
+                        }
                     } else if (mCurrentPage == 0 && infiniteScroll && !enableFeed) {
                         finalPage = returnToOriginalPage ? mCurrentPage : getChildCount() - 1;
-                        snapToPageWithVelocity(finalPage, velocity);
-	
+                        if (!returnToOriginalPage) {
+                            runOnPageScrollsInitialized(
+                                    () -> snapToPageWrapped(finalPage, velocity));
+                        } else {
+                            if (isWrapScrolling()) {
+                                finalizeWrapScroll();
+                            }
+                            runOnPageScrollsInitialized(
+                                    () -> snapToPageWithVelocity(finalPage, velocity));
+                        }
                     } else {
+                        if (isWrapScrolling()) {
+                            finalizeWrapScroll();
+                        }
                         runOnPageScrollsInitialized(this::snapToDestination);
                     }
                 } else {
@@ -1491,6 +1535,9 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
 
         case MotionEvent.ACTION_CANCEL:
             if (mIsBeingDragged) {
+                if (isWrapScrolling()) {
+                    finalizeWrapScroll();
+                }
                 runOnPageScrollsInitialized(this::snapToDestination);
             }
             mEdgeGlowLeft.onRelease(ev);
@@ -1697,9 +1744,98 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
         return (float) Math.sin(f);
     }
 
+    /**
+     * Initiates a wrap-scroll animation that moves one page distance in the correct swipe
+     * direction when wrapping between first↔last page.
+     */
+    private void snapToPageWrapped(int targetPage, int velocity) {
+        if (!mScroller.isFinished()) {
+            abortScrollerAnimation(false);
+        }
+        if (!isWrapScrolling()) {
+            startWrapDrag(targetPage);
+        }
+        if (!isWrapScrolling()) {
+            return;
+        }
+
+        int onePageDistance = getOnePageDistance();
+        if (onePageDistance == 0) {
+            finalizeWrapScroll();
+            return;
+        }
+
+        int currentScroll = mOrientationHandler.getPrimaryScroll(this);
+        // In LTR: wrapping to page 0 means target is to the right (beyond maxScroll).
+        // In RTL: directions are reversed.
+        int virtualTarget = ((targetPage == 0) != mIsRtl)
+                ? mSavedMaxScroll + onePageDistance
+                : mSavedMinScroll - onePageDistance;
+        int delta = virtualTarget - currentScroll;
+        int duration = computeSnapDuration(delta, velocity);
+
+        mNextPage = validateNewPage(targetPage);
+        pageBeginTransition();
+        mScroller.startScroll(currentScroll, 0, delta, 0, duration);
+        updatePageIndicator();
+        invalidate();
+    }
+
+    /**
+     * Resets wrap-scroll state: clears translation, restores scroll bounds, and jumps
+     * scroll position to the target page's real location.
+     */
+    private void finalizeWrapScroll() {
+        if (!isWrapScrolling()) {
+            return;
+        }
+        int targetPage = mWrapToPage;
+        mWrapToPage = INVALID_PAGE;
+
+        View targetView = getPageAt(targetPage);
+        if (targetView != null) {
+            targetView.setTranslationX(0);
+        }
+
+        mMinScroll = mSavedMinScroll;
+        mMaxScroll = mSavedMaxScroll;
+
+        int targetScroll = getScrollForPage(targetPage);
+        mOrientationHandler.setPrimary(this, VIEW_SCROLL_TO, targetScroll);
+    }
+
+    /**
+     * Returns the scroll value to use for the page indicator during wrap scrolling.
+     * Maps out-of-bounds scroll values back into the normal range so dots animate correctly.
+     */
+    protected int getScrollForPageIndicator() {
+        int scroll = getScrollX();
+        if (!isWrapScrolling() || !isPageScrollsInitialized() || getChildCount() < 2) {
+            return scroll;
+        }
+        int onePageDistance = getOnePageDistance();
+        if (onePageDistance == 0) {
+            return scroll;
+        }
+        int totalRange = computeMaxScroll() + onePageDistance;
+        if (scroll > mSavedMaxScroll) {
+            return scroll - totalRange;
+        }
+        if (scroll < mSavedMinScroll) {
+            return scroll + totalRange;
+        }
+        return scroll;
+    }
+
+    private int getOnePageDistance() {
+        if (!isPageScrollsInitialized() || mPageScrolls.length < 2) {
+            return 0;
+        }
+        return Math.abs(mPageScrolls[1] - mPageScrolls[0]);
+    }
+
     protected boolean snapToPageWithVelocity(int whichPage, int velocity) {
         whichPage = validateNewPage(whichPage);
-        int halfScreenSize = mOrientationHandler.getMeasuredSize(this) / 2;
 
         final int newLoc = getScrollForPage(whichPage);
         int delta = newLoc - mOrientationHandler.getPrimaryScroll(this);
@@ -1711,6 +1847,47 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
             return snapToPage(whichPage, getSnapAnimationDuration());
         }
 
+        duration = computeSnapDuration(delta, velocity);
+
+        return snapToPage(whichPage, delta, duration);
+    }
+
+    /**
+     * Begins a wrap-drag by translating the target page's View next to the current page
+     * and extending scroll bounds so scrollTo doesn't clamp.
+     */
+    private void startWrapDrag(int targetPage) {
+        if (!isPageScrollsInitialized() || getChildCount() < 2 || isWrapScrolling()) {
+            return;
+        }
+        int onePageDistance = getOnePageDistance();
+        if (onePageDistance == 0) {
+            return;
+        }
+        View targetView = getPageAt(targetPage);
+        if (targetView == null) {
+            return;
+        }
+
+        int totalWidth = mMaxScroll - mMinScroll + onePageDistance;
+        mSavedMinScroll = mMinScroll;
+        mSavedMaxScroll = mMaxScroll;
+        mWrapToPage = targetPage;
+
+        // In LTR: page 0 is leftmost. Wrapping to page 0 from last page means we place
+        // page 0 to the right of the last page (positive translation).
+        // In RTL: page 0 is rightmost, so wrapping to page 0 means placing it to the left.
+        if ((targetPage == 0) != mIsRtl) {
+            targetView.setTranslationX(totalWidth);
+            mMaxScroll = mSavedMaxScroll + onePageDistance;
+        } else {
+            targetView.setTranslationX(-totalWidth);
+            mMinScroll = mSavedMinScroll - onePageDistance;
+        }
+    }
+
+    private int computeSnapDuration(int delta, int velocity) {
+        int halfScreenSize = mOrientationHandler.getMeasuredSize(this) / 2;
         // Here we compute a "distance" that will be used in the computation of the overall
         // snap duration. This is a function of the actual distance that needs to be traveled;
         // we keep this value close to half screen size in order to reduce the variance in snap
@@ -1725,9 +1902,7 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
         // we want the page's snap velocity to approximately match the velocity at which the
         // user flings, so we scale the duration by a value near to the derivative of the scroll
         // interpolator at zero, ie. 5. We use 4 to make it a little slower.
-        duration = 4 * Math.round(1000 * Math.abs(distance / velocity));
-
-        return snapToPage(whichPage, delta, duration);
+        return 4 * Math.round(1000 * Math.abs(distance / velocity));
     }
 
     protected int getSnapAnimationDuration() {

--- a/src/com/android/launcher3/PagedView.java
+++ b/src/com/android/launcher3/PagedView.java
@@ -1266,7 +1266,12 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
 
             int scrollOffset = mIsRtl ? getPaddingRight() : getPaddingLeft();
             int baselineX = mPageScrolls[index] + scrollOffset;
-            return (int) (child.getX() - baselineX);
+            float childX = child.getX();
+            // Wrap-scroll's translationX isn't a layout transition; don't let it skew parallax offset.
+            if (isWrapScrolling() && index == mWrapToPage) {
+                childX -= child.getTranslationX();
+            }
+            return (int) (childX - baselineX);
         }
     }
 
@@ -1871,6 +1876,33 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
         }
         if (scroll < mSavedMinScroll) {
             return scroll + totalRange;
+        }
+        return scroll;
+    }
+
+    /**
+     * Returns the scroll value to use for wallpaper parallax during wrap scrolling.
+     * While the page wraps one page distance via translationX, the wallpaper sweeps the full
+     * scroll range in the opposite direction so it slides continuously from one edge to the
+     * other (matching the pre-wrap-animation behavior and other launchers like Nova).
+     */
+    public int getScrollForWallpaper() {
+        int scroll = getScrollX();
+        if (!isWrapScrolling() || !isPageScrollsInitialized() || getChildCount() < 2) {
+            return scroll;
+        }
+        int onePageDistance = getOnePageDistance();
+        if (onePageDistance == 0) {
+            return scroll;
+        }
+        int scrollRange = mSavedMaxScroll - mSavedMinScroll;
+        if (scroll > mSavedMaxScroll) {
+            float progress = (float) (scroll - mSavedMaxScroll) / onePageDistance;
+            return Math.round(mSavedMaxScroll - progress * scrollRange);
+        }
+        if (scroll < mSavedMinScroll) {
+            float progress = (float) (mSavedMinScroll - scroll) / onePageDistance;
+            return Math.round(mSavedMinScroll + progress * scrollRange);
         }
         return scroll;
     }

--- a/src/com/android/launcher3/PagedView.java
+++ b/src/com/android/launcher3/PagedView.java
@@ -138,6 +138,7 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
     private int mWrapToPage = INVALID_PAGE;
     private int mSavedMinScroll;
     private int mSavedMaxScroll;
+    private boolean mCachedEnableFeed;
 
     private boolean isWrapScrolling() {
         return mWrapToPage != INVALID_PAGE;
@@ -1329,6 +1330,7 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
             mTotalMotion = 0;
             mAllowEasyFling = false;
             mActivePointerId = ev.getPointerId(0);
+            mCachedEnableFeed = PreferenceCacheExtensionsKt.firstCached(prefs2.getEnableFeed());
             if (mIsBeingDragged) {
                 pageBeginTransition();
             }
@@ -1381,7 +1383,7 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
 
                 if (delta != 0) {
                     if (prefs.getInfiniteScrolling().get() && !mFreeScroll && getChildCount() > 1) {
-                        boolean enableFeed = PreferenceExtensionsKt.firstBlocking(prefs2.getEnableFeed());
+                        boolean enableFeed = mCachedEnableFeed;
                         float pulledTo = oldScroll + delta;
                         if (!isWrapScrolling() && mCurrentPage == getChildCount() - 1) {
                             boolean pastEnd = mIsRtl ? pulledTo < mMinScroll : pulledTo > mMaxScroll;
@@ -1476,7 +1478,7 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
                     // move to the left and fling to the right will register as a fling to the right.
 
                     boolean infiniteScroll = prefs.getInfiniteScrolling().get();
-                    boolean enableFeed = PreferenceCacheExtensionsKt.firstCached(prefs2.getEnableFeed());
+                    boolean enableFeed = mCachedEnableFeed;
 
                     if (((isSignificantMove && !isDeltaLeft && !isFling) ||
                             (isFling && !isVelocityLeft)) && mCurrentPage > 0) {
@@ -1853,6 +1855,9 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
             targetView.setTranslationX(0);
         }
         mWrapToPage = INVALID_PAGE;
+        int clamped = Utilities.boundToRange(
+                mOrientationHandler.getPrimaryScroll(this), mSavedMinScroll, mSavedMaxScroll);
+        mOrientationHandler.setPrimary(this, VIEW_SCROLL_TO, clamped);
         mMinScroll = mSavedMinScroll;
         mMaxScroll = mSavedMaxScroll;
     }

--- a/src/com/android/launcher3/PagedView.java
+++ b/src/com/android/launcher3/PagedView.java
@@ -135,6 +135,7 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
     @Nullable protected int[] mPageScrolls = null;
     private boolean mIsBeingDragged;
 
+    // LC-Note: Track temporary page translation and bounds for animated infinite scrolling.
     private int mWrapToPage = INVALID_PAGE;
     private int mSavedMinScroll;
     private int mSavedMaxScroll;
@@ -288,6 +289,7 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
 
     private void abortScrollerAnimation(boolean resetNextPage) {
         mScroller.abortAnimation();
+        // LC-Note: Restore temporary infinite-scroll state when AOSP aborts an animation.
         if (isWrapScrolling()) {
             finalizeWrapScroll();
         }
@@ -306,6 +308,7 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
      */
     public void forceFinishScroller() {
         mScroller.forceFinished(true);
+        // LC-Note: Restore temporary infinite-scroll state when AOSP finishes an animation.
         if (isWrapScrolling()) {
             finalizeWrapScroll();
         }
@@ -589,6 +592,7 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
                 mOrientationHandler.setPrimary(this, VIEW_SCROLL_TO, mScroller.getCurrX());
             }
 
+            // LC-Note: Wrap animations extend the scroll bounds and must not trigger edge effects.
             if (mAllowOverScroll && !isWrapScrolling()) {
                 if (newPos < mMinScroll && oldPos >= mMinScroll) {
                     mEdgeGlowLeft.onAbsorb((int) mScroller.getCurrVelocity());
@@ -1209,6 +1213,7 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
 
     protected float getScrollProgress(int screenCenter, View v, int page) {
         final int halfScreenSize = getMeasuredWidth() / 2;
+        // LC-Note: Account for wrap translation in page effects and layout offsets.
         int delta = screenCenter - (getVisualScrollForPage(page) + halfScreenSize);
         int panelCount = getPanelCount();
         int pageCount = getChildCount();
@@ -1240,7 +1245,8 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
     }
 
     /**
-     * Returns the visual scroll position for a page, accounting for wrap-scroll translation.
+     * LC-Note: Returns the visual scroll position for a page, accounting for wrap-scroll
+     * translation.
      * Only used by getScrollProgress so that alpha/scroll-progress calculations see the
      * correct on-screen location of the wrap target.
      */
@@ -1268,7 +1274,7 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
             int scrollOffset = mIsRtl ? getPaddingRight() : getPaddingLeft();
             int baselineX = mPageScrolls[index] + scrollOffset;
             float childX = child.getX();
-            // Wrap-scroll's translationX isn't a layout transition; don't let it skew parallax offset.
+            // LC-Note: Wrap translation isn't a layout transition; exclude it from the offset.
             if (isWrapScrolling() && index == mWrapToPage) {
                 childX -= child.getTranslationX();
             }
@@ -1303,6 +1309,7 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
 
     @Override
     public boolean onTouchEvent(MotionEvent ev) {
+        // LC-Note: Animate infinite-scroll wrapping across drag, release, and cancellation.
         // Skip touch handling if there are no pages to swipe
         if (getChildCount() <= 0) return false;
 
@@ -1782,8 +1789,8 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
     }
 
     /**
-     * Initiates a wrap-scroll animation that moves one page distance in the correct swipe
-     * direction when wrapping between first↔last page.
+     * LC-Note: Initiates a wrap-scroll animation that moves one page distance in the correct
+     * swipe direction when wrapping between first↔last page.
      */
     private void snapToPageWrapped(int targetPage, int velocity) {
         if (!mScroller.isFinished()) {
@@ -1803,7 +1810,7 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
         }
 
         int currentScroll = mOrientationHandler.getPrimaryScroll(this);
-        // In LTR: wrapping to page 0 means target is to the right (beyond maxScroll).
+        // LC-Note: In LTR, page 0 wraps to the right beyond maxScroll.
         // In RTL: directions are reversed.
         int virtualTarget = ((targetPage == 0) != mIsRtl)
                 ? mSavedMaxScroll + onePageDistance
@@ -1819,7 +1826,7 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
     }
 
     /**
-     * Resets wrap-scroll state: clears translation, restores scroll bounds, and jumps
+     * LC-Note: Resets wrap-scroll state: clears translation, restores scroll bounds, and jumps
      * scroll position to the target page's real location.
      */
     private void finalizeWrapScroll() {
@@ -1842,7 +1849,7 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
     }
 
     /**
-     * Cancels wrap-scroll state without jumping scroll position.
+     * LC-Note: Cancels wrap-scroll state without jumping scroll position.
      * Used when the user drags back or the gesture is cancelled, so the subsequent
      * snapToPage animates from the current drag position instead of jumping first.
      */
@@ -1863,7 +1870,7 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
     }
 
     /**
-     * Returns the scroll value to use for the page indicator during wrap scrolling.
+     * LC-Note: Returns the scroll value to use for the page indicator during wrap scrolling.
      * Maps out-of-bounds scroll values back into the normal range so dots animate correctly.
      */
     protected int getScrollForPageIndicator() {
@@ -1886,7 +1893,7 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
     }
 
     /**
-     * Returns the scroll value to use for wallpaper parallax during wrap scrolling.
+     * LC-Note: Returns the scroll value to use for wallpaper parallax during wrap scrolling.
      * While the page wraps one page distance via translationX, the wallpaper sweeps the full
      * scroll range in the opposite direction so it slides continuously from one edge to the
      * other (matching the pre-wrap-animation behavior and other launchers like Nova).
@@ -1912,7 +1919,7 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
         return scroll;
     }
 
-    // Returns 0 on two-panel (foldable) workspaces, disabling wrap scroll.
+    // LC-Note: Returns 0 on two-panel (foldable) workspaces, disabling wrap scroll.
     private int getOnePageDistance() {
         if (!isPageScrollsInitialized() || mPageScrolls.length < 2) {
             return 0;
@@ -1920,6 +1927,7 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
         return Math.abs(mPageScrolls[1] - mPageScrolls[0]);
     }
 
+    // LC-Note: Share AOSP snap timing with the animated infinite-scroll helpers below.
     protected boolean snapToPageWithVelocity(int whichPage, int velocity) {
         whichPage = validateNewPage(whichPage);
 
@@ -1939,7 +1947,7 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
     }
 
     /**
-     * Begins a wrap-drag by translating the target page's View next to the current page
+     * LC-Note: Begins a wrap-drag by translating the target page's View next to the current page
      * and extending scroll bounds so scrollTo doesn't clamp.
      */
     private void startWrapDrag(int targetPage) {
@@ -1960,8 +1968,8 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
         mSavedMaxScroll = mMaxScroll;
         mWrapToPage = targetPage;
 
-        // In LTR: page 0 is leftmost. Wrapping to page 0 from last page means we place
-        // page 0 to the right of the last page (positive translation).
+        // LC-Note: In LTR, page 0 is leftmost. Wrapping from the last page places it
+        // to the right of the last page (positive translation).
         // In RTL: page 0 is rightmost, so wrapping to page 0 means placing it to the left.
         if ((targetPage == 0) != mIsRtl) {
             targetView.setTranslationX(totalWidth);

--- a/src/com/android/launcher3/PagedView.java
+++ b/src/com/android/launcher3/PagedView.java
@@ -138,6 +138,7 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
     private int mWrapToPage = INVALID_PAGE;
     private int mSavedMinScroll;
     private int mSavedMaxScroll;
+    private boolean mCachedEnableFeed;
 
     private boolean isWrapScrolling() {
         return mWrapToPage != INVALID_PAGE;
@@ -1329,6 +1330,7 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
             mTotalMotion = 0;
             mAllowEasyFling = false;
             mActivePointerId = ev.getPointerId(0);
+            mCachedEnableFeed = PreferenceExtensionsKt.firstBlocking(prefs2.getEnableFeed());
             if (mIsBeingDragged) {
                 pageBeginTransition();
             }
@@ -1381,7 +1383,7 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
 
                 if (delta != 0) {
                     if (prefs.getInfiniteScrolling().get() && !mFreeScroll && getChildCount() > 1) {
-                        boolean enableFeed = PreferenceExtensionsKt.firstBlocking(prefs2.getEnableFeed());
+                        boolean enableFeed = mCachedEnableFeed;
                         float pulledTo = oldScroll + delta;
                         if (!isWrapScrolling() && mCurrentPage == getChildCount() - 1) {
                             boolean pastEnd = mIsRtl ? pulledTo < mMinScroll : pulledTo > mMaxScroll;
@@ -1476,7 +1478,7 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
                     // move to the left and fling to the right will register as a fling to the right.
 
                     boolean infiniteScroll = prefs.getInfiniteScrolling().get();
-                    boolean enableFeed = PreferenceExtensionsKt.firstBlocking(prefs2.getEnableFeed());
+                    boolean enableFeed = mCachedEnableFeed;
 
                     if (((isSignificantMove && !isDeltaLeft && !isFling) ||
                             (isFling && !isVelocityLeft)) && mCurrentPage > 0) {
@@ -1853,6 +1855,9 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
             targetView.setTranslationX(0);
         }
         mWrapToPage = INVALID_PAGE;
+        int clamped = Utilities.boundToRange(
+                mOrientationHandler.getPrimaryScroll(this), mSavedMinScroll, mSavedMaxScroll);
+        mOrientationHandler.setPrimary(this, VIEW_SCROLL_TO, clamped);
         mMinScroll = mSavedMinScroll;
         mMaxScroll = mSavedMaxScroll;
     }

--- a/src/com/android/launcher3/Workspace.java
+++ b/src/com/android/launcher3/Workspace.java
@@ -1507,7 +1507,7 @@ public class Workspace<T extends View & PageIndicator> extends PagedView<T>
 
     public void showPageIndicatorAtCurrentScroll() {
         if (mPageIndicator != null) {
-            mPageIndicator.setScroll(getScrollX(), computeMaxScroll());
+            mPageIndicator.setScroll(getScrollForPageIndicator(), computeMaxScroll());
             var isHotseatEnabled = PreferenceCacheExtensionsKt.firstCached(mPreferenceManager2.isHotseatEnabled());
             mPageIndicator.setVisibility(isHotseatEnabled ? VISIBLE : INVISIBLE);
         }

--- a/src/com/android/launcher3/Workspace.java
+++ b/src/com/android/launcher3/Workspace.java
@@ -1507,6 +1507,7 @@ public class Workspace<T extends View & PageIndicator> extends PagedView<T>
 
     public void showPageIndicatorAtCurrentScroll() {
         if (mPageIndicator != null) {
+            // LC-Note: Use wrap-aware scroll for continuous infinite-scroll indicator animation.
             mPageIndicator.setScroll(getScrollForPageIndicator(), computeMaxScroll());
             var isHotseatEnabled = PreferenceCacheExtensionsKt.firstCached(mPreferenceManager2.isHotseatEnabled());
             mPageIndicator.setVisibility(isHotseatEnabled ? VISIBLE : INVISIBLE);

--- a/src/com/android/launcher3/Workspace.java
+++ b/src/com/android/launcher3/Workspace.java
@@ -1433,7 +1433,7 @@ public class Workspace<T extends View & PageIndicator> extends PagedView<T>
 
     public void showPageIndicatorAtCurrentScroll() {
         if (mPageIndicator != null) {
-            mPageIndicator.setScroll(getScrollX(), computeMaxScroll());
+            mPageIndicator.setScroll(getScrollForPageIndicator(), computeMaxScroll());
             var isHotseatEnabled = PreferenceExtensionsKt.firstBlocking(mPreferenceManager2.isHotseatEnabled());
             mPageIndicator.setVisibility(isHotseatEnabled ? VISIBLE : INVISIBLE);
         }

--- a/src/com/android/launcher3/util/WallpaperOffsetInterpolator.java
+++ b/src/com/android/launcher3/util/WallpaperOffsetInterpolator.java
@@ -167,6 +167,7 @@ public class WallpaperOffsetInterpolator {
 
     public void syncWithScroll() {
         int numScreens = getNumScrollableScreensExcludingEmpty();
+        // LC-Note: Use wrap-aware scroll to preserve wallpaper parallax during infinite scrolling.
         wallpaperOffsetForScroll(mWorkspace.getScrollForWallpaper(), numScreens, sTempInt);
         Message msg = Message.obtain(mHandler, MSG_UPDATE_OFFSET, sTempInt[0], sTempInt[1],
                 mWindowToken);

--- a/src/com/android/launcher3/util/WallpaperOffsetInterpolator.java
+++ b/src/com/android/launcher3/util/WallpaperOffsetInterpolator.java
@@ -167,7 +167,7 @@ public class WallpaperOffsetInterpolator {
 
     public void syncWithScroll() {
         int numScreens = getNumScrollableScreensExcludingEmpty();
-        wallpaperOffsetForScroll(mWorkspace.getScrollX(), numScreens, sTempInt);
+        wallpaperOffsetForScroll(mWorkspace.getScrollForWallpaper(), numScreens, sTempInt);
         Message msg = Message.obtain(mHandler, MSG_UPDATE_OFFSET, sTempInt[0], sTempInt[1],
                 mWindowToken);
         if (numScreens != mNumScreens) {


### PR DESCRIPTION
### Description

Fixes the infinite scroll wrap animation so it scrolls one page in the correct swipe direction instead of animating through all intermediate pages.

Fixes #6268

### Reasoning

When wrapping between first↔last page, snapToPageWithVelocity computed a delta spanning the entire page range, causing the
scroller to visually pass through every intermediate page. The core problem: pages are laid out linearly, so scrolling from page 2 to page 0 must traverse pages 2→1→0.

The fix uses setTranslationX to temporarily move the target page's View next to the current page (e.g., page 0 is moved to
the right of page 2). This lets the scroller travel just one page distance in the correct direction. Scroll bounds (mMinScroll/mMaxScroll) are temporarily extended so scrollTo doesn't clamp the position. When the animation completes (or is
interrupted), the translation is reset, bounds are restored, and scroll jumps to the target page's real position.

The page indicator is also handled: during wrap, the out-of-bounds scroll value is mapped back into the normal range so the
dots animate correctly.

### Testing

1. Enable Settings → Home Screen → Infinite scrolling
2. Create 3+ workspace pages
3. On the last page, swipe right → should wrap to first page with a single-page animation in the swipe direction
4. On the first page, swipe left → should wrap to last page with a single-page animation in the swipe direction
5. Slowly drag past the edge → target page should peek in from the side, matching normal drag behavior
6. Drag past edge then drag back → should return to current page normally
7. Tap screen during wrap animation → should stop cleanly on the target page
8. Verify page indicator dots animate correctly during wrap
9. Verify normal (non-wrap) page scrolling is unaffected

### Type of change

:white_check_mark: Bug fix (A non-breaking change that fixes an issue)
:x: New feature (A non-breaking change that adds functionality)
:x: Breaking change (A fix or feature that would cause existing functionality to not work as expected)
:x: Refactor (A code change that neither fixes a bug nor adds a feature)
:x: Performance (A code change that improves performance)
:x: Style (Code style changes)
:x: Docs (Changes to documentation)
:x: Chore (Changes to the build process or other tooling)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added wrap-scrolling for seamless infinite swipes between first and last pages.

* **Improvements**
  * More reliable touch/gesture behavior at page boundaries (start, cancel, finalize wrap drags).
  * Page indicator and transition visuals now reflect wrapped positions for consistent progress and alpha.
  * Wallpaper parallax synced to the normalized indicator scroll for visual consistency.
  * Reduced edge-glow/overscroll during wrap scrolling; unified snap-duration for smoother animations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->