### PR TITLE
fix: Hide destructive popup from locked home screen

### DIFF
--- a/lawnchair/src/app/lawnchair/ui/popup/LawnchairShortcut.kt
+++ b/lawnchair/src/app/lawnchair/ui/popup/LawnchairShortcut.kt
@@ -58,6 +58,9 @@ class LawnchairShortcut {
 
         val UNINSTALL =
             SystemShortcut.Factory { activity: ActivityContext, itemInfo: ItemInfo, view: View ->
+                if (PreferenceManager2.INSTANCE.get(activity.asContext()).lockHomeScreen.firstBlocking()) {
+                    return@Factory null
+                }
                 if (itemInfo.targetComponent == null) {
                     return@Factory null
                 }

--- a/quickstep/src/com/android/launcher3/hybridhotseat/HotseatPredictionController.java
+++ b/quickstep/src/com/android/launcher3/hybridhotseat/HotseatPredictionController.java
@@ -37,6 +37,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
+import app.lawnchair.preferences2.PreferenceManager2;
 import com.android.launcher3.DeviceProfile;
 import com.android.launcher3.DragSource;
 import com.android.launcher3.DropTarget;
@@ -65,6 +66,7 @@ import com.android.launcher3.uioverrides.PredictedAppIcon;
 import com.android.launcher3.uioverrides.QuickstepLauncher;
 import com.android.launcher3.views.Snackbar;
 
+import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -391,6 +393,10 @@ public class HotseatPredictionController implements DragController.DragListener,
     @Override
     public SystemShortcut<QuickstepLauncher> getShortcut(QuickstepLauncher activity,
             ItemInfo itemInfo, View originalView) {
+        PreferenceManager2 prefs = PreferenceManager2.getInstance(activity);
+        if (PreferenceExtensionsKt.firstBlocking(prefs.getLockHomeScreen())) {
+            return null;
+        }
         if (itemInfo.container != LauncherSettings.Favorites.CONTAINER_HOTSEAT_PREDICTION) {
             return null;
         }

--- a/src/com/android/launcher3/popup/SystemShortcut.java
+++ b/src/com/android/launcher3/popup/SystemShortcut.java
@@ -134,9 +134,13 @@ public abstract class SystemShortcut<T extends ActivityContext> extends ItemInfo
         SystemShortcut<T> getShortcut(T context, ItemInfo itemInfo, @NonNull View originalView);
     }
 
-    public static final Factory<ActivityContext> WIDGETS = (context, itemInfo, originalView) -> {
+    private static boolean isHomeLocked(ActivityContext context) {
         PreferenceManager2 prefs = PreferenceManager2.getInstance(context.asContext());
-        if (PreferenceExtensionsKt.firstBlocking(prefs.getLockHomeScreen())) {
+        return PreferenceExtensionsKt.firstBlocking(prefs.getLockHomeScreen());
+    }
+
+    public static final Factory<ActivityContext> WIDGETS = (context, itemInfo, originalView) -> {
+        if (isHomeLocked(context)) {
             return null;
         }
 
@@ -260,8 +264,7 @@ public abstract class SystemShortcut<T extends ActivityContext> extends ItemInfo
     }
 
     public static final Factory<ActivityContext> REMOVE = (context, itemInfo, originalView) -> {
-        PreferenceManager2 prefs = PreferenceManager2.getInstance(context.asContext());
-        if (PreferenceExtensionsKt.firstBlocking(prefs.getLockHomeScreen())) {
+        if (isHomeLocked(context)) {
             return null;
         }
         return new RemoveApp<>(context, itemInfo, originalView);
@@ -286,8 +289,7 @@ public abstract class SystemShortcut<T extends ActivityContext> extends ItemInfo
 
     public static final Factory<ActivityContext> PRIVATE_PROFILE_INSTALL =
             (context, itemInfo, originalView) -> {
-                PreferenceManager2 prefs = PreferenceManager2.getInstance(context.asContext());
-                if (PreferenceExtensionsKt.firstBlocking(prefs.getLockHomeScreen())) {
+                if (isHomeLocked(context)) {
                     return null;
                 }
                 if (originalView == null) {
@@ -396,8 +398,7 @@ public abstract class SystemShortcut<T extends ActivityContext> extends ItemInfo
 
     public static final Factory<ActivityContext> DONT_SUGGEST_APP =
             (activity, itemInfo, originalView) -> {
-                PreferenceManager2 prefs = PreferenceManager2.getInstance(activity.asContext());
-                if (PreferenceExtensionsKt.firstBlocking(prefs.getLockHomeScreen())) {
+                if (isHomeLocked(activity)) {
                     return null;
                 }
                 if (!itemInfo.isPredictedItem()) {
@@ -431,8 +432,7 @@ public abstract class SystemShortcut<T extends ActivityContext> extends ItemInfo
 
     public static final Factory<ActivityContext> UNINSTALL_APP =
             (activityContext, itemInfo, originalView) -> {
-                PreferenceManager2 prefs = PreferenceManager2.getInstance(activityContext.asContext());;
-                if (PreferenceExtensionsKt.firstBlocking(prefs.getLockHomeScreen())) {
+                if (isHomeLocked(activityContext)) {
                     return null;
                 }
                 if (originalView == null) {

--- a/src/com/android/launcher3/popup/SystemShortcut.java
+++ b/src/com/android/launcher3/popup/SystemShortcut.java
@@ -135,6 +135,11 @@ public abstract class SystemShortcut<T extends ActivityContext> extends ItemInfo
     }
 
     public static final Factory<ActivityContext> WIDGETS = (context, itemInfo, originalView) -> {
+        PreferenceManager2 prefs = PreferenceManager2.getInstance(context.asContext());
+        if (PreferenceExtensionsKt.firstBlocking(prefs.getLockHomeScreen())) {
+            return null;
+        }
+
         final PackageUserKey packageUserKey = PackageUserKey.fromItemInfo(itemInfo);
         if (packageUserKey == null) return null;
 
@@ -254,7 +259,13 @@ public abstract class SystemShortcut<T extends ActivityContext> extends ItemInfo
         }
     }
 
-    public static final Factory<ActivityContext> REMOVE = RemoveApp::new;
+    public static final Factory<ActivityContext> REMOVE = (context, itemInfo, originalView) -> {
+        PreferenceManager2 prefs = PreferenceManager2.getInstance(context.asContext());
+        if (PreferenceExtensionsKt.firstBlocking(prefs.getLockHomeScreen())) {
+            return null;
+        }
+        return new RemoveApp<>(context, itemInfo, originalView);
+    };
 
     public static class RemoveApp<T extends ActivityContext> extends SystemShortcut<T> {
 
@@ -275,6 +286,10 @@ public abstract class SystemShortcut<T extends ActivityContext> extends ItemInfo
 
     public static final Factory<ActivityContext> PRIVATE_PROFILE_INSTALL =
             (context, itemInfo, originalView) -> {
+                PreferenceManager2 prefs = PreferenceManager2.getInstance(context.asContext());
+                if (PreferenceExtensionsKt.firstBlocking(prefs.getLockHomeScreen())) {
+                    return null;
+                }
                 if (originalView == null) {
                     return null;
                 }
@@ -381,6 +396,10 @@ public abstract class SystemShortcut<T extends ActivityContext> extends ItemInfo
 
     public static final Factory<ActivityContext> DONT_SUGGEST_APP =
             (activity, itemInfo, originalView) -> {
+                PreferenceManager2 prefs = PreferenceManager2.getInstance(activity.asContext());
+                if (PreferenceExtensionsKt.firstBlocking(prefs.getLockHomeScreen())) {
+                    return null;
+                }
                 if (!itemInfo.isPredictedItem()) {
                     return null;
                 }
@@ -412,6 +431,10 @@ public abstract class SystemShortcut<T extends ActivityContext> extends ItemInfo
 
     public static final Factory<ActivityContext> UNINSTALL_APP =
             (activityContext, itemInfo, originalView) -> {
+                PreferenceManager2 prefs = PreferenceManager2.getInstance(activityContext.asContext());;
+                if (PreferenceExtensionsKt.firstBlocking(prefs.getLockHomeScreen())) {
+                    return null;
+                }
                 if (originalView == null) {
                     return null;
                 }

--- a/src/com/android/launcher3/widget/WidgetCell.java
+++ b/src/com/android/launcher3/widget/WidgetCell.java
@@ -70,8 +70,6 @@ import java.util.function.Consumer;
 import app.lawnchair.LawnchairAppWidgetHostView;
 import app.lawnchair.font.FontManager;
 import app.lawnchair.theme.drawable.DrawableTokens;
-import app.lawnchair.preferences2.PreferenceManager2;
-import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
 
 /**
  * Represents the individual cell of the widget inside the widget tray. The preview is drawn
@@ -83,8 +81,6 @@ import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
  * consider the appropriate scaling factor.
  */
 public class WidgetCell extends LinearLayout {
-
-    PreferenceManager2 prefs2 = PreferenceManager2.INSTANCE.get(getContext());
 
     private static final String TAG = "WidgetCell";
     private static final boolean DEBUG = false;
@@ -615,7 +611,6 @@ public class WidgetCell extends LinearLayout {
      * @param callback Callback to be set on the button.
      */
     public void showAddButton(View.OnClickListener callback) {
-        if (PreferenceExtensionsKt.firstBlocking(prefs2.getLockHomeScreen())) return;
         if (mIsShowingAddButton) return;
         mIsShowingAddButton = true;
 


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Hide destructive popup and popup that changes the home screen/private space when the home screen is locked.

Fixes https://discord.com/channels/803299970169700402/803506450805817385/1503511525451628756

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->

Properly lock the home screen by just checking on the aforementioned popup if the home screen is locked or not.

In additions to that, this PR also remove the check when deciding to add widget add button in widget selector because it will not be shown to the user anymore making the check obsolete. 

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Turn on lock mode from lawnchair settings then press and hold for popup in home screen.

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)
:x: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System shortcuts (uninstall, remove, add widgets, private-profile install, don't-suggest) are suppressed when the home screen is locked.
  * Hotseat prediction pinning shortcuts are disabled when the home screen is locked.

* **Chores**
  * Removed redundant home-screen-lock validation from widget add-button logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LawnchairLauncher/lawnchair/pull/6774?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->