### PR TITLE
fix: Restore back navigation on Android 13 and below

### DIFF
--- a/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
+++ b/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
@@ -289,12 +289,6 @@ class LawnchairLauncher : QuickstepLauncher() {
         gestureController.onHomePressed()
     }
 
-    override fun registerBackDispatcher() {
-        if (LawnchairApp.isAtleastT) {
-            super.registerBackDispatcher()
-        }
-    }
-
     fun bindItems(items: List<ItemInfo>, forceAnimateIcons: Boolean) {
         // pE-TODO(QPR1): Note: null is modelWriter + bindItems override something
         val inflatedItems = items.map { i ->

--- a/quickstep/src/com/android/launcher3/uioverrides/QuickstepLauncher.java
+++ b/quickstep/src/com/android/launcher3/uioverrides/QuickstepLauncher.java
@@ -1017,8 +1017,7 @@ public class QuickstepLauncher extends Launcher implements RecentsViewContainer,
             return false;
         }
 
-        // Lawnchair-TODO-Merge: LC disabled this, 16r2 enabled it.
-//        getOnBackAnimationCallback().onBackInvoked();
+        getOnBackAnimationCallback().onBackInvoked();
         return true;
     }
 
@@ -1075,6 +1074,18 @@ public class QuickstepLauncher extends Launcher implements RecentsViewContainer,
                             mActiveOnBackAnimationCallback.onBackCancelled();
                             mActiveOnBackAnimationCallback = null;
                         }
+                    });
+        } else if (Utilities.ATLEAST_T) {
+            // On Android 13 the API 34 OnBackAnimationCallback interface used by
+            // FlingOnBackAnimationCallback cannot be instantiated, but a plain
+            // OnBackInvokedCallback works. Registering it is required because
+            // android:enableOnBackInvokedCallback="true" disables legacy key dispatch
+            // on Android 13+; without a callback the system would finish the Launcher.
+            getOnBackInvokedDispatcher().registerOnBackInvokedCallback(
+                    OnBackInvokedDispatcher.PRIORITY_DEFAULT,
+                    () -> {
+                        onBackPressed();
+                        TestLogging.recordEvent(TestProtocol.SEQUENCE_MAIN, "onBackInvoked");
                     });
         }
     }


### PR DESCRIPTION
### Description

Restore working back navigation on the home screen for Android 13 and below. Adds a tiered `OnBackInvokedCallback` registration in `QuickstepLauncher` (Android 13 now gets a simple, API-33-safe callback while Android 14+ keeps the full `FlingOnBackAnimationCallback`) and re-enables the back-key invocation in `tryHandleBackKey()` that was accidentally left disabled during a Lawnchair upstream merge. Also removes the now-redundant `registerBackDispatcher()` override in `LawnchairLauncher`.

- Closes: #6780

### Reasoning

The bug had two distinct root causes that combined into the reported symptom:

**Android 13 (back finishes Launcher / lands in last app):**
Both Launcher manifests declare `android:enableOnBackInvokedCallback="true"`, which tells Android 13+ to stop dispatching the legacy `KEYCODE_BACK` / `onBackPressed()` path and only consult `OnBackInvokedDispatcher`. However, commit `b3fff331d7` ("Lock Quickstep back dispatcher to at least Android 14") tightened the registration gate in `QuickstepLauncher.registerBackDispatcher()` from `Utilities.ATLEAST_T` to `Utilities.ATLEAST_U`. On Android 13 no callback is registered, so the system falls back to the activity default and finishes the Launcher — landing the user on whatever task was previously focused.

The gate was raised to U for a real reason: `FlingOnBackAnimationCallback` implements `OnBackAnimationCallback`, which is an API 34 interface, so instantiating it on API 33 can fail class verification. The fix here keeps the API-34 callback gated to `ATLEAST_U` (preserving the crash protection) and adds a second branch for `ATLEAST_T` that registers a plain `OnBackInvokedCallback` lambda — exactly the shape `BaseActivity.registerBackDispatcher()` uses, and verification-safe on API 33.

**Android 12 and below (nothing happens):**
On API 32 and below the `enableOnBackInvokedCallback` manifest attribute is ignored, so `KEYCODE_BACK` still reaches `QuickstepLauncher.dispatchKeyEvent()` → `tryHandleBackKey()`. But that method had its `getOnBackAnimationCallback().onBackInvoked()` call commented out with the note "Lawnchair-TODO-Merge: LC disabled this, 16r2 enabled it." — the event was swallowed (`return true`) without invoking back. Uncommenting the line restores the upstream 16r2 behavior. This path is not exercised on Android 13+ (the dispatcher takes over), so there's no risk of double invocation.

After Change 1, the `LawnchairLauncher.registerBackDispatcher()` override only re-gates on T and calls super — but super now handles the T case itself, making the override dead code. Removed it for clarity.

### Testing

1. Build and install the `lawnWithQuickstepGithubDebug` variant.
2. **Android 14+** (predictive back path):
   - Open the app drawer, swipe back from the edge — animates and returns to workspace.
   - Open a folder, press back — closes the folder.
   - Cold-launch the Launcher — no crash.
3. **Android 13** (`OnBackInvokedDispatcher`, no animation):
   - Open the app drawer, press back — returns to workspace.
   - Open a folder, press back — closes the folder.
   - Press back on the workspace — no longer finishes the Launcher / drops to a previous app (system-default behavior, as expected).
   - Cold-launch the Launcher — no crash (this is the case the original `ATLEAST_U` gate was protecting).
4. **Android 12 / 11** (legacy `KEYCODE_BACK` path):
   - Open the app drawer, press back — returns to workspace.
   - Open a folder, press back — closes the folder.

### Type of change

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
:x: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced back button navigation handling to ensure consistent behavior across Android versions
  * Improved back gesture support for Android 13 and later devices to prevent unintended app closure

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LawnchairLauncher/lawnchair/pull/6791?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->