### PR TITLE
feat(workspace): edit-mode page reorder, default home, and page strip

### DIFF
--- a/lawnchair/res/color/edit_mode_page_strip_home_tint.xml
+++ b/lawnchair/res/color/edit_mode_page_strip_home_tint.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:color="@color/materialColorPrimary"
+        android:state_selected="true" />
+    <item android:color="?android:attr/textColorSecondary" />
+</selector>

--- a/lawnchair/res/drawable/bg_edit_mode_page_strip_item.xml
+++ b/lawnchair/res/drawable/bg_edit_mode_page_strip_item.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:enterFadeDuration="100"
+    android:exitFadeDuration="100">
+    <item
+        android:drawable="@drawable/bg_edit_mode_page_strip_item_default"
+        android:state_selected="true" />
+    <item android:drawable="@drawable/bg_edit_mode_page_strip_item_unselected" />
+</selector>

--- a/lawnchair/res/drawable/bg_edit_mode_page_strip_item_default.xml
+++ b/lawnchair/res/drawable/bg_edit_mode_page_strip_item_default.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="16dp" />
+    <solid android:color="#33FFFFFF" />
+    <stroke
+        android:width="2dp"
+        android:color="@color/materialColorPrimary" />
+</shape>

--- a/lawnchair/res/drawable/bg_edit_mode_page_strip_item_unselected.xml
+++ b/lawnchair/res/drawable/bg_edit_mode_page_strip_item_unselected.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="16dp" />
+    <solid android:color="#1AFFFFFF" />
+    <stroke
+        android:width="2dp"
+        android:color="#00FFFFFF" />
+</shape>

--- a/lawnchair/res/layout/edit_mode_page_strip_item.xml
+++ b/lawnchair/res/layout/edit_mode_page_strip_item.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="112dp"
+    android:layout_height="72dp"
+    android:layout_marginStart="6dp"
+    android:layout_marginEnd="6dp"
+    android:background="@drawable/bg_edit_mode_page_strip_item"
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:paddingHorizontal="12dp">
+
+    <TextView
+        android:id="@+id/page_strip_title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:duplicateParentState="true"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:textColor="?android:attr/textColorPrimary"
+        android:textSize="14sp" />
+
+    <ImageButton
+        android:id="@+id/page_strip_home_button"
+        android:layout_width="28dp"
+        android:layout_height="28dp"
+        android:background="@android:color/transparent"
+        android:contentDescription="@string/edit_mode_page_strip_set_home"
+        android:duplicateParentState="true"
+        android:padding="4dp"
+        android:src="@drawable/ic_home_pin"
+        android:tint="@color/edit_mode_page_strip_home_tint" />
+
+</LinearLayout>

--- a/lawnchair/res/layout/edit_mode_page_strip_item.xml
+++ b/lawnchair/res/layout/edit_mode_page_strip_item.xml
@@ -22,12 +22,14 @@
 
     <ImageButton
         android:id="@+id/page_strip_home_button"
-        android:layout_width="28dp"
-        android:layout_height="28dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:minWidth="48dp"
+        android:minHeight="48dp"
         android:background="@android:color/transparent"
         android:contentDescription="@string/edit_mode_page_strip_set_home"
         android:duplicateParentState="true"
-        android:padding="4dp"
+        android:padding="10dp"
         android:src="@drawable/ic_home_pin"
         android:tint="@color/edit_mode_page_strip_home_tint" />
 

--- a/lawnchair/res/layout/launcher.xml
+++ b/lawnchair/res/layout/launcher.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Copyright (C) 2007 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<com.android.launcher3.LauncherRootView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:launcher="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/launcher"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
+
+    <com.android.launcher3.dragndrop.DragLayer
+        android:id="@+id/drag_layer"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:clipChildren="false"
+        android:clipToPadding="false"
+        android:importantForAccessibility="no">
+
+        <com.android.launcher3.views.AccessibilityActionsView
+            android:id="@+id/accessibility_action_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:contentDescription="@string/home_screen"
+            />
+
+        <!-- The workspace contains 5 screens of cells -->
+        <!-- DO NOT CHANGE THE ID -->
+        <com.android.launcher3.Workspace
+            android:id="@+id/workspace"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_gravity="center"
+            android:theme="@style/HomeScreenElementTheme"
+            launcher:pageIndicator="@+id/page_indicator" />
+
+        <!-- DO NOT CHANGE THE ID -->
+        <include
+            android:id="@+id/hotseat"
+            layout="@layout/hotseat" />
+
+        <!-- Keep these behind the workspace so that they are not visible when
+         we go into AllApps -->
+        <com.android.launcher3.pageindicators.PageIndicatorDots
+            android:id="@+id/page_indicator"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/workspace_page_indicator_height"
+            android:layout_gravity="bottom|center_horizontal"
+            android:theme="@style/HomeScreenElementTheme" />
+
+        <app.lawnchair.views.EditModePageStrip
+            android:id="@+id/edit_mode_page_strip"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/edit_mode_page_strip_height"
+            android:layout_gravity="bottom"
+            android:clipToPadding="false"
+            android:paddingStart="12dp"
+            android:paddingEnd="12dp"
+            android:paddingBottom="12dp"
+            android:visibility="gone" />
+
+        <include
+            android:id="@+id/drop_target_bar"
+            layout="@layout/drop_target_bar" />
+
+        <app.lawnchair.views.LawnchairScrimView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:id="@+id/scrim_view"
+            android:background="@android:color/transparent" />
+
+        <include
+            android:id="@+id/overview_panel"
+            layout="@layout/overview_panel" />
+
+        <include
+            android:id="@+id/apps_view"
+            layout="@layout/all_apps"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+    </com.android.launcher3.dragndrop.DragLayer>
+
+</com.android.launcher3.LauncherRootView>

--- a/lawnchair/res/values/dimens.xml
+++ b/lawnchair/res/values/dimens.xml
@@ -28,6 +28,11 @@
 
     <dimen name="lawnchair_dialog_corner_radius">24dp</dimen>
 
+    <!-- Edit Mode page strip (bottom of DragLayer) -->
+    <dimen name="edit_mode_page_strip_height">88dp</dimen>
+    <dimen name="edit_mode_workspace_bottom_gap">8dp</dimen>
+    <dimen name="edit_mode_page_strip_tip_margin">8dp</dimen>
+
     <!-- qsb -->
     <dimen name="all_apps_search_bar_bottom_padding">36dp</dimen>
     <dimen name="all_apps_search_vertical_offset">30dp</dimen>

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -692,6 +692,14 @@
 
     <string name="set_default_home_page">Set as default page</string>
     <string name="default_home_page_set">Default home page updated</string>
+    <string name="move_page_left">Move page left</string>
+    <string name="move_page_right">Move page right</string>
+    <string name="page_order_updated">Page order updated</string>
+    <string name="edit_mode_page_strip_default">Default</string>
+    <string name="edit_mode_page_strip_page">Page %1$d</string>
+    <string name="edit_mode_page_strip_set_home">Set as home page</string>
+    <string name="edit_mode_page_strip_home_selected">Default home page</string>
+    <string name="edit_mode_page_strip_tip">Drag pages to reorder. Tap the home icon to set your default page.</string>
 
     <string name="popup_menu">Pop-up menu</string>
     <string name="popup_menu_items">Pop-up menu items</string>

--- a/lawnchair/src/app/lawnchair/views/EditModePageStrip.kt
+++ b/lawnchair/src/app/lawnchair/views/EditModePageStrip.kt
@@ -1,0 +1,319 @@
+package app.lawnchair.views
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.view.View
+import android.view.View.GONE
+import android.view.View.VISIBLE
+import android.view.ViewGroup
+import android.widget.ImageButton
+import android.widget.TextView
+import androidx.recyclerview.widget.DefaultItemAnimator
+import androidx.recyclerview.widget.ItemTouchHelper
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.android.app.animation.Interpolators
+import com.android.launcher3.Launcher
+import com.android.launcher3.LauncherPrefs
+import com.android.launcher3.R
+import com.android.launcher3.Utilities
+import com.android.launcher3.Workspace
+import com.android.launcher3.util.IntArray
+import com.android.launcher3.util.OnboardingPrefs
+import com.android.launcher3.views.ArrowTipView
+
+class EditModePageStrip @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0,
+) : RecyclerView(context, attrs, defStyleAttr) {
+
+    private val pageStripAdapter = PageStripAdapter()
+    private var workspace: Workspace<*>? = null
+    private var educationTip: ArrowTipView? = null
+    private val showEducationTipRunnable = Runnable { showEducationTipIfNeeded() }
+
+    init {
+        layoutManager = LinearLayoutManager(context, HORIZONTAL, false)
+        overScrollMode = OVER_SCROLL_NEVER
+        itemAnimator = DefaultItemAnimator().apply {
+            moveDuration = 200
+            changeDuration = 150
+            supportsChangeAnimations = true
+        }
+        adapter = pageStripAdapter
+        ItemTouchHelper(DragCallback()).attachToRecyclerView(this)
+    }
+
+    fun bindWorkspace(workspace: Workspace<*>) {
+        this.workspace = workspace
+        refreshItems()
+    }
+
+    fun showForEditMode(workspace: Workspace<*>, duration: Long) {
+        cancelVisibilityAnimation()
+        bindWorkspace(workspace)
+        if (duration <= 0) {
+            applyVisibleState()
+            return
+        }
+        val offset = stripSlideOffset()
+        visibility = VISIBLE
+        alpha = 0f
+        translationY = offset
+        animate()
+            .alpha(1f)
+            .translationY(0f)
+            .setDuration(duration)
+            .setInterpolator(Interpolators.DECELERATE_2)
+            .start()
+    }
+
+    fun maybeShowEducationTip(launcher: Launcher) {
+        if (OnboardingPrefs.EDIT_MODE_PAGE_STRIP_TIP_SEEN.get(launcher)) {
+            return
+        }
+        if (visibility != VISIBLE) {
+            return
+        }
+        removeCallbacks(showEducationTipRunnable)
+        postDelayed(showEducationTipRunnable, 150)
+    }
+
+    fun dismissEducationTip() {
+        removeCallbacks(showEducationTipRunnable)
+        educationTip?.close(true)
+        educationTip = null
+    }
+
+    private fun showEducationTipIfNeeded() {
+        if (visibility != VISIBLE || width == 0) {
+            return
+        }
+        val launcher = context as? Launcher ?: return
+        if (OnboardingPrefs.EDIT_MODE_PAGE_STRIP_TIP_SEEN.get(launcher)) {
+            return
+        }
+        val bounds = Utilities.getViewBounds(this)
+        val margin = resources.getDimensionPixelSize(R.dimen.edit_mode_page_strip_tip_margin)
+        val tip =
+            ArrowTipView(launcher, false).showAtLocation(
+                resources.getString(R.string.edit_mode_page_strip_tip),
+                bounds.centerX(),
+                bounds.top - margin,
+            ) ?: return
+        educationTip = tip
+        LauncherPrefs.get(launcher).put(OnboardingPrefs.EDIT_MODE_PAGE_STRIP_TIP_SEEN, true)
+    }
+
+    fun hideForEditMode(duration: Long) {
+        dismissEducationTip()
+        cancelVisibilityAnimation()
+        if (duration <= 0) {
+            applyHiddenState()
+            return
+        }
+        val offset = stripSlideOffset()
+        animate()
+            .alpha(0f)
+            .translationY(offset)
+            .setDuration(duration)
+            .setInterpolator(Interpolators.ACCELERATE)
+            .withEndAction { applyHiddenState() }
+            .start()
+    }
+
+    private fun cancelVisibilityAnimation() {
+        animate().cancel()
+    }
+
+    private fun stripSlideOffset(): Float {
+        if (height > 0) {
+            return height.toFloat()
+        }
+        return resources.getDimension(R.dimen.edit_mode_page_strip_height)
+    }
+
+    private fun applyVisibleState() {
+        visibility = VISIBLE
+        alpha = 1f
+        translationY = 0f
+    }
+
+    private fun applyHiddenState() {
+        visibility = GONE
+        alpha = 1f
+        translationY = 0f
+    }
+
+    fun refreshItems() {
+        val ws = workspace
+        if (ws == null) {
+            pageStripAdapter.setItems(emptyList())
+            return
+        }
+        val starts = ws.reorderablePageGroupStarts
+        val defaultGroupIndex = ws.defaultPageGroupIndex
+        val items = (0 until starts.size()).map { i ->
+            PageItem(isDefault = i == defaultGroupIndex)
+        }
+        pageStripAdapter.setItems(items)
+    }
+
+    private fun moveGroup(from: Int, to: Int): Boolean {
+        val ws = workspace ?: return false
+        if (!ws.moveReorderablePageGroup(from, to)) {
+            return false
+        }
+        pageStripAdapter.moveItem(from, to)
+        return true
+    }
+
+    private fun setHomeGroup(position: Int): Boolean {
+        val ws = workspace ?: return false
+        val oldDefaultIndex = pageStripAdapter.indexOfDefault()
+        val set = ws.setDefaultPageForReorderableGroup(position)
+        if (!set) {
+            return false
+        }
+        pageStripAdapter.updateDefaultHome(oldDefaultIndex, position)
+        dismissEducationTip()
+        return true
+    }
+
+    private fun resetDragView(view: View) {
+        view.animate()
+            .scaleX(1f)
+            .scaleY(1f)
+            .translationZ(0f)
+            .setDuration(150)
+            .start()
+    }
+
+    private inner class DragCallback :
+        ItemTouchHelper.SimpleCallback(
+            ItemTouchHelper.LEFT or ItemTouchHelper.RIGHT,
+            0,
+        ) {
+        override fun isLongPressDragEnabled(): Boolean = true
+
+        override fun onMove(
+            recyclerView: RecyclerView,
+            viewHolder: ViewHolder,
+            target: ViewHolder,
+        ): Boolean {
+            val from = viewHolder.bindingAdapterPosition
+            val to = target.bindingAdapterPosition
+            if (from == NO_POSITION || to == NO_POSITION) {
+                return false
+            }
+            return moveGroup(from, to)
+        }
+
+        override fun onSwiped(viewHolder: ViewHolder, direction: Int) {
+            // No-op.
+        }
+
+        override fun onSelectedChanged(viewHolder: ViewHolder?, actionState: Int) {
+            val itemView = viewHolder?.itemView ?: return
+            when (actionState) {
+                ItemTouchHelper.ACTION_STATE_DRAG -> {
+                    dismissEducationTip()
+                    itemView.animate()
+                        .scaleX(1.05f)
+                        .scaleY(1.05f)
+                        .translationZ(8f)
+                        .setDuration(150)
+                        .start()
+                }
+
+                else -> resetDragView(itemView)
+            }
+        }
+
+        override fun clearView(recyclerView: RecyclerView, viewHolder: ViewHolder) {
+            super.clearView(recyclerView, viewHolder)
+            resetDragView(viewHolder.itemView)
+        }
+    }
+
+    private inner class PageStripAdapter : Adapter<PageStripViewHolder>() {
+        private val items = mutableListOf<PageItem>()
+
+        fun setItems(newItems: List<PageItem>) {
+            items.clear()
+            items.addAll(newItems)
+            notifyDataSetChanged()
+        }
+
+        fun moveItem(from: Int, to: Int) {
+            if (from == to || from !in items.indices || to !in items.indices) {
+                return
+            }
+            val item = items.removeAt(from)
+            items.add(to, item)
+            notifyItemMoved(from, to)
+        }
+
+        fun indexOfDefault(): Int = items.indexOfFirst { it.isDefault }
+
+        fun updateDefaultHome(oldIndex: Int, newIndex: Int) {
+            if (oldIndex in items.indices) {
+                items[oldIndex] = items[oldIndex].copy(isDefault = false)
+                notifyItemChanged(oldIndex)
+            }
+            if (newIndex in items.indices) {
+                items[newIndex] = items[newIndex].copy(isDefault = true)
+                notifyItemChanged(newIndex)
+            }
+        }
+
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PageStripViewHolder {
+            val view = LayoutInflater.from(parent.context)
+                .inflate(R.layout.edit_mode_page_strip_item, parent, false)
+            return PageStripViewHolder(view)
+        }
+
+        override fun onBindViewHolder(holder: PageStripViewHolder, position: Int) {
+            val item = items[position]
+            holder.itemView.isSelected = item.isDefault
+            holder.title.text = if (item.isDefault) {
+                resources.getString(R.string.edit_mode_page_strip_default)
+            } else {
+                resources.getString(R.string.edit_mode_page_strip_page, position + 1)
+            }
+            holder.homeButton.isSelected = item.isDefault
+            holder.homeButton.contentDescription = if (item.isDefault) {
+                resources.getString(R.string.edit_mode_page_strip_home_selected)
+            } else {
+                resources.getString(R.string.edit_mode_page_strip_set_home)
+            }
+            holder.homeButton.setOnClickListener {
+                val index = holder.bindingAdapterPosition
+                if (index != NO_POSITION) {
+                    setHomeGroup(index)
+                }
+            }
+            holder.itemView.setOnClickListener {
+                val ws = workspace ?: return@setOnClickListener
+                val starts = ws.reorderablePageGroupStarts
+                val index = holder.bindingAdapterPosition
+                if (index in 0 until starts.size()) {
+                    ws.snapToPage(starts[index])
+                }
+            }
+        }
+
+        override fun getItemCount(): Int = items.size
+    }
+
+    private class PageStripViewHolder(itemView: View) : ViewHolder(itemView) {
+        val title: TextView = itemView.findViewById(R.id.page_strip_title)
+        val homeButton: ImageButton = itemView.findViewById(R.id.page_strip_home_button)
+    }
+
+    private data class PageItem(
+        val isDefault: Boolean,
+    )
+}

--- a/lawnchair/src/app/lawnchair/views/EditModePageStrip.kt
+++ b/lawnchair/src/app/lawnchair/views/EditModePageStrip.kt
@@ -254,6 +254,8 @@ class EditModePageStrip @JvmOverloads constructor(
             val item = items.removeAt(from)
             items.add(to, item)
             notifyItemMoved(from, to)
+            val start = minOf(from, to)
+            notifyItemRangeChanged(start, maxOf(from, to) - start + 1)
         }
 
         fun indexOfDefault(): Int = items.indexOfFirst { it.isDefault }

--- a/src/com/android/launcher3/Launcher.java
+++ b/src/com/android/launcher3/Launcher.java
@@ -252,6 +252,7 @@ import com.android.launcher3.util.WallpaperThemeManager;
 import com.android.launcher3.views.FloatingIconView;
 import com.android.launcher3.views.FloatingSurfaceView;
 import com.android.launcher3.views.OptionsPopupView;
+import app.lawnchair.views.EditModePageStrip;
 import com.android.launcher3.views.ScrimView;
 import com.android.launcher3.widget.LauncherAppWidgetHostView;
 import com.android.launcher3.widget.LauncherAppWidgetProviderInfo;
@@ -364,6 +365,7 @@ public class Launcher extends StatefulActivity<LauncherState>
 
     // UI and state for the overview panel
     private View mOverviewPanel;
+    private EditModePageStrip mEditModePageStrip;
 
     // Used to notify when an activity launch has been deferred because launcher is not yet resumed
     // TODO: See if we can remove this later
@@ -1307,6 +1309,28 @@ public class Launcher extends StatefulActivity<LauncherState>
         mDragLayer = findViewById(R.id.drag_layer);
         mFocusHandler = mDragLayer.getFocusIndicatorHelper();
         mWorkspace = mDragLayer.findViewById(R.id.workspace);
+        mEditModePageStrip = mDragLayer.findViewById(R.id.edit_mode_page_strip);
+        if (mEditModePageStrip != null) {
+            mStateManager.addStateListener(new StateManager.StateListener<LauncherState>() {
+                @Override
+                public void onStateTransitionStart(LauncherState toState) {
+                    if (toState == EDIT_MODE) {
+                        long duration = EDIT_MODE.getTransitionDuration(Launcher.this, true);
+                        mEditModePageStrip.showForEditMode(mWorkspace, duration);
+                    } else if (mStateManager.getCurrentStableState() == EDIT_MODE) {
+                        long duration = EDIT_MODE.getTransitionDuration(Launcher.this, false);
+                        mEditModePageStrip.hideForEditMode(duration);
+                    }
+                }
+
+                @Override
+                public void onStateTransitionComplete(LauncherState finalState) {
+                    if (finalState == EDIT_MODE) {
+                        mEditModePageStrip.maybeShowEducationTip(Launcher.this);
+                    }
+                }
+            });
+        }
         mWorkspace.initParentViews(mDragLayer);
         mOverviewPanel = findViewById(R.id.overview_panel);
         mHotseat = findViewById(R.id.hotseat);

--- a/src/com/android/launcher3/LauncherPrefs.kt
+++ b/src/com/android/launcher3/LauncherPrefs.kt
@@ -282,6 +282,7 @@ constructor(@ApplicationContext private val encryptedContext: Context) {
             nonRestorableItem(FIRST_LOAD_AFTER_RESTORE_KEY, false, EncryptionType.ENCRYPTED)
         @JvmField val APP_WIDGET_IDS = backedUpItem(RestoreDbTask.APPWIDGET_IDS, "")
         @JvmField val OLD_APP_WIDGET_IDS = backedUpItem(RestoreDbTask.APPWIDGET_OLD_IDS, "")
+        @JvmField val WORKSPACE_SCREEN_ORDER = backedUpItem("workspace_screen_order", "")
 
         @JvmField
         val GRID_NAME =

--- a/src/com/android/launcher3/ModelCallbacks.kt
+++ b/src/com/android/launcher3/ModelCallbacks.kt
@@ -231,7 +231,6 @@ class ModelCallbacks(private var launcher: Launcher) : BgDataModel.Callbacks {
                     bindItems(it, false)
                 }
             }
-        workspace.stripEmptyScreens()
     }
 
     /**
@@ -292,15 +291,15 @@ class ModelCallbacks(private var launcher: Launcher) : BgDataModel.Callbacks {
             /*pause=*/ true,
             launcher.deviceProfile.deviceProperties.isTwoPanels,
         )
-        val firstScreenPosition = 0
-        if (orderedScreenIds.indexOf(FIRST_SCREEN_ID) != firstScreenPosition) {
-            orderedScreenIds.removeValue(FIRST_SCREEN_ID)
-            orderedScreenIds.add(firstScreenPosition, FIRST_SCREEN_ID)
-        } else if (orderedScreenIds.isEmpty) {
+        if (orderedScreenIds.isEmpty) {
             // If there are no screens, we need to have an empty screen
             launcher.workspace.addExtraEmptyScreens()
+        } else if (orderedScreenIds.indexOf(FIRST_SCREEN_ID) < 0) {
+            // Keep persisted order stable; only add FIRST_SCREEN_ID if missing.
+            orderedScreenIds.add(0, FIRST_SCREEN_ID)
         }
         bindAddScreens(orderedScreenIds)
+        launcher.workspace.reorderBoundWorkspaceScreens(orderedScreenIds)
 
         // After we have added all the screens, if the wallpaper was locked to the default state,
         // then notify to indicate that it can be released and a proper wallpaper offset can be

--- a/src/com/android/launcher3/Workspace.java
+++ b/src/com/android/launcher3/Workspace.java
@@ -61,6 +61,7 @@ import android.os.Parcelable;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.util.SparseArray;
+import android.util.SparseIntArray;
 import android.view.HapticFeedbackConstants;
 import android.view.Gravity;
 import android.view.LayoutInflater;
@@ -253,6 +254,8 @@ public class Workspace<T extends View & PageIndicator> extends PagedView<T>
     boolean mChildrenLayersEnabled = true;
 
     private boolean mStripScreensOnPageStopMoving = false;
+
+    private boolean mDeferStripEmptyScreensForScreenRemap = false;
     public boolean mHasOnLayoutBeenCalled = false;
 
     private boolean mWorkspaceFadeInAdjacentScreens;
@@ -702,7 +705,7 @@ public class Workspace<T extends View & PageIndicator> extends PagedView<T>
         mScreenOrder.clear();
         mWorkspaceScreens.clear();
 
-        // Ensure that the first page is always present
+        // Ensure there is always at least one page during bind lifecycle.
         bindAndInitFirstWorkspaceScreen();
 
         // Re-enable the layout transitions
@@ -938,6 +941,8 @@ public class Workspace<T extends View & PageIndicator> extends PagedView<T>
             stripEmptyScreens();
         }
 
+        persistCurrentScreenOrderSync();
+
         if (onComplete != null) {
             onComplete.run();
         }
@@ -985,6 +990,7 @@ public class Workspace<T extends View & PageIndicator> extends PagedView<T>
 
         mWorkspaceScreens.put(newScreenId, cl);
         mScreenOrder.add(newScreenId);
+        persistCurrentScreenOrderSync();
 
         return newScreenId;
     }
@@ -1081,11 +1087,20 @@ public class Workspace<T extends View & PageIndicator> extends PagedView<T>
             return;
         }
 
+        if (mDeferStripEmptyScreensForScreenRemap) {
+            return;
+        }
+
+        if (mLauncher.isInState(EDIT_MODE)) {
+            return;
+        }
+
         if (isPageInTransition()) {
             mStripScreensOnPageStopMoving = true;
             return;
         }
 
+        IntSet persistedScreenIds = getPersistedWorkspaceScreenIds();
         int currentPage = getNextPage();
         IntArray removeScreens = new IntArray();
         int total = mWorkspaceScreens.size();
@@ -1093,6 +1108,10 @@ public class Workspace<T extends View & PageIndicator> extends PagedView<T>
             int id = mWorkspaceScreens.keyAt(i);
             CellLayout cl = mWorkspaceScreens.valueAt(i);
             // FIRST_SCREEN_ID can never be removed.
+            if (shouldPreserveEmptyScreenWhenStripping(
+                    id, persistedScreenIds, isExtraEmptyScreen(id))) {
+                continue;
+            }
             if ((!PreferenceExtensionsKt.firstBlocking(PreferenceManager2.INSTANCE.get(getContext()).getEnableSmartspace()) || id > FIRST_SCREEN_ID)
                     && cl.getShortcutsAndWidgets().getChildCount() == 0) {
                 removeScreens.add(id);
@@ -1158,6 +1177,7 @@ public class Workspace<T extends View & PageIndicator> extends PagedView<T>
         if (storedDefault >= getChildCount()) {
             setDefaultPage(DEFAULT_PAGE);
         }
+        persistCurrentScreenOrderSync();
     }
 
     /**
@@ -3262,6 +3282,240 @@ public class Workspace<T extends View & PageIndicator> extends PagedView<T>
         // hardware layers on children are enabled on startup, but should be disabled until
         // needed
         updateChildrenLayersEnabled();
+    }
+
+    private boolean isExtraEmptyScreen(int screenId) {
+        return screenId == EXTRA_EMPTY_SCREEN_ID || screenId == EXTRA_EMPTY_SCREEN_SECOND_ID;
+    }
+
+    private boolean isPageGroupMovable(int pageGroupStart) {
+        int panelCount = getPanelCount();
+        if (pageGroupStart < 0 || pageGroupStart + panelCount > mScreenOrder.size()) {
+            return false;
+        }
+        for (int i = 0; i < panelCount; i++) {
+            if (isExtraEmptyScreen(mScreenOrder.get(pageGroupStart + i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean canMovePageGroup(int pageGroupStart, int direction) {
+        int panelCount = getPanelCount();
+        int targetStart = pageGroupStart + direction * panelCount;
+        return isPageGroupMovable(pageGroupStart) && isPageGroupMovable(targetStart);
+    }
+
+    private boolean movePageGroup(int pageIndex, int direction) {
+        int panelCount = getPanelCount();
+        int fromStart = getLeftmostVisiblePageForIndex(pageIndex);
+        int targetStart = fromStart + direction * panelCount;
+        if (!canMovePageGroup(fromStart, direction)) {
+            return false;
+        }
+        int defaultPage = getDefaultPage();
+        int defaultScreenId = getScreenIdForPageIndex(defaultPage);
+        IntArray screenOrderSnapshot = new IntArray();
+        for (int i = 0; i < mScreenOrder.size(); i++) {
+            screenOrderSnapshot.add(mScreenOrder.get(i));
+        }
+        SparseIntArray screenSwapMap =
+                createPageGroupSwapMap(screenOrderSnapshot, fromStart, targetStart, panelCount);
+        if (screenSwapMap.size() == 0) {
+            return false;
+        }
+        for (int i = 0; i < panelCount; i++) {
+            int fromIndex = fromStart + i;
+            int targetIndex = targetStart + i;
+            int fromScreenId = mScreenOrder.get(fromIndex);
+            int targetScreenId = mScreenOrder.get(targetIndex);
+            mScreenOrder.set(fromIndex, targetScreenId);
+            mScreenOrder.set(targetIndex, fromScreenId);
+        }
+        applyScreenOrderToChildViews();
+        if (screenSwapMap.size() > 0) {
+            mLauncher.getModelWriter().persistWorkspaceScreenOrderSync(getPersistableScreenOrder());
+            mDeferStripEmptyScreensForScreenRemap = true;
+            mLauncher.getModelWriter().moveWorkspaceScreensInDatabase(
+                    screenSwapMap, this::onWorkspaceScreenRemapFinished);
+        }
+        int remappedDefaultPage = mScreenOrder.indexOf(defaultScreenId);
+        if (remappedDefaultPage >= 0 && remappedDefaultPage != defaultPage) {
+            setDefaultPage(remappedDefaultPage);
+        }
+        updateAccessibilityViewPageDescription();
+        int pageOffset = pageIndex - fromStart;
+        int destinationPage = targetStart + pageOffset;
+        setCurrentPage(destinationPage, destinationPage);
+        showPageIndicatorAtCurrentScroll();
+        return true;
+    }
+
+    public IntArray getReorderablePageGroupStarts() {
+        IntArray starts = new IntArray();
+        int panelCount = getPanelCount();
+        IntArray candidateStarts = getPageGroupStarts(mScreenOrder, panelCount);
+        for (int i = 0; i < candidateStarts.size(); i++) {
+            int start = candidateStarts.get(i);
+            if (isPageGroupMovable(start)) {
+                starts.add(start);
+            }
+        }
+        return starts;
+    }
+
+    @VisibleForTesting
+    static IntArray getPageGroupStarts(IntArray screenOrder, int panelCount) {
+        IntArray starts = new IntArray();
+        for (int i = 0; i < screenOrder.size(); i += panelCount) {
+            starts.add(i);
+        }
+        return starts;
+    }
+
+    public boolean moveReorderablePageGroup(int fromGroupIndex, int toGroupIndex) {
+        if (fromGroupIndex == toGroupIndex) {
+            return true;
+        }
+        IntArray starts = getReorderablePageGroupStarts();
+        if (fromGroupIndex < 0 || fromGroupIndex >= starts.size()
+                || toGroupIndex < 0 || toGroupIndex >= starts.size()) {
+            return false;
+        }
+        int fromPage = starts.get(fromGroupIndex);
+        int currentGroup = fromGroupIndex;
+        int direction = toGroupIndex > fromGroupIndex ? 1 : -1;
+        while (currentGroup != toGroupIndex) {
+            if (!movePageGroup(fromPage, direction)) {
+                return false;
+            }
+            currentGroup += direction;
+            fromPage += direction * getPanelCount();
+        }
+        return true;
+    }
+
+    public boolean setDefaultPageForReorderableGroup(int groupIndex) {
+        IntArray starts = getReorderablePageGroupStarts();
+        if (groupIndex < 0 || groupIndex >= starts.size()) {
+            return false;
+        }
+        int pageIndex = starts.get(groupIndex);
+        setDefaultPage(pageIndex);
+        Toast.makeText(mLauncher, R.string.default_home_page_set, Toast.LENGTH_SHORT).show();
+        return true;
+    }
+
+    public int getDefaultPageGroupIndex() {
+        IntArray starts = getReorderablePageGroupStarts();
+        int defaultPage = getDefaultPage();
+        int leftmostPage = getLeftmostVisiblePageForIndex(defaultPage);
+        return starts.indexOf(leftmostPage);
+    }
+
+    private IntArray getPersistableScreenOrder() {
+        IntArray persistableOrder = new IntArray();
+        for (int i = 0; i < mScreenOrder.size(); i++) {
+            int screenId = mScreenOrder.get(i);
+            if (!isExtraEmptyScreen(screenId)) {
+                persistableOrder.add(screenId);
+            }
+        }
+        return persistableOrder;
+    }
+
+    private IntSet getPersistedWorkspaceScreenIds() {
+        return getPersistedWorkspaceScreenIds(
+                LauncherPrefs.get(getContext()).get(LauncherPrefs.WORKSPACE_SCREEN_ORDER));
+    }
+
+    @VisibleForTesting
+    static IntSet getPersistedWorkspaceScreenIds(String persistedOrder) {
+        IntSet ids = new IntSet();
+        if (persistedOrder == null || persistedOrder.isBlank()) {
+            return ids;
+        }
+        for (String part : persistedOrder.split(",")) {
+            try {
+                int id = Integer.parseInt(part.trim());
+                if (id >= 0) {
+                    ids.add(id);
+                }
+            } catch (NumberFormatException ignored) {
+                // Skip invalid entries.
+            }
+        }
+        return ids;
+    }
+
+    @VisibleForTesting
+    static boolean shouldPreserveEmptyScreenWhenStripping(
+            int screenId, IntSet persistedScreenIds, boolean isExtraEmptyScreen) {
+        return persistedScreenIds.contains(screenId) && !isExtraEmptyScreen;
+    }
+
+    private void onWorkspaceScreenRemapFinished() {
+        mDeferStripEmptyScreensForScreenRemap = false;
+    }
+
+    private void persistCurrentScreenOrderSync() {
+        if (mLauncher.isWorkspaceLoading()) {
+            return;
+        }
+        mLauncher.getModelWriter().persistWorkspaceScreenOrderSync(getPersistableScreenOrder());
+    }
+
+    private void applyScreenOrderToChildViews() {
+        for (int i = 0; i < mScreenOrder.size(); i++) {
+            CellLayout layout = mWorkspaceScreens.get(mScreenOrder.get(i));
+            if (layout == null) {
+                continue;
+            }
+            int currentIndex = indexOfChild(layout);
+            if (currentIndex != i) {
+                removeView(layout);
+                addView(layout, i);
+            }
+        }
+        updatePageScrollValues();
+    }
+
+    public void reorderBoundWorkspaceScreens(IntArray orderedScreenIds) {
+        if (orderedScreenIds == null || orderedScreenIds.isEmpty()) {
+            return;
+        }
+        IntArray reordered = new IntArray();
+        for (int i = 0; i < orderedScreenIds.size(); i++) {
+            int screenId = orderedScreenIds.get(i);
+            if (mWorkspaceScreens.containsKey(screenId) && !reordered.contains(screenId)) {
+                reordered.add(screenId);
+            }
+        }
+        for (int i = 0; i < mScreenOrder.size(); i++) {
+            int existingId = mScreenOrder.get(i);
+            if (!reordered.contains(existingId)) {
+                reordered.add(existingId);
+            }
+        }
+        mScreenOrder.clear();
+        mScreenOrder.addAll(reordered);
+        applyScreenOrderToChildViews();
+    }
+
+    @VisibleForTesting
+    static SparseIntArray createPageGroupSwapMap(
+            IntArray screenOrder, int fromStart, int targetStart, int panelCount) {
+        SparseIntArray swapMap = new SparseIntArray(panelCount * 2);
+        for (int i = 0; i < panelCount; i++) {
+            int fromScreen = screenOrder.get(fromStart + i);
+            int targetScreen = screenOrder.get(targetStart + i);
+            if (fromScreen != targetScreen) {
+                swapMap.put(fromScreen, targetScreen);
+                swapMap.put(targetScreen, fromScreen);
+            }
+        }
+        return swapMap;
     }
 
     /**

--- a/src/com/android/launcher3/model/ModelWriter.java
+++ b/src/com/android/launcher3/model/ModelWriter.java
@@ -24,11 +24,13 @@ import android.content.ContentValues;
 import android.content.Context;
 import android.text.TextUtils;
 import android.util.Log;
+import android.util.SparseIntArray;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.android.launcher3.LauncherModel;
+import com.android.launcher3.LauncherPrefs;
 import com.android.launcher3.LauncherModel.CallbackTask;
 import com.android.launcher3.LauncherSettings.Favorites;
 import com.android.launcher3.Utilities;
@@ -44,6 +46,7 @@ import com.android.launcher3.model.data.WorkspaceItemInfo;
 import com.android.launcher3.provider.LauncherDbUtils.SQLiteTransaction;
 import com.android.launcher3.util.ContentWriter;
 import com.android.launcher3.util.Executors;
+import com.android.launcher3.util.IntArray;
 import com.android.launcher3.util.ItemInfoMatcher;
 import com.android.launcher3.util.LooperExecutor;
 import com.android.launcher3.widget.LauncherWidgetHolder;
@@ -216,6 +219,105 @@ public class ModelWriter {
             contentValues.add(values);
         }
         enqueueDeleteRunnable(new UpdateItemsRunnable(items, contentValues));
+    }
+
+    /**
+     * Remaps workspace screen ids for all desktop items using the provided mapping.
+     */
+    public void moveWorkspaceScreensInDatabase(SparseIntArray screenIdMap) {
+        moveWorkspaceScreensInDatabase(screenIdMap, null);
+    }
+
+    /**
+     * Remaps workspace screen ids for all desktop items using the provided mapping.
+     *
+     * @param onComplete optional runnable executed on the main thread after item callbacks are
+     *                   dispatched (always runs, including when there are no item updates).
+     */
+    public void moveWorkspaceScreensInDatabase(SparseIntArray screenIdMap, Runnable onComplete) {
+        if (screenIdMap == null || screenIdMap.size() == 0) {
+            if (onComplete != null) {
+                mUiExecutor.execute(onComplete);
+            }
+            return;
+        }
+        ModelVerifier verifier = new ModelVerifier();
+        enqueueDeleteRunnable(newModelTask(() -> {
+            try (SQLiteTransaction t = mModel.getModelDbController().newTransaction()) {
+                // First pass to temporary ids to avoid collisions in cycles.
+                for (int i = 0; i < screenIdMap.size(); i++) {
+                    int fromScreenId = screenIdMap.keyAt(i);
+                    int tempScreenId = Integer.MIN_VALUE + i;
+                    ContentValues tempValues = new ContentValues();
+                    tempValues.put(Favorites.SCREEN, tempScreenId);
+                    mModel.getModelDbController().update(
+                            tempValues,
+                            Favorites.CONTAINER + "=" + Favorites.CONTAINER_DESKTOP + " AND "
+                                    + Favorites.SCREEN + "=" + fromScreenId,
+                            null);
+                }
+                // Second pass to final ids.
+                for (int i = 0; i < screenIdMap.size(); i++) {
+                    int toScreenId = screenIdMap.valueAt(i);
+                    int tempScreenId = Integer.MIN_VALUE + i;
+                    ContentValues finalValues = new ContentValues();
+                    finalValues.put(Favorites.SCREEN, toScreenId);
+                    mModel.getModelDbController().update(
+                            finalValues,
+                            Favorites.CONTAINER + "=" + Favorites.CONTAINER_DESKTOP + " AND "
+                                    + Favorites.SCREEN + "=" + tempScreenId,
+                            null);
+                }
+                t.commit();
+            } catch (Exception e) {
+                Log.e(TAG, "Failed to remap workspace screens", e);
+                if (onComplete != null) {
+                    mUiExecutor.execute(onComplete);
+                }
+                return;
+            }
+
+            ArrayList<ItemInfo> updatedItems = new ArrayList<>();
+            synchronized (mBgDataModel) {
+                for (ItemInfo item : mBgDataModel.itemsIdMap) {
+                    if (item.container != Favorites.CONTAINER_DESKTOP) {
+                        continue;
+                    }
+                    int newScreenId = screenIdMap.get(item.screenId, item.screenId);
+                    if (newScreenId != item.screenId) {
+                        item.screenId = newScreenId;
+                        updatedItems.add(item);
+                    }
+                }
+                if (!updatedItems.isEmpty()) {
+                    mBgDataModel.updateItems(updatedItems, mOwner);
+                }
+                verifier.verifyModel();
+            }
+            final HashSet<ItemInfo> updates = new HashSet<>(updatedItems);
+            mUiExecutor.execute(() -> {
+                if (!updates.isEmpty()) {
+                    if (mOwner != null) {
+                        mOwner.bindItemsUpdated(updates);
+                    }
+                    notifyOtherCallbacks(c -> c.bindItemsUpdated(updates));
+                }
+                if (onComplete != null) {
+                    onComplete.run();
+                }
+            });
+        }));
+    }
+
+    /**
+     * Persists explicit workspace screen order synchronously.
+     */
+    public void persistWorkspaceScreenOrderSync(IntArray screenOrder) {
+        if (screenOrder == null || screenOrder.isEmpty()) {
+            return;
+        }
+        String serialized = screenOrder.toConcatString();
+        LauncherPrefs.get(mContext).putSync(LauncherPrefs.WORKSPACE_SCREEN_ORDER.to(serialized));
     }
 
     /**

--- a/src/com/android/launcher3/model/data/WorkspaceData.kt
+++ b/src/com/android/launcher3/model/data/WorkspaceData.kt
@@ -24,6 +24,7 @@ import androidx.core.util.valueIterator
 import app.lawnchair.preferences2.PreferenceManager2
 import com.android.launcher3.BuildConfig
 import com.android.launcher3.BuildConfigs
+import com.android.launcher3.LauncherPrefs
 import com.android.launcher3.LauncherSettings.Favorites.CONTAINER_DESKTOP
 import com.android.launcher3.Workspace
 import com.android.launcher3.model.data.WorkspaceChangeEvent.AddEvent
@@ -54,7 +55,8 @@ sealed class WorkspaceData : Iterable<ItemInfo> {
         if (smartspaceEnabled || screenSet.isEmpty) {
             screenSet.add(Workspace.FIRST_SCREEN_ID)
         }
-        return screenSet.array
+        val persistedOrder = LauncherPrefs.get(context).get(LauncherPrefs.WORKSPACE_SCREEN_ORDER)
+        return mergeWorkspaceScreens(screenSet.array, persistedOrder)
     }
 
     /** Returns the [ItemInfo] associated with the [id] or null */
@@ -187,5 +189,28 @@ sealed class WorkspaceData : Iterable<ItemInfo> {
         @VisibleForTesting const val MAX_HISTORY_SIZE = 4
 
         private val VERSION_COUNTER = AtomicInteger()
+
+        @VisibleForTesting
+        fun mergeWorkspaceScreens(itemScreens: IntArray, persistedOrder: String): IntArray {
+            if (persistedOrder.isBlank()) return itemScreens
+
+            val merged = IntArray()
+            val persistedScreens =
+                persistedOrder
+                    .split(",")
+                    .mapNotNull { it.trim().toIntOrNull() }
+                    .filter { it >= 0 }
+            persistedScreens.forEach { screenId ->
+                if (!merged.contains(screenId)) {
+                    merged.add(screenId)
+                }
+            }
+            itemScreens.forEach { screenId ->
+                if (!merged.contains(screenId)) {
+                    merged.add(screenId)
+                }
+            }
+            return merged
+        }
     }
 }

--- a/src/com/android/launcher3/states/EditModeState.kt
+++ b/src/com/android/launcher3/states/EditModeState.kt
@@ -19,8 +19,10 @@ import android.content.Context
 import com.android.launcher3.Flags.enableScalingRevealHomeAnimation
 import com.android.launcher3.Launcher
 import com.android.launcher3.LauncherState
+import com.android.launcher3.R
 import com.android.launcher3.logging.StatsLogManager
 import com.android.launcher3.views.ActivityContext
+import kotlin.math.min
 
 /** Definition for Edit Mode state used for home gardening multi-select */
 class EditModeState(id: Int) : LauncherState(id, StatsLogManager.LAUNCHER_STATE_HOME, STATE_FLAGS) {
@@ -34,6 +36,65 @@ class EditModeState(id: Int) : LauncherState(id, StatsLogManager.LAUNCHER_STATE_
                 FLAG_DISABLE_RESTORE or
                 FLAG_WORKSPACE_ICONS_CAN_BE_DRAGGED or
                 FLAG_WORKSPACE_HAS_BACKGROUNDS)
+
+        private fun getEditModePageStripHeightPx(launcher: Launcher): Int =
+            launcher.resources.getDimensionPixelSize(R.dimen.edit_mode_page_strip_height)
+
+        private fun getEditModeWorkspaceVerticalBounds(launcher: Launcher): Pair<Float, Float> {
+            val grid = launcher.deviceProfile
+            val top = (grid.getInsets().top + grid.workspacePadding.top).toFloat()
+
+            val stripHeightPx = getEditModePageStripHeightPx(launcher)
+            val bottomGap =
+                launcher.resources.getDimensionPixelSize(
+                    R.dimen.edit_mode_workspace_bottom_gap,
+                )
+            val hotseat = launcher.hotseat
+            val bottom =
+                if (hotseat.top > 0) {
+                    hotseat.top + hotseat.translationY - bottomGap
+                } else {
+                    grid.getCellLayoutSpringLoadShrunkBottom(launcher) - stripHeightPx
+                }
+            return top to bottom
+        }
+
+        private fun getEditModeWorkspaceScale(
+            launcher: Launcher,
+            top: Float,
+            bottom: Float,
+        ): Float {
+            val grid = launcher.deviceProfile
+            var scale = (bottom - top) / grid.cellLayoutHeight.toFloat()
+            scale = min(scale, 1f)
+
+            val workspaceWidth = grid.deviceProperties.availableWidthPx
+            val scaledWorkspaceWidth = workspaceWidth * scale
+            val maxAvailableWidth =
+                workspaceWidth - (2 * grid.workspaceSpringLoadedMinNextPageVisiblePx)
+            if (scaledWorkspaceWidth > maxAvailableWidth) {
+                scale *= maxAvailableWidth / scaledWorkspaceWidth
+            }
+            return scale
+        }
+
+        private fun getEditModeWorkspaceScaleAndTranslation(
+            launcher: Launcher,
+        ): ScaleAndTranslation {
+            val ws = launcher.workspace
+            if (ws.childCount == 0) {
+                return ScaleAndTranslation(1f, 0f, 0f)
+            }
+
+            val (top, bottom) = getEditModeWorkspaceVerticalBounds(launcher)
+            val scale = getEditModeWorkspaceScale(launcher, top, bottom)
+
+            val halfHeight = ws.height / 2f
+            val myCenter = ws.top + halfHeight
+            val cellTopFromCenter = halfHeight - ws.getChildAt(0).top
+            val actualCellTop = myCenter - cellTopFromCenter * scale
+            return ScaleAndTranslation(scale, 0f, top - actualCellTop)
+        }
     }
 
     override fun getTransitionDuration(context: ActivityContext, isToState: Boolean) = 150
@@ -46,14 +107,12 @@ class EditModeState(id: Int) : LauncherState(id, StatsLogManager.LAUNCHER_STATE_
         }
     }
 
-    override fun getWorkspaceScaleAndTranslation(launcher: Launcher): ScaleAndTranslation {
-        val scale = launcher.deviceProfile.getWorkspaceSpringLoadScale(launcher)
-        return ScaleAndTranslation(scale, 0f, 0f)
-    }
+    override fun getWorkspaceScaleAndTranslation(launcher: Launcher): ScaleAndTranslation =
+        getEditModeWorkspaceScaleAndTranslation(launcher)
 
     override fun getHotseatScaleAndTranslation(launcher: Launcher): ScaleAndTranslation {
-        val scale = launcher.deviceProfile.getWorkspaceSpringLoadScale(launcher)
-        return ScaleAndTranslation(scale, 0f, 0f)
+        val offset = getEditModePageStripHeightPx(launcher).toFloat()
+        return ScaleAndTranslation(1f, 0f, -offset)
     }
 
     override fun getWorkspaceBackgroundAlpha(launcher: Launcher): Float {

--- a/src/com/android/launcher3/util/OnboardingPrefs.kt
+++ b/src/com/android/launcher3/util/OnboardingPrefs.kt
@@ -78,4 +78,8 @@ object OnboardingPrefs {
     val HOTSEAT_LONGPRESS_TIP_SEEN = backedUpItem("launcher.hotseat_longpress_tip_seen", false)
 
     @JvmField val TASKBAR_SEARCH_EDU_SEEN = backedUpItem("launcher.taskbar_search_edu_seen", false)
+
+    @JvmField
+    val EDIT_MODE_PAGE_STRIP_TIP_SEEN =
+        backedUpItem("launcher.edit_mode_page_strip_tip_seen", false)
 }

--- a/tests/multivalentTests/src/com/android/launcher3/WorkspacePageReorderTest.kt
+++ b/tests/multivalentTests/src/com/android/launcher3/WorkspacePageReorderTest.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android.launcher3
+
+import android.util.SparseIntArray
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SmallTest
+import com.android.launcher3.util.IntArray
+import com.android.launcher3.util.IntSet
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@SmallTest
+@RunWith(AndroidJUnit4::class)
+class WorkspacePageReorderTest {
+
+    @Test
+    fun createPageGroupSwapMap_singlePanel_swapsBothScreens() {
+        val screenOrder = IntArray.wrap(0, 1, 2, 3)
+
+        val swapMap = Workspace.createPageGroupSwapMap(screenOrder, 1, 2, 1)
+
+        assertSwap(swapMap, 1, 2)
+        assertSwap(swapMap, 2, 1)
+    }
+
+    @Test
+    fun createPageGroupSwapMap_twoPanel_swapsPagePairs() {
+        val screenOrder = IntArray.wrap(0, 1, 2, 3, 4, 5)
+
+        val swapMap = Workspace.createPageGroupSwapMap(screenOrder, 2, 4, 2)
+
+        assertSwap(swapMap, 2, 4)
+        assertSwap(swapMap, 3, 5)
+        assertSwap(swapMap, 4, 2)
+        assertSwap(swapMap, 5, 3)
+    }
+
+    @Test
+    fun getPageGroupStarts_singlePanel_returnsEveryPageStart() {
+        val starts = Workspace.getPageGroupStarts(IntArray.wrap(0, 1, 2, 3), 1)
+        assertThat(starts.toArray().asList()).containsExactly(0, 1, 2, 3).inOrder()
+    }
+
+    @Test
+    fun getPageGroupStarts_twoPanel_returnsPairStarts() {
+        val starts = Workspace.getPageGroupStarts(IntArray.wrap(0, 1, 2, 3, 4, 5), 2)
+        assertThat(starts.toArray().asList()).containsExactly(0, 2, 4).inOrder()
+    }
+
+    @Test
+    fun getPersistedWorkspaceScreenIds_parsesCommaSeparatedOrder() {
+        val ids = Workspace.getPersistedWorkspaceScreenIds("0,1,2")
+        assertThat(ids.getArray().toArray().asList()).containsExactly(0, 1, 2).inOrder()
+    }
+
+    @Test
+    fun getPersistedWorkspaceScreenIds_ignoresInvalidEntries() {
+        val ids = Workspace.getPersistedWorkspaceScreenIds("2, ,x,0")
+        assertThat(ids.getArray().toArray().asList()).containsExactly(0, 2).inOrder()
+    }
+
+    @Test
+    fun shouldPreserveEmptyScreenWhenStripping_skipsPersistedNonExtraScreens() {
+        val persisted = IntSet.wrap(0, 1, 2)
+        assertThat(
+            Workspace.shouldPreserveEmptyScreenWhenStripping(2, persisted, false),
+        ).isTrue()
+        assertThat(
+            Workspace.shouldPreserveEmptyScreenWhenStripping(
+                Workspace.EXTRA_EMPTY_SCREEN_ID,
+                persisted,
+                true,
+            ),
+        ).isFalse()
+        assertThat(
+            Workspace.shouldPreserveEmptyScreenWhenStripping(3, persisted, false),
+        ).isFalse()
+    }
+
+    private fun assertSwap(map: SparseIntArray, from: Int, to: Int) {
+        assertThat(map.indexOfKey(from)).isAtLeast(0)
+        assertThat(map.get(from)).isEqualTo(to)
+    }
+}

--- a/tests/multivalentTests/src/com/android/launcher3/model/data/WorkspaceDataTest.kt
+++ b/tests/multivalentTests/src/com/android/launcher3/model/data/WorkspaceDataTest.kt
@@ -23,7 +23,9 @@ import com.android.launcher3.model.data.WorkspaceChangeEvent.AddEvent
 import com.android.launcher3.model.data.WorkspaceChangeEvent.RemoveEvent
 import com.android.launcher3.model.data.WorkspaceChangeEvent.UpdateEvent
 import com.android.launcher3.model.data.WorkspaceData.Companion.MAX_HISTORY_SIZE
+import com.android.launcher3.model.data.WorkspaceData.Companion.mergeWorkspaceScreens
 import com.android.launcher3.model.data.WorkspaceData.MutableWorkspaceData
+import com.android.launcher3.util.IntArray
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -125,6 +127,36 @@ class WorkspaceDataTest {
 
         data.removeItems(listOf(createItemInfo(0)), null)
         assertThat(data.diff(start)).isNull()
+    }
+
+    @Test
+    fun mergeWorkspaceScreens_usesPersistedOrder_first() {
+        val merged = mergeWorkspaceScreens(IntArray.wrap(0, 1, 2), "2,0,1")
+        assertThat(merged.toArray().asList()).containsExactly(2, 0, 1).inOrder()
+    }
+
+    @Test
+    fun mergeWorkspaceScreens_keepsPersistedEmptyScreens() {
+        val merged = mergeWorkspaceScreens(IntArray.wrap(0, 2), "9,2,0")
+        assertThat(merged.toArray().asList()).containsExactly(9, 2, 0).inOrder()
+    }
+
+    @Test
+    fun mergeWorkspaceScreens_appendsMissingItemScreens() {
+        val merged = mergeWorkspaceScreens(IntArray.wrap(0, 1, 2, 3), "2,0")
+        assertThat(merged.toArray().asList()).containsExactly(2, 0, 1, 3).inOrder()
+    }
+
+    @Test
+    fun mergeWorkspaceScreens_preservesFirstScreenPositionFromPersistedOrder() {
+        val merged = mergeWorkspaceScreens(IntArray.wrap(0, 1, 2), "1,0,2")
+        assertThat(merged.toArray().asList()).containsExactly(1, 0, 2).inOrder()
+    }
+
+    @Test
+    fun mergeWorkspaceScreens_emptyPersistedFallsBackToItemOrder() {
+        val merged = mergeWorkspaceScreens(IntArray.wrap(0, 1, 2), "")
+        assertThat(merged.toArray().asList()).containsExactly(0, 1, 2).inOrder()
     }
 
     private fun createItemSparseArray(size: Int) =


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

Adds edit-mode workspace page reordering and a default home page, with order persisted across restarts. Introduces a bottom EditModePageStrip (drag to reorder page groups, tap home icon to set default), polishes edit-mode layout (workspace scaling, hotseat offset, strip enter/exit animation, page dots visible), and shows a one-time ArrowTipView explaining strip gestures.

- Closes: #6796 

### Reasoning
Lawnchair edit mode previously had no way to reorder workspace screens or choose which page opens on home, and screen order was not reliably restored after reboot. This follows Launcher3 edit-mode / spring-loaded patterns: state-driven layout in EditModeState, model persistence via ModelWriter + WorkspaceData, and a Lawnchair-specific strip UI wired from Launcher state transitions.

Core pieces:
Model: WORKSPACE_SCREEN_ORDER in LauncherPrefs, merge on bind in WorkspaceData, reorder helpers on Workspace (page groups, default screen).
UI: EditModePageStrip in the drag layer; hotseat lifts by strip height; workspace vertical bounds use status-bar padding + hotseat position (not drop-target spring-load top / double strip subtraction).
Robustness: defer stripEmptyScreens during screen-ID remap; no strip in edit mode.
Onboarding: EDIT_MODE_PAGE_STRIP_TIP_SEEN + ArrowTipView above the strip (dismiss on drag, set-home, or exit).

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing
1. Long-press home → enter edit mode: page strip at bottom; hotseat/QSB above strip; page dots visible between workspace and hotseat.
2. Long-press a strip chip → drag to reorder → exit edit mode → confirm order on home and after force-stop/reboot.
3. Tap home icon on a non-default chip → label shows Default → reboot → launcher opens on that page.
4. Tap a strip chip (no long-press) → workspace snaps to that page group.
5. First edit-mode entry only: tooltip above strip; dismisses on drag, set-home, or exit; does not reappear.
6. Enter/exit edit mode: strip fades/slides with ~150ms transition; layout returns to normal.
7. Multi-page: swipe workspace in edit mode; dots update and stay visible.
8. Run unit tests: WorkspacePageReorderTest, WorkspaceDataTest.


### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

:x: **Bug fix** (A non-breaking change that fixes an issue)
:white_check_mark: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)

<img width="1080" height="2400" alt="Screenshot_20260529-103608_Lawnchair" src="https://github.com/user-attachments/assets/eb16a5df-26ba-4499-acc9-eb2b7466ea9a" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Page reordering in edit mode with drag-and-drop and persistent screen order.
  * Set a default home page from the page management UI.
  * New edit-mode page strip UI showing pages and a home button.
  * Optional education tip to guide first-time use.

* **Improvements**
  * Refined edit-mode scaling, layout and visuals for clearer page management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LawnchairLauncher/lawnchair/pull/6809?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->