### PR TITLE
fix: Clear two layers stale state from highlight decoration

### DIFF
--- a/lawnchair/src/app/lawnchair/allapps/AllAppsSearchInput.kt
+++ b/lawnchair/src/app/lawnchair/allapps/AllAppsSearchInput.kt
@@ -213,6 +213,10 @@ class AllAppsSearchInput(context: Context, attrs: AttributeSet?) :
                 input.setHint("")
                 hint.text = ""
             }
+
+            if (::appsView.isInitialized) {
+                appsView.mSearchRecyclerView.invalidate()
+            }
         }
 
         input.addTextChangedListener(

--- a/lawnchair/src/app/lawnchair/allapps/views/SearchResultIcon.kt
+++ b/lawnchair/src/app/lawnchair/allapps/views/SearchResultIcon.kt
@@ -66,7 +66,6 @@ class SearchResultIcon(context: Context, attrs: AttributeSet?) :
     }
 
     override fun bind(target: SearchTargetCompat, shortcuts: List<SearchTargetCompat>) {
-        if (boundId == target.id) return
         boundId = target.id
         flags = getFlags(target.extras)
         reset()
@@ -83,7 +82,7 @@ class SearchResultIcon(context: Context, attrs: AttributeSet?) :
 
             target.shortcutInfo != null -> {
                 allowLongClick = true
-                bindFromShortcutInfo(target.shortcutInfo)
+                bindFromShortcutInfo(target.id, target.shortcutInfo)
             }
 
             else -> {
@@ -150,9 +149,14 @@ class SearchResultIcon(context: Context, attrs: AttributeSet?) :
         }
         notifyApplied(info)
         if (bindIcon) {
+            val targetId = boundId
             Executors.MODEL_EXECUTOR.handler.postAtFrontOfQueue {
                 populateSearchActionItemInfo(target, info)
-                runOnMainThread { applyFromItemInfoWithIcon(info) }
+                runOnMainThread {
+                    if (boundId == targetId) {
+                        applyFromItemInfoWithIcon(info)
+                    }
+                }
             }
         }
     }
@@ -176,7 +180,7 @@ class SearchResultIcon(context: Context, attrs: AttributeSet?) :
         notifyApplied(appInfo)
     }
 
-    private fun bindFromShortcutInfo(shortcutInfo: ShortcutInfo) {
+    private fun bindFromShortcutInfo(targetId: String, shortcutInfo: ShortcutInfo) {
         val si = WorkspaceItemInfo(shortcutInfo, launcher)
         si.container = LauncherSettings.Favorites.CONTAINER_ALL_APPS
         applyFromWorkspaceItem(si)
@@ -184,7 +188,11 @@ class SearchResultIcon(context: Context, attrs: AttributeSet?) :
         val cache = LauncherAppState.getInstance(launcher).iconCache
         Executors.MODEL_EXECUTOR.handler.postAtFrontOfQueue {
             cache.getShortcutIcon(si, shortcutInfo)
-            runOnMainThread { applyFromWorkspaceItem(si) }
+            runOnMainThread {
+                if (boundId == targetId) {
+                    applyFromWorkspaceItem(si)
+                }
+            }
         }
     }
 

--- a/lawnchair/src/app/lawnchair/allapps/views/SearchResultIconRow.kt
+++ b/lawnchair/src/app/lawnchair/allapps/views/SearchResultIconRow.kt
@@ -31,7 +31,6 @@ class SearchResultIconRow(context: Context, attrs: AttributeSet?) :
     private var delimiter: View? = null
     private lateinit var shortcutIcons: Array<SearchResultIcon>
 
-    private var boundId = ""
     private var flags = 0
 
     override fun onFinishInflate() {
@@ -78,8 +77,6 @@ class SearchResultIconRow(context: Context, attrs: AttributeSet?) :
     }
 
     override fun bind(target: SearchTargetCompat, shortcuts: List<SearchTargetCompat>) {
-        if (boundId == target.id) return
-        boundId = target.id
         flags = getFlags(target.extras)
 
         icon.bind(target) {

--- a/lawnchair/src/app/lawnchair/allapps/views/SearchResultRightLeftIcon.kt
+++ b/lawnchair/src/app/lawnchair/allapps/views/SearchResultRightLeftIcon.kt
@@ -82,7 +82,8 @@ class SearchResultRightLeftIcon(context: Context, attrs: AttributeSet?) :
         this.layoutParams = layoutParams
     }
 
-    override val isQuickLaunch: Boolean get() = hasFlag(flags, SearchResultView.FLAG_QUICK_LAUNCH)
+    override val isQuickLaunch: Boolean
+        get() = avatar.isQuickLaunch || hasFlag(flags, SearchResultView.FLAG_QUICK_LAUNCH)
 
     override val titleText: CharSequence? get() = title.text
 
@@ -97,6 +98,7 @@ class SearchResultRightLeftIcon(context: Context, attrs: AttributeSet?) :
         target: SearchTargetCompat,
         shortcuts: List<SearchTargetCompat>,
     ) {
+        flags = getFlags(target.extras)
         title.text = target.searchAction?.title
         val isNewFile = target.resultType == SearchTargetCompat.RESULT_TYPE_FILE_TILE &&
             target.layoutType == LayoutType.THUMBNAIL

--- a/lawnchair/src/app/lawnchair/allapps/views/SearchResultRightLeftIcon.kt
+++ b/lawnchair/src/app/lawnchair/allapps/views/SearchResultRightLeftIcon.kt
@@ -83,7 +83,7 @@ class SearchResultRightLeftIcon(context: Context, attrs: AttributeSet?) :
     }
 
     override val isQuickLaunch: Boolean
-        get() = avatar.isQuickLaunch || hasFlag(flags, SearchResultView.FLAG_QUICK_LAUNCH)
+        get() = hasFlag(flags, SearchResultView.FLAG_QUICK_LAUNCH)
 
     override val titleText: CharSequence? get() = title.text
 

--- a/lawnchair/src/app/lawnchair/search/LawnchairSearchAdapterProvider.kt
+++ b/lawnchair/src/app/lawnchair/search/LawnchairSearchAdapterProvider.kt
@@ -41,7 +41,12 @@ class LawnchairSearchAdapterProvider(
     private var quickLaunchItem: SearchResultView? = null
         set(value) {
             field = value
-            appsView.searchUiManager.setFocusedResultTitle(field?.titleText, field?.titleText, true)
+            appsView.searchUiManager.setFocusedResultTitle(
+                field?.titleText,
+                field?.titleText,
+                field != null,
+            )
+            appsView.mSearchRecyclerView.invalidate()
         }
 
     override fun isViewSupported(viewType: Int): Boolean = layoutIdMap.contains(viewType)
@@ -90,6 +95,11 @@ class LawnchairSearchAdapterProvider(
     override fun launchHighlightedItem(): Boolean = quickLaunchItem?.launch() ?: false
 
     override fun getHighlightedItem() = quickLaunchItem as View?
+
+    override fun clearHighlightedItem() {
+        super.clearHighlightedItem()
+        quickLaunchItem = null
+    }
 
     override fun getDecorator() = decorator
 

--- a/lawnchair/src/app/lawnchair/search/adapter/SearchAdapterItem.kt
+++ b/lawnchair/src/app/lawnchair/search/adapter/SearchAdapterItem.kt
@@ -1,6 +1,7 @@
 package app.lawnchair.search.adapter
 
 import android.content.res.ColorStateList
+import android.graphics.Color
 import android.graphics.drawable.InsetDrawable
 import android.graphics.drawable.RippleDrawable
 import android.graphics.drawable.ShapeDrawable
@@ -8,6 +9,7 @@ import android.graphics.drawable.shapes.RoundRectShape
 import android.view.View
 import app.lawnchair.allapps.views.SearchItemBackground
 import app.lawnchair.search.LawnchairSearchAdapterProvider
+import com.android.launcher3.R
 import com.android.launcher3.allapps.BaseAllAppsAdapter
 
 data class SearchAdapterItem(
@@ -28,26 +30,13 @@ data class SearchAdapterItem(
 
     fun setRippleEffect(child: View) {
         val shape = RoundRectShape(background?.cornerRadii, null, null)
-        val shapeDrawable = ShapeDrawable(shape)
-        val colorDefault = background?.groupHighlight ?: 0
-        val colorPressed = background?.focusHighlight ?: 0
-
-        val colorStateList = ColorStateList(
-            arrayOf(
-                intArrayOf(android.R.attr.state_pressed),
-                intArrayOf(-android.R.attr.state_pressed),
-            ),
-            intArrayOf(
-                colorPressed,
-                colorDefault,
-            ),
-        )
-
-        shapeDrawable.paint.color = colorDefault
-        val inset = 3
-        val insetDrawable = InsetDrawable(shapeDrawable, 0, inset, 0, inset)
-        val rippleDrawable = RippleDrawable(colorStateList, insetDrawable, null)
-        child.background = rippleDrawable
+        val maskDrawable = ShapeDrawable(shape).apply {
+            paint.color = Color.WHITE
+        }
+        val rippleColor = background?.focusHighlight ?: background?.groupHighlight ?: 0
+        val inset = child.resources.getDimensionPixelSize(R.dimen.search_decoration_padding)
+        val insetMask = InsetDrawable(maskDrawable, 0, inset, 0, inset)
+        child.background = RippleDrawable(ColorStateList.valueOf(rippleColor), null, insetMask)
     }
 
     companion object {

--- a/src/com/android/launcher3/allapps/ActivityAllAppsContainerView.java
+++ b/src/com/android/launcher3/allapps/ActivityAllAppsContainerView.java
@@ -1783,7 +1783,7 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
                     new ViewGroupFocusHelper(mRecyclerView)) : new FocusedItemDecorator(
                     mRecyclerView);
             mRecyclerView.addItemDecoration(focusedItemDecorator);
-            // LC-Note: This is needed for highlight focused app decoration, this has some problem of it own but purely visual.
+            // LC-Note: This is needed for highlight decoration
             if (isSearch()) {
                 RecyclerView.ItemDecoration searchDecorator = getMainAdapterProvider().getDecorator();
                 if (searchDecorator != null) {


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Clear staled layers from highlight decorator, making sure that quick launch result works correctly so that highlight knows what to highlight.

Fix LC-Note where search highlight decorator get applied twice to the result.

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

1. Search for any result, like files, photos, webs, apps (before highlight only applied to apps only)
2. Observe highlight effects (before highlight is much brighter or inconsistent compared to before)

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stale icon updates in search results caused by out-of-order async updates.
  * Improved search UI refresh when focus is lost and when quick-launch focus changes.
  * Corrected quick-launch highlight clearing behavior.

* **Improvements**
  * Ensured search result rows always rebind to reflect the latest target state.
  * Initialized per-result flags so behavior matches current result data.
  * Refined ripple effect styling for search result interactions.

* **Style**
  * Minor comment clarification in highlight-related code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->