### PR TITLE
fix: Set enable allapps two line to false by default

### DIFF
--- a/lawnchair/res/values/config.xml
+++ b/lawnchair/res/values/config.xml
@@ -152,7 +152,7 @@
     <bool name="config_default_live_information_show_announcements">true</bool>
     <bool name="config_default_enable_dot_pagination">true</bool>
     <bool name="config_default_enable_material_u_popup">true</bool>
-    <bool name="config_default_enable_two_line_allapps">true</bool>
+    <bool name="config_default_enable_two_line_allapps">false</bool>
     <bool name="config_default_enable_nightly_auto_updater">true</bool>
     <bool name="config_default_enable_folder_icon_shape_customization">false</bool>
 


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Fix mismatch that shows allapps two line preference as true from Lawnchair prefs2 side, but in reality it's false from Launcher3 prefs side thus needing to toggle the two line prefs off and on again. This PR fixes it by just setting the default to match Launcher3

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Need really long application name before testing.

1. Open Lawnchair
2. Scroll to allapps
3. Observe two line state

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated the default app list display to show single-line items instead of the two-line format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->