### PR TITLE
fix: Don't align padding of the search too close to the screen

### DIFF
--- a/lawnchair/res/layout/search_results_rv_layout.xml
+++ b/lawnchair/res/layout/search_results_rv_layout.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<app.lawnchair.search.LawnchairSearchRecyclerView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/search_results_list_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:clipToPadding="false"
+    android:descendantFocusability="afterDescendants"
+    android:focusable="true" />

--- a/lawnchair/res/values/dimens.xml
+++ b/lawnchair/res/values/dimens.xml
@@ -53,6 +53,7 @@
     <dimen name="search_decoration_padding">1dp</dimen>
     <dimen name="search_group_radius">28dp</dimen>
     <dimen name="search_hero_inline_button_text_size">12sp</dimen>
+    <dimen name="search_result_recycler_view_padding">8dp</dimen>
     <dimen name="search_result_hero_title_size">16sp</dimen>
     <dimen name="search_result_hero_subtitle_size">14sp</dimen>
     <dimen name="search_result_margin">8dp</dimen>

--- a/lawnchair/src/app/lawnchair/allapps/views/SearchItemBackground.kt
+++ b/lawnchair/src/app/lawnchair/allapps/views/SearchItemBackground.kt
@@ -75,7 +75,7 @@ class SearchItemBackground(
         if (child is SearchResultIcon) {
             val density = child.resources.displayMetrics.density
             val iconSize = child.iconSize.toFloat()
-            val desiredWidth = iconSize + 24.dpToPx(resources) * density
+            val desiredWidth = iconSize + 48f * density
             val cellWidth = child.width.toFloat()
             if (desiredWidth < cellWidth) {
                 val inset = (cellWidth - desiredWidth) / 2

--- a/lawnchair/src/app/lawnchair/allapps/views/SearchItemBackground.kt
+++ b/lawnchair/src/app/lawnchair/allapps/views/SearchItemBackground.kt
@@ -9,6 +9,7 @@ import android.view.View
 import app.lawnchair.theme.color.tokens.ColorTokens
 import com.android.launcher3.R
 import com.android.systemui.shared.system.BlurUtils
+import com.android.systemui.util.dpToPx
 
 class SearchItemBackground(
     context: Context,
@@ -66,10 +67,26 @@ class SearchItemBackground(
 
         paint.color = color
 
-        val left = child.left.toFloat() + searchDecorationPadding
-        val top = child.top.toFloat() + searchDecorationPadding
-        val right = child.right.toFloat() - searchDecorationPadding
-        val bottom = child.bottom.toFloat() - searchDecorationPadding
+        var left = child.left.toFloat() + searchDecorationPadding
+        var top = child.top.toFloat() + searchDecorationPadding
+        var right = child.right.toFloat() - searchDecorationPadding
+        var bottom = child.bottom.toFloat() - searchDecorationPadding
+
+        if (child is SearchResultIcon) {
+            val density = child.resources.displayMetrics.density
+            val iconSize = child.iconSize.toFloat()
+            val desiredWidth = iconSize + 24.dpToPx(resources) * density
+            val cellWidth = child.width.toFloat()
+            if (desiredWidth < cellWidth) {
+                val inset = (cellWidth - desiredWidth) / 2
+                left += inset
+                right -= inset
+            }
+            val insetVertical = 6f * density
+            top += insetVertical
+            bottom -= insetVertical
+        }
+
         tmpRect.set(left, top, right, bottom)
 
         tmpPath.reset()

--- a/lawnchair/src/app/lawnchair/allapps/views/SearchResultRightLeftIcon.kt
+++ b/lawnchair/src/app/lawnchair/allapps/views/SearchResultRightLeftIcon.kt
@@ -77,8 +77,8 @@ class SearchResultRightLeftIcon(context: Context, attrs: AttributeSet?) :
             LayoutParams.MATCH_PARENT,
             heightRes,
         )
-        layoutParams.leftMargin = grid.allAppsPadding.left
-        layoutParams.rightMargin = grid.allAppsPadding.right
+        layoutParams.leftMargin = 0
+        layoutParams.rightMargin = 0
         this.layoutParams = layoutParams
     }
 

--- a/lawnchair/src/app/lawnchair/search/LawnchairSearchAdapterProvider.kt
+++ b/lawnchair/src/app/lawnchair/search/LawnchairSearchAdapterProvider.kt
@@ -76,14 +76,14 @@ class LawnchairSearchAdapterProvider(
 
         if (viewType != SEARCH_RESULT_ICON) {
             val layoutParams = ViewGroup.MarginLayoutParams(view.layoutParams)
-            layoutParams.leftMargin = leftMargin
-            layoutParams.rightMargin = rightMargin
+            layoutParams.leftMargin = 0
+            layoutParams.rightMargin = 0
             view.layoutParams = layoutParams
         }
         if (viewType == SEARCH_TEXT_HEADER) {
             val layoutParams: ViewGroup.MarginLayoutParams = ViewGroup.MarginLayoutParams(0, 0)
-            layoutParams.leftMargin = leftMargin
-            layoutParams.rightMargin = rightMargin
+            layoutParams.leftMargin = 0
+            layoutParams.rightMargin = 0
             view.layoutParams = layoutParams
         }
 

--- a/lawnchair/src/app/lawnchair/search/LawnchairSearchRecyclerView.kt
+++ b/lawnchair/src/app/lawnchair/search/LawnchairSearchRecyclerView.kt
@@ -1,0 +1,19 @@
+package app.lawnchair.search
+
+import android.content.Context
+import android.util.AttributeSet
+import com.android.launcher3.R
+import com.android.launcher3.allapps.SearchRecyclerView
+
+class LawnchairSearchRecyclerView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0,
+    defStyleRes: Int = 0,
+) : SearchRecyclerView(context, attrs, defStyleAttr, defStyleRes) {
+
+    override fun setPadding(left: Int, top: Int, right: Int, bottom: Int) {
+        val extraPadding = resources.getDimensionPixelSize(R.dimen.search_result_recycler_view_padding)
+        super.setPadding(left + extraPadding, top, right + extraPadding, bottom)
+    }
+}


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Align search with expanded search bar width so that it's not sitting at the edge of the display.

Part 1 of small search layout adjustment.

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

1. Search
2. Observe

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved search results list layout and spacing for a cleaner, more consistent visual appearance.
  * Centered and tightened highlight bounds around result icons for better visual focus.
  * Ensured consistent horizontal padding and margins across search items, improving alignment and touch targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->