### PR TITLE
fix: Don't make search result content sit too close to layout

### DIFF
--- a/lawnchair/res/layout/search_result_icon_right_left.xml
+++ b/lawnchair/res/layout/search_result_icon_right_left.xml
@@ -12,6 +12,7 @@
         style="@style/BaseIcon"
         android:layout_width="@dimen/search_row_files_preview_width"
         android:layout_height="@dimen/search_row_files_preview_height"
+        android:layout_marginStart="8dp"
         android:drawableTint="?android:textColorPrimary"
         android:ellipsize="end"
         launcher:iconDisplay="search_result_small"
@@ -23,6 +24,7 @@
         style="@style/BaseIcon"
         android:layout_width="@dimen/search_row_medium_icon_size"
         android:layout_height="@dimen/search_row_medium_icon_size"
+        android:layout_marginStart="8dp"
         android:drawableTint="?android:textColorPrimary"
         android:ellipsize="end"
         launcher:iconDisplay="search_result_small"
@@ -84,9 +86,7 @@
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_gravity="end"
-        android:paddingTop="@dimen/dynamic_grid_edge_margin"
-        android:paddingEnd="@dimen/dynamic_grid_edge_margin"
-        android:paddingBottom="@dimen/dynamic_grid_edge_margin"
+        android:paddingEnd="16dp"
         android:orientation="horizontal"
         android:singleLine="true">
 

--- a/lawnchair/res/layout/search_result_small_icon_right_left.xml
+++ b/lawnchair/res/layout/search_result_small_icon_right_left.xml
@@ -12,6 +12,7 @@
         style="@style/BaseIcon"
         android:layout_width="@dimen/search_row_files_preview_width"
         android:layout_height="@dimen/search_row_files_preview_height"
+        android:layout_marginStart="8dp"
         android:drawableTint="?android:textColorPrimary"
         android:ellipsize="end"
         launcher:iconDisplay="search_result_small"
@@ -23,6 +24,7 @@
         style="@style/BaseIcon"
         android:layout_width="@dimen/search_row_medium_icon_size"
         android:layout_height="@dimen/search_row_medium_icon_size"
+        android:layout_marginStart="8dp"
         android:drawableTint="?android:textColorPrimary"
         android:ellipsize="end"
         launcher:iconDisplay="search_result_small"
@@ -84,9 +86,7 @@
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_gravity="end"
-        android:paddingTop="@dimen/dynamic_grid_edge_margin"
-        android:paddingEnd="@dimen/dynamic_grid_edge_margin"
-        android:paddingBottom="@dimen/dynamic_grid_edge_margin"
+        android:paddingEnd="16dp"
         android:orientation="horizontal"
         android:singleLine="true">
 

--- a/lawnchair/res/layout/search_result_text_header.xml
+++ b/lawnchair/res/layout/search_result_text_header.xml
@@ -4,8 +4,8 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:minHeight="@dimen/search_result_text_height"
-    android:orientation="horizontal"
-    android:paddingStart="8dp">
+    android:paddingStart="16dp"
+    android:paddingEnd="16dp">
 
     <LinearLayout
         android:id="@+id/text_rows"
@@ -15,9 +15,7 @@
         android:layout_gravity="center_vertical"
         android:layout_weight="1.0"
         android:orientation="horizontal"
-        android:paddingStart="@dimen/dynamic_grid_edge_margin"
         android:paddingTop="@dimen/dynamic_grid_edge_margin"
-        android:paddingEnd="@dimen/dynamic_grid_edge_margin"
         android:paddingBottom="@dimen/dynamic_grid_edge_margin"
         android:singleLine="true">
         <TextView

--- a/lawnchair/res/values/dimens.xml
+++ b/lawnchair/res/values/dimens.xml
@@ -51,7 +51,7 @@
     <dimen name="search_box_container_height">60dp</dimen>
     <dimen name="search_box_height">52dp</dimen>
     <dimen name="search_decoration_padding">1dp</dimen>
-    <dimen name="search_group_radius">28dp</dimen>
+    <dimen name="search_group_radius">20dp</dimen>
     <dimen name="search_hero_inline_button_text_size">12sp</dimen>
     <dimen name="search_result_recycler_view_padding">8dp</dimen>
     <dimen name="search_result_hero_title_size">16sp</dimen>
@@ -60,10 +60,10 @@
     <dimen name="search_result_padding">16dp</dimen>
     <dimen name="search_result_padding_medium">12dp</dimen>
     <dimen name="search_result_radius">4dp</dimen>
-    <dimen name="search_result_row_height">88dp</dimen>
-    <dimen name="search_result_row_medium_height">72dp</dimen>
-    <dimen name="search_result_small_row_height">56dp</dimen>
-    <dimen name="search_result_files_row_height">96dp</dimen>
+    <dimen name="search_result_row_height">92dp</dimen>
+    <dimen name="search_result_row_medium_height">76dp</dimen>
+    <dimen name="search_result_small_row_height">60dp</dimen>
+    <dimen name="search_result_files_row_height">100dp</dimen>
     <dimen name="search_result_text_height">52dp</dimen>
     <dimen name="search_result_subtitle_padding_start">4dp</dimen>
 
@@ -105,13 +105,13 @@
 
     <dimen name="theme_icon_size">24dp</dimen>
 
-    <dimen name="search_row_medium_icon_size">24dp</dimen>
+    <dimen name="search_row_medium_icon_size">36dp</dimen>
     <dimen name="search_row_mini_icon_size">22dp</dimen>
     <dimen name="space_layout_height">14dp</dimen>
     <dimen name="space_layout_mini_height">8dp</dimen>
     <dimen name="search_row_files_preview_width">80dp</dimen>
     <dimen name="search_row_files_preview_height">64dp</dimen>
-    <dimen name="search_row_preview_radius">18dp</dimen>
+    <dimen name="search_row_preview_radius">4dp</dimen>
 
     <dimen name="wallpaper_carousel_height">120dp</dimen>
 

--- a/lawnchair/res/values/dimens.xml
+++ b/lawnchair/res/values/dimens.xml
@@ -62,7 +62,7 @@
     <dimen name="search_result_radius">4dp</dimen>
     <dimen name="search_result_row_height">92dp</dimen>
     <dimen name="search_result_row_medium_height">76dp</dimen>
-    <dimen name="search_result_small_row_height">60dp</dimen>
+    <dimen name="search_result_small_row_height">64dp</dimen>
     <dimen name="search_result_files_row_height">100dp</dimen>
     <dimen name="search_result_text_height">52dp</dimen>
     <dimen name="search_result_subtitle_padding_start">4dp</dimen>

--- a/lawnchair/src/app/lawnchair/allapps/views/SearchItemBackground.kt
+++ b/lawnchair/src/app/lawnchair/allapps/views/SearchItemBackground.kt
@@ -73,16 +73,15 @@ class SearchItemBackground(
         var bottom = child.bottom.toFloat() - searchDecorationPadding
 
         if (child is SearchResultIcon) {
-            val density = child.resources.displayMetrics.density
             val iconSize = child.iconSize.toFloat()
-            val desiredWidth = iconSize + 48f * density
+            val desiredWidth = iconSize + 48.dpToPx(resources)
             val cellWidth = child.width.toFloat()
             if (desiredWidth < cellWidth) {
                 val inset = (cellWidth - desiredWidth) / 2
                 left += inset
                 right -= inset
             }
-            val insetVertical = 6f * density
+            val insetVertical = 6.dpToPx(resources)
             top += insetVertical
             bottom -= insetVertical
         }

--- a/lawnchair/src/app/lawnchair/allapps/views/SearchItemBackground.kt
+++ b/lawnchair/src/app/lawnchair/allapps/views/SearchItemBackground.kt
@@ -81,9 +81,11 @@ class SearchItemBackground(
                 left += inset
                 right -= inset
             }
-            val insetVertical = 6.dpToPx(resources)
-            top += insetVertical
-            bottom -= insetVertical
+            val isTwoLine = child.lineCount > 1
+            val insetTop = 6.dpToPx(resources)
+            val insetBottom = if (isTwoLine) 6.dpToPx(resources) else 0.dpToPx(resources)
+            top += insetTop
+            bottom -= insetBottom
         }
 
         tmpRect.set(left, top, right, bottom)

--- a/lawnchair/src/app/lawnchair/allapps/views/SearchResultIcon.kt
+++ b/lawnchair/src/app/lawnchair/allapps/views/SearchResultIcon.kt
@@ -64,23 +64,25 @@ class SearchResultIcon(context: Context, attrs: AttributeSet?) :
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         val width = MeasureSpec.getSize(widthMeasureSpec)
-        if (width > 0) {
-            if (defaultPaddingLeft == -1) {
-                defaultPaddingLeft = paddingLeft
-                defaultPaddingRight = paddingRight
+        if (defaultPaddingLeft == -1) {
+            defaultPaddingLeft = paddingLeft
+            defaultPaddingRight = paddingRight
+        }
+        val isLayoutHorizontal = compoundDrawablesRelative[0] != null || compoundDrawablesRelative[2] != null
+        if (isLayoutHorizontal) {
+            if (paddingLeft != defaultPaddingLeft || paddingRight != defaultPaddingRight) {
+                setPadding(defaultPaddingLeft, paddingTop, defaultPaddingRight, paddingBottom)
             }
-            val isLayoutHorizontal = compoundDrawablesRelative[0] != null || compoundDrawablesRelative[2] != null
-            if (!isLayoutHorizontal) {
-                val desiredWidth = iconSize + 48.dpToPx(resources)
-                if (desiredWidth < width) {
-                    val inset = ((width - desiredWidth) / 2).toInt()
-                    if (paddingLeft != inset || paddingRight != inset) {
-                        setPadding(inset, paddingTop, inset, paddingBottom)
-                    }
-                } else {
-                    if (paddingLeft != defaultPaddingLeft || paddingRight != defaultPaddingRight) {
-                        setPadding(defaultPaddingLeft, paddingTop, defaultPaddingRight, paddingBottom)
-                    }
+        } else if (width > 0) {
+            val desiredWidth = iconSize + 48.dpToPx(resources)
+            if (desiredWidth < width) {
+                val inset = ((width - desiredWidth) / 2).toInt()
+                if (paddingLeft != inset || paddingRight != inset) {
+                    setPadding(inset, paddingTop, inset, paddingBottom)
+                }
+            } else {
+                if (paddingLeft != defaultPaddingLeft || paddingRight != defaultPaddingRight) {
+                    setPadding(defaultPaddingLeft, paddingTop, defaultPaddingRight, paddingBottom)
                 }
             }
         }

--- a/lawnchair/src/app/lawnchair/allapps/views/SearchResultIcon.kt
+++ b/lawnchair/src/app/lawnchair/allapps/views/SearchResultIcon.kt
@@ -30,6 +30,7 @@ import com.android.launcher3.touch.ItemClickHandler
 import com.android.launcher3.touch.ItemLongClickListener
 import com.android.launcher3.util.ComponentKey
 import com.android.launcher3.util.Executors
+import com.android.systemui.util.dpToPx
 
 class SearchResultIcon(context: Context, attrs: AttributeSet?) :
     BubbleTextView(context, attrs),
@@ -44,6 +45,8 @@ class SearchResultIcon(context: Context, attrs: AttributeSet?) :
     private var callback: ((info: ItemInfoWithIcon) -> Unit)? = null
 
     private val searchResultMargin = resources.getDimensionPixelSize(R.dimen.search_result_margin)
+    private var defaultPaddingLeft = -1
+    private var defaultPaddingRight = -1
 
     override fun onFinishInflate() {
         super.onFinishInflate()
@@ -55,6 +58,33 @@ class SearchResultIcon(context: Context, attrs: AttributeSet?) :
             ViewGroup.LayoutParams.MATCH_PARENT,
             launcher.deviceProfile.allAppsProfile.cellHeightPx,
         )
+        defaultPaddingLeft = paddingLeft
+        defaultPaddingRight = paddingRight
+    }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        val width = MeasureSpec.getSize(widthMeasureSpec)
+        if (width > 0) {
+            if (defaultPaddingLeft == -1) {
+                defaultPaddingLeft = paddingLeft
+                defaultPaddingRight = paddingRight
+            }
+            val isLayoutHorizontal = compoundDrawablesRelative[0] != null || compoundDrawablesRelative[2] != null
+            if (!isLayoutHorizontal) {
+                val desiredWidth = iconSize + 48.dpToPx(resources)
+                if (desiredWidth < width) {
+                    val inset = ((width - desiredWidth) / 2).toInt()
+                    if (paddingLeft != inset || paddingRight != inset) {
+                        setPadding(inset, paddingTop, inset, paddingBottom)
+                    }
+                } else {
+                    if (paddingLeft != defaultPaddingLeft || paddingRight != defaultPaddingRight) {
+                        setPadding(defaultPaddingLeft, paddingTop, defaultPaddingRight, paddingBottom)
+                    }
+                }
+            }
+        }
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec)
     }
 
     override val isQuickLaunch get() = hasFlag(flags, SearchResultView.FLAG_QUICK_LAUNCH)

--- a/lawnchair/src/app/lawnchair/allapps/views/SearchResultRightLeftIcon.kt
+++ b/lawnchair/src/app/lawnchair/allapps/views/SearchResultRightLeftIcon.kt
@@ -77,8 +77,6 @@ class SearchResultRightLeftIcon(context: Context, attrs: AttributeSet?) :
             LayoutParams.MATCH_PARENT,
             heightRes,
         )
-        layoutParams.leftMargin = 0
-        layoutParams.rightMargin = 0
         this.layoutParams = layoutParams
     }
 

--- a/res/values/dimens.xml
+++ b/res/values/dimens.xml
@@ -528,7 +528,7 @@
 
     <!-- Search results related parameters -->
     <dimen name="search_row_icon_size">48dp</dimen>
-    <dimen name="search_row_small_icon_size">32dp</dimen>
+    <dimen name="search_row_small_icon_size">38dp</dimen> <!-- LC-Note: Intentional raise from 32dp to 38dp -->
     <dimen name="padded_rounded_button_padding">8dp</dimen>
 
     <!-- Bottom sheet related parameters -->


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Align search result so that it's not sitting too close to the layout, and increase some sizes of icon row to make it slightly easier to see.

Part 2 of small search layout adjustment.

<img width="625" height="1040" alt="image" src="https://github.com/user-attachments/assets/fbb099ec-48e6-4b11-b744-75d7c879cb05" />

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->

Visual matching with Pixel Launcher (approximate), subjectively but overall I think this looks visually pleasing to my eye.

Changes here are just alignment changes.

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

1. Search
2. Observe

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined spacing and padding across search result rows for improved alignment.
  * Increased heights of various search-result rows to strengthen visual hierarchy.
  * Adjusted icon sizing, centering and baseline padding for more consistent presentation.
  * Reduced preview corner radius for search-result thumbnails for a flatter look.
  * Increased small icon size and reduced search-group corner radius to match updated visuals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->