### PR TITLE
feat: Support non-cellular enabled devices

### DIFF
--- a/lawnchair/AndroidManifest.xml
+++ b/lawnchair/AndroidManifest.xml
@@ -40,6 +40,9 @@
     <uses-permission android:name="android.permission.SUSPEND_APPS" tools:ignore="ProtectedPermissions" />
     <uses-permission android:name="android.permission.FLASHLIGHT" />
 
+    <!-- Support non-cellular enabled devices -->
+    <uses-feature android:name="android.hardware.telephony" android:required="false" />
+
     <!--override minSdk declared in it-->
     <uses-sdk tools:overrideLibrary="com.kieronquinn.app.smartspacer.sdk" />
 


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Support non-cellular enabled device like wifi only tablet, phone, etc.,

Fixes #6675

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->

Without declaring telephony as optional, we will have excluded all of non-cellular enabled device when the app is working fine on those devices.

The telephony service comes because Launcher3 declares telephony permission in manifest but never uses it, purpose is unknown since it's been almost 3 decades since the permission was added.

According to Play Console device catalog this would have added support for around 7k+ additional "equipment' or devices to the app. (depends on which app used to calculate statistics but this is close enough.)

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->


### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **New feature** (A non-breaking change that adds functionality)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded device compatibility: The app now supports devices without telephony hardware, including tablets and WiFi-only devices, broadening the range of compatible platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->