### PR TITLE
fix: Find the correct folder size depending on which parent owned them

### DIFF
--- a/src/com/android/launcher3/folder/FolderPagedView.java
+++ b/src/com/android/launcher3/folder/FolderPagedView.java
@@ -294,7 +294,12 @@ public class FolderPagedView extends PagedView<PageIndicatorDots> implements Cli
     private CellLayout createAndAddNewPage() {
         DeviceProfile grid = mFolder.mActivityContext.getDeviceProfile();
         CellLayout page = mViewCache.getView(R.layout.folder_page, getContext(), this);
-        page.setCellDimensions(grid.folderCellWidthPx, grid.folderCellHeightPx);
+        // Lawnchair: Find the correct folder size depending on which parent owned them
+        if (mFolder.isInAppDrawer()) {
+            page.setCellDimensions(grid.getAllAppsProfile().getCellWidthPx(), grid.getAllAppsProfile().getCellHeightPx());
+        } else {
+            page.setCellDimensions(grid.folderCellWidthPx, grid.folderCellHeightPx);
+        }
         page.getShortcutsAndWidgets().setMotionEventSplittingEnabled(false);
         page.setInvertIfRtl(true);
         page.setGridSize(mGridCountX, mGridCountY);

--- a/src/com/android/launcher3/folder/PreviewBackground.java
+++ b/src/com/android/launcher3/folder/PreviewBackground.java
@@ -20,6 +20,7 @@ import static com.android.app.animation.Interpolators.ACCELERATE_DECELERATE;
 import static com.android.app.animation.Interpolators.EMPHASIZED_DECELERATE;
 import static com.android.launcher3.folder.ClippedFolderIconLayoutRule.ICON_OVERLAP_FACTOR;
 import static com.android.launcher3.icons.GraphicsUtils.setColorAlphaBound;
+import static com.android.launcher3.icons.IconNormalizer.ICON_VISIBLE_AREA_FACTOR;
 
 import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
@@ -206,10 +207,18 @@ public class PreviewBackground extends DelegatedCellDrawing {
         ta.recycle();
 
         DeviceProfile grid = activity.getDeviceProfile();
-        previewSize = grid.folderIconSizePx;
+        // Lawnchair: Find the correct icon size depending on which parent owned them
+        if (invalidateDelegate instanceof FolderIcon && ((FolderIcon) invalidateDelegate).isInAppDrawer()) {
+            int allAppsIconSize = grid.getAllAppsProfile().getIconSizePx();
+            previewSize = Math.round(allAppsIconSize * ICON_VISIBLE_AREA_FACTOR);
+            basePreviewOffsetX = (availableSpaceX - previewSize) / 2;
+            basePreviewOffsetY = topPadding + (allAppsIconSize - previewSize) / 2;
+        } else {
+            previewSize = grid.folderIconSizePx;
 
-        basePreviewOffsetX = (availableSpaceX - previewSize) / 2;
-        basePreviewOffsetY = topPadding + grid.folderIconOffsetYPx;
+            basePreviewOffsetX = (availableSpaceX - previewSize) / 2;
+            basePreviewOffsetY = topPadding + grid.folderIconOffsetYPx;
+        }
 
         // Stroke width is 1dp
         mStrokeWidth = context.getResources().getDisplayMetrics().density;

--- a/src/com/android/launcher3/folder/PreviewItemManager.java
+++ b/src/com/android/launcher3/folder/PreviewItemManager.java
@@ -456,23 +456,34 @@ public class PreviewItemManager {
         p.anim = anim;
     }
 
+    /** Lawnchair: Find the correct folder size depending on which parent owned them 
+     * @return Icon size that's typically use for workspace or size that's for allapps page */
+    private int getChildIconSize() {
+        if (mIcon.isInAppDrawer()) {
+            return ActivityContext.lookupContext(mContext).getDeviceProfile().getAllAppsProfile().getIconSizePx();
+        }
+        return mIconSize;
+    }
+
     @VisibleForTesting
     public void setDrawable(PreviewItemDrawingParams p, ItemInfo item) {
+        // Lawnchair: Find the correct folder size depending on which parent owned them
+        int iconSize = getChildIconSize();
         if (item instanceof WorkspaceItemInfo wii) {
             if (isActivePendingIcon(wii)) {
                 p.drawable = newPendingIcon(mContext, wii);
             } else {
                 p.drawable = wii.newIcon(mContext, FLAG_THEMED);
             }
-            p.drawable.setBounds(0, 0, mIconSize, mIconSize);
+            p.drawable.setBounds(0, 0, iconSize, iconSize);
         } else if (item instanceof AppPairInfo api) {
             AppPairIconDrawingParams appPairParams = new AppPairIconDrawingParams(mContext, DISPLAY_FOLDER);
             p.drawable = AppPairIconGraphic.composeDrawable(api, appPairParams);
-            p.drawable.setBounds(0, 0, mIconSize, mIconSize);
+            p.drawable.setBounds(0, 0, iconSize, iconSize);
         } else if (item instanceof ItemInfoWithIcon withIcon){
             var isThemed = PreferenceManager.getInstance(mContext).getDrawerThemedIcons().get() ? FLAG_THEMED : 0;
             p.drawable = withIcon.newIcon(mContext, isThemed);
-            p.drawable.setBounds(0, 0, mIconSize, mIconSize);
+            p.drawable.setBounds(0, 0, iconSize, iconSize);
         }
 
         p.item = item;


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Find the correct folder size depending on which parent owned them

Correct folder size when it's presented on allapps panel, folder on workspace should use value from workspace and folder on allapps should use value from allapps.

Fixes #5952

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Visual test

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Folder previews now display with proper sizing and positioning when located in the app drawer, adapting preview item dimensions to match the app drawer layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->