### PR TITLE
fix: Custom notification dot colour not being applied

### DIFF
--- a/lawnchair/src/app/lawnchair/theme/color/tokens/ColorTokens.kt
+++ b/lawnchair/src/app/lawnchair/theme/color/tokens/ColorTokens.kt
@@ -133,8 +133,6 @@ object ColorTokens {
 
     @JvmField val SearchboxHighlightBlur = SearchboxHighlight.setAlpha(.54f)
 
-    @JvmField val FolderDotColor = Accent3_100
-
     @JvmField val DotColor = Accent3_200
 
     @JvmField val FolderBackgroundColor = DayNightColorToken(Neutral1_50.setLStar(94.0), Neutral2_900.setLStar(12.0))

--- a/src/com/android/launcher3/folder/PreviewBackground.java
+++ b/src/com/android/launcher3/folder/PreviewBackground.java
@@ -196,7 +196,8 @@ public class PreviewBackground extends DelegatedCellDrawing {
         int folderColor = colorOption.getColorPreferenceEntry().getLightColor().invoke(context);
 
         TypedArray ta = context.getTheme().obtainStyledAttributes(R.styleable.FolderIconPreview);
-        mDotColor = ColorTokens.FolderDotColor.resolveColor(context);
+        ColorOption dotColorOption = PreferenceExtensionsKt.firstBlocking(preferenceManager2.getNotificationDotColor());
+        mDotColor = dotColorOption.getColorPreferenceEntry().getLightColor().invoke(context);
         mStrokeColor = ColorTokens.FolderIconBorderColor.resolveColor(context);
         if (folderColor != 0) {
             mBgColor = folderColor;


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Custom notification dot colour not being applied because we didn't handle them at all. This PR fixes it to handle those colour.

This PR handle folder notification dot colour not being accurate and is not applying any Lawnchair customisation

* Submitted together: https://github.com/LawnchairLauncher/platform_frameworks_libs_systemui/pull/29 (handle app notification dot colour)

Fixes https://github.com/LawnchairLauncher/lawnchair/issues/6831
Fixes https://github.com/LawnchairLauncher/lawnchair/issues/6231

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Visual test

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Folder notification dot now follows user-selected notification color instead of a fixed system color, improving personalization.

* **Chores**
  * Updated SystemUI framework to a newer pinned version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->