### PR TITLE
feat: Nova-style padding controls

### DIFF
--- a/lawnchair/res/values/config.xml
+++ b/lawnchair/res/values/config.xml
@@ -174,6 +174,10 @@
     <item name="config_default_recent_max_result_count" type="dimen" format="integer">2</item>
     <item name="config_default_max_web_suggestion_delay" type="dimen" format="integer">1000</item>
     <item name="config_default_hotseat_bottom_factor" type="dimen" format="float">1.0</item>
+    <item name="config_default_workspace_padding_horizontal" type="dimen" format="float">1.0</item>
+    <item name="config_default_workspace_padding_vertical" type="dimen" format="float">1.0</item>
+    <item name="config_default_widget_padding_factor" type="dimen" format="float">1.0</item>
+    <item name="config_default_drawer_padding_vertical" type="dimen" format="float">0.0</item>
 
 
     <!-- The max scale for the wallpaper when it's zoomed in -->

--- a/lawnchair/res/values/config.xml
+++ b/lawnchair/res/values/config.xml
@@ -177,7 +177,7 @@
     <item name="config_default_workspace_padding_horizontal" type="dimen" format="float">1.0</item>
     <item name="config_default_workspace_padding_vertical" type="dimen" format="float">1.0</item>
     <item name="config_default_widget_padding_factor" type="dimen" format="float">1.0</item>
-    <item name="config_default_drawer_padding_vertical" type="dimen" format="float">0.0</item>
+    <item name="config_default_drawer_padding_vertical" type="dimen" format="float">1.0</item>
 
 
     <!-- The max scale for the wallpaper when it's zoomed in -->

--- a/lawnchair/res/values/config.xml
+++ b/lawnchair/res/values/config.xml
@@ -177,7 +177,7 @@
     <item name="config_default_workspace_padding_horizontal" type="dimen" format="float">1.0</item>
     <item name="config_default_workspace_padding_vertical" type="dimen" format="float">1.0</item>
     <item name="config_default_widget_padding_factor" type="dimen" format="float">1.0</item>
-    <item name="config_default_drawer_padding_vertical" type="dimen" format="float">1.0</item>
+    <item name="config_default_drawer_padding_top" type="dimen" format="float">1.0</item>
 
 
     <!-- The max scale for the wallpaper when it's zoomed in -->

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -278,12 +278,8 @@
     <string name="twoline_label">Use multiple lines</string>
 
     <!-- Icon-related settings -->
-    <string name="transparent_background_icons_label">Transparent icon backgrounds</string>
-    <string name="transparent_background_icons_description">Remove the automatic white background added behind icons with transparent areas</string>
-    <string name="workspace_padding_horizontal_label">Horizontal padding</string>
-    <string name="workspace_padding_vertical_label">Vertical padding</string>
-    <string name="widget_padding_label">Widget padding</string>
-    <string name="app_drawer_padding_vertical_label">Vertical padding</string>
+    <string name="transparent_background_icons_label">Transparent themed icons</string>
+    <string name="transparent_background_icons_description">Use transparent background on themed icons</string>
 
     <string name="auto_adaptive_icons_label">Auto-adaptive icons</string>
     <string name="auto_adaptive_icons_description">For all non-adaptive icons</string>
@@ -690,6 +686,10 @@
     <string name="home_screen_unlock">Unlock home screen</string>
     <string name="home_screen_locked">Home screen is locked</string>
     <string name="home_screen_lock_description">Prevent changes to the home screen layout</string>
+
+    <string name="horizontal_padding_label">Horizontal padding</string>
+    <string name="vertical_padding_label">Vertical padding</string>
+    <string name="widget_padding_label">Widget padding</string>
 
     <string name="set_default_home_page">Set as default page</string>
     <string name="default_home_page_set">Default home page updated</string>

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -278,8 +278,12 @@
     <string name="twoline_label">Use multiple lines</string>
 
     <!-- Icon-related settings -->
-    <string name="transparent_background_icons_label">Transparent themed icons</string>
-    <string name="transparent_background_icons_description">Use transparent background on themed icons</string>
+    <string name="transparent_background_icons_label">Transparent icon backgrounds</string>
+    <string name="transparent_background_icons_description">Remove the automatic white background added behind icons with transparent areas</string>
+    <string name="workspace_padding_horizontal_label">Horizontal padding</string>
+    <string name="workspace_padding_vertical_label">Vertical padding</string>
+    <string name="widget_padding_label">Widget padding</string>
+    <string name="app_drawer_padding_vertical_label">Vertical padding</string>
 
     <string name="auto_adaptive_icons_label">Auto-adaptive icons</string>
     <string name="auto_adaptive_icons_description">For all non-adaptive icons</string>

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -689,6 +689,7 @@
 
     <string name="horizontal_padding_label">Horizontal padding</string>
     <string name="vertical_padding_label">Vertical padding</string>
+    <string name="top_padding_label">Top padding</string>
     <string name="widget_padding_label">Widget padding</string>
 
     <string name="set_default_home_page">Set as default page</string>

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
@@ -551,9 +551,9 @@ class PreferenceManager2 @Inject constructor(
         onSet = { reloadHelper.reloadGrid() },
     )
 
-    val drawerPaddingVerticalFactor = preference(
-        key = floatPreferencesKey(name = "drawer_padding_vertical"),
-        defaultValue = resourceProvider.getFloat(R.dimen.config_default_drawer_padding_vertical),
+    val drawerPaddingTopFactor = preference(
+        key = floatPreferencesKey(name = "drawer_padding_top"),
+        defaultValue = resourceProvider.getFloat(R.dimen.config_default_drawer_padding_top),
         onSet = { reloadHelper.reloadGrid() },
     )
 

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
@@ -533,6 +533,30 @@ class PreferenceManager2 @Inject constructor(
         onSet = { reloadHelper.reloadGrid() },
     )
 
+    val workspacePaddingHorizontalFactor = preference(
+        key = floatPreferencesKey(name = "workspace_padding_horizontal"),
+        defaultValue = resourceProvider.getFloat(R.dimen.config_default_workspace_padding_horizontal),
+        onSet = { reloadHelper.reloadGrid() },
+    )
+
+    val workspacePaddingVerticalFactor = preference(
+        key = floatPreferencesKey(name = "workspace_padding_vertical"),
+        defaultValue = resourceProvider.getFloat(R.dimen.config_default_workspace_padding_vertical),
+        onSet = { reloadHelper.reloadGrid() },
+    )
+
+    val widgetPaddingFactor = preference(
+        key = floatPreferencesKey(name = "widget_padding_factor"),
+        defaultValue = resourceProvider.getFloat(R.dimen.config_default_widget_padding_factor),
+        onSet = { reloadHelper.reloadGrid() },
+    )
+
+    val drawerPaddingVerticalFactor = preference(
+        key = floatPreferencesKey(name = "drawer_padding_vertical"),
+        defaultValue = resourceProvider.getFloat(R.dimen.config_default_drawer_padding_vertical),
+        onSet = { reloadHelper.reloadGrid() },
+    )
+
     val enableFuzzySearch = preference(
         key = booleanPreferencesKey(name = "enable_fuzzy_search"),
         defaultValue = context.resources.getBoolean(R.bool.config_default_enable_fuzzy_search),

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/AppDrawerPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/AppDrawerPreferences.kt
@@ -146,8 +146,8 @@ fun AppDrawerPreferences(
             Item {
                 SliderPreference(
                     adapter = prefs2.drawerPaddingVerticalFactor.getAdapter(),
-                    label = stringResource(id = R.string.app_drawer_padding_vertical_label),
-                    valueRange = 0.0F..1.0F,
+                    label = stringResource(id = R.string.vertical_padding_label),
+                    valueRange = 1.0F..2.0F,
                     step = 0.05F,
                     showAsPercentage = true,
                 )

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/AppDrawerPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/AppDrawerPreferences.kt
@@ -143,6 +143,15 @@ fun AppDrawerPreferences(
                     showAsPercentage = true,
                 )
             }
+            Item {
+                SliderPreference(
+                    adapter = prefs2.drawerPaddingVerticalFactor.getAdapter(),
+                    label = stringResource(id = R.string.app_drawer_padding_vertical_label),
+                    valueRange = 0.0F..1.0F,
+                    step = 0.05F,
+                    showAsPercentage = true,
+                )
+            }
         }
         val showDrawerLabels = prefs2.showIconLabelsInDrawer.getAdapter()
         PreferenceGroup(heading = stringResource(id = R.string.icons)) {

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/AppDrawerPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/AppDrawerPreferences.kt
@@ -145,8 +145,8 @@ fun AppDrawerPreferences(
             }
             Item {
                 SliderPreference(
-                    adapter = prefs2.drawerPaddingVerticalFactor.getAdapter(),
-                    label = stringResource(id = R.string.vertical_padding_label),
+                    adapter = prefs2.drawerPaddingTopFactor.getAdapter(),
+                    label = stringResource(id = R.string.top_padding_label),
                     valueRange = 1.0F..2.0F,
                     step = 0.05F,
                     showAsPercentage = true,

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/GeneralPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/GeneralPreferences.kt
@@ -158,10 +158,7 @@ fun GeneralPreferences() {
                     subtitle = iconStyleSubtitle,
                 )
             }
-            Item(
-                "themed_icon",
-                themedIconsEnabled,
-            ) {
+            Item {
                 SwitchPreference(
                     adapter = prefs.transparentIconBackground.getAdapter(),
                     label = stringResource(id = R.string.transparent_background_icons_label),

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/GeneralPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/GeneralPreferences.kt
@@ -158,7 +158,10 @@ fun GeneralPreferences() {
                     subtitle = iconStyleSubtitle,
                 )
             }
-            Item {
+            Item(
+                "themed_icon",
+                themedIconsEnabled,
+            ) {
                 SwitchPreference(
                     adapter = prefs.transparentIconBackground.getAdapter(),
                     label = stringResource(id = R.string.transparent_background_icons_label),

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/HomeScreenPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/HomeScreenPreferences.kt
@@ -182,28 +182,28 @@ fun HomeScreenPreferences(
                 )
             }
             Item {
+                SliderPreference(
+                    label = stringResource(id = R.string.horizontal_padding_label),
+                    adapter = prefs2.workspacePaddingHorizontalFactor.getAdapter(),
+                    step = 0.05f,
+                    valueRange = 0F..2F,
+                    showAsPercentage = true,
+                )
+            }
+            Item {
+                SliderPreference(
+                    label = stringResource(id = R.string.vertical_padding_label),
+                    adapter = prefs2.workspacePaddingVerticalFactor.getAdapter(),
+                    step = 0.05f,
+                    valueRange = 0F..2F,
+                    showAsPercentage = true,
+                )
+            }
+            Item {
                 SwitchPreference(
                     adapter = lockHomeScreenAdapter,
                     label = stringResource(id = R.string.home_screen_lock),
                     description = stringResource(id = R.string.home_screen_lock_description),
-                )
-            }
-            Item {
-                SliderPreference(
-                    label = stringResource(id = R.string.workspace_padding_horizontal_label),
-                    adapter = prefs2.workspacePaddingHorizontalFactor.getAdapter(),
-                    step = 0.05f,
-                    valueRange = 0F..1F,
-                    showAsPercentage = true,
-                )
-            }
-            Item {
-                SliderPreference(
-                    label = stringResource(id = R.string.workspace_padding_vertical_label),
-                    adapter = prefs2.workspacePaddingVerticalFactor.getAdapter(),
-                    step = 0.05f,
-                    valueRange = 0F..1F,
-                    showAsPercentage = true,
                 )
             }
         }

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/HomeScreenPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/HomeScreenPreferences.kt
@@ -188,6 +188,24 @@ fun HomeScreenPreferences(
                     description = stringResource(id = R.string.home_screen_lock_description),
                 )
             }
+            Item {
+                SliderPreference(
+                    label = stringResource(id = R.string.workspace_padding_horizontal_label),
+                    adapter = prefs2.workspacePaddingHorizontalFactor.getAdapter(),
+                    step = 0.05f,
+                    valueRange = 0F..1F,
+                    showAsPercentage = true,
+                )
+            }
+            Item {
+                SliderPreference(
+                    label = stringResource(id = R.string.workspace_padding_vertical_label),
+                    adapter = prefs2.workspacePaddingVerticalFactor.getAdapter(),
+                    step = 0.05f,
+                    valueRange = 0F..1F,
+                    showAsPercentage = true,
+                )
+            }
         }
         PreferenceGroup(heading = stringResource(id = R.string.popup_menu)) {
             Item { LauncherPopupPreferenceItem() }
@@ -288,6 +306,15 @@ fun HomeScreenPreferences(
                     adapter = prefs2.forceWidgetResize.getAdapter(),
                     label = stringResource(id = R.string.force_widget_resize_label),
                     description = stringResource(id = R.string.force_widget_resize_description),
+                )
+            }
+            Item {
+                SliderPreference(
+                    label = stringResource(id = R.string.widget_padding_label),
+                    adapter = prefs2.widgetPaddingFactor.getAdapter(),
+                    step = 0.05f,
+                    valueRange = 0F..2F,
+                    showAsPercentage = true,
                 )
             }
         }

--- a/src/com/android/launcher3/AppWidgetResizeFrame.java
+++ b/src/com/android/launcher3/AppWidgetResizeFrame.java
@@ -306,7 +306,9 @@ public class AppWidgetResizeFrame extends AbstractFloatingView implements View.O
         // on font / display change, the dp/px size of a cell changes, which means, existing spans
         // may be invalid. User should be able to resize to the correct widget size.
         boolean isWidgetVSpanInvalid = widgetInfoOnView.spanY < mMinVSpan;
-        mVerticalResizeActive = (info.resizeMode & AppWidgetProviderInfo.RESIZE_VERTICAL) != 0 && (
+        // Lawnchair: use the (possibly overridden) resizeMode so force/unlimited resize can
+        // show handles even for widgets whose provider declares limited/no resizing.
+        mVerticalResizeActive = (resizeMode & AppWidgetProviderInfo.RESIZE_VERTICAL) != 0 && (
                 (mMinVSpan < idp.numRows && mMaxVSpan > 1 && mMinVSpan < mMaxVSpan)
                         || isWidgetVSpanInvalid);
         if (!mVerticalResizeActive) {
@@ -318,7 +320,7 @@ public class AppWidgetResizeFrame extends AbstractFloatingView implements View.O
         // may be invalid. User should be able to resize to the correct widget size.
         boolean isWidgetHSpanInvalid = widgetInfoOnView.spanX < mMinHSpan;
         mHorizontalResizeActive =
-                (info.resizeMode & AppWidgetProviderInfo.RESIZE_HORIZONTAL) != 0 && (
+                (resizeMode & AppWidgetProviderInfo.RESIZE_HORIZONTAL) != 0 && (
                         (mMinHSpan < idp.numColumns && mMaxHSpan > 1 && mMinHSpan < mMaxHSpan)
                                 || isWidgetHSpanInvalid);
         if (!mHorizontalResizeActive) {

--- a/src/com/android/launcher3/AppWidgetResizeFrame.java
+++ b/src/com/android/launcher3/AppWidgetResizeFrame.java
@@ -319,6 +319,8 @@ public class AppWidgetResizeFrame extends AbstractFloatingView implements View.O
         // on font / display change, the dp/px size of a cell changes, which means, existing spans
         // may be invalid. User should be able to resize to the correct widget size.
         boolean isWidgetHSpanInvalid = widgetInfoOnView.spanX < mMinHSpan;
+        // Lawnchair: use the (possibly overridden) resizeMode so force/unlimited resize can
+        // show handles even for widgets whose provider declares limited/no resizing.
         mHorizontalResizeActive =
                 (resizeMode & AppWidgetProviderInfo.RESIZE_HORIZONTAL) != 0 && (
                         (mMinHSpan < idp.numColumns && mMaxHSpan > 1 && mMinHSpan < mMaxHSpan)

--- a/src/com/android/launcher3/DeviceProfile.java
+++ b/src/com/android/launcher3/DeviceProfile.java
@@ -357,14 +357,16 @@ public class DeviceProfile {
         preferenceManager2 = PreferenceManager2.INSTANCE.get(context);
         allAppsCellHeightMultiplier = PreferenceExtensionsKt
                 .firstBlocking(preferenceManager2.getDrawerCellHeightFactor());
-        workspacePaddingHorizontalFactor = PreferenceExtensionsKt
-                .firstBlocking(preferenceManager2.getWorkspacePaddingHorizontalFactor());
-        workspacePaddingVerticalFactor = PreferenceExtensionsKt
-                .firstBlocking(preferenceManager2.getWorkspacePaddingVerticalFactor());
-        widgetPaddingFactor = PreferenceExtensionsKt
-                .firstBlocking(preferenceManager2.getWidgetPaddingFactor());
-        drawerPaddingVerticalFactor = PreferenceExtensionsKt
-                .firstBlocking(preferenceManager2.getDrawerPaddingVerticalFactor());
+        // Lawnchair: clamp the user padding factors to their slider ranges so a restored or
+        // manually edited preference can't feed out-of-range values into the layout math.
+        workspacePaddingHorizontalFactor = Utilities.boundToRange(PreferenceExtensionsKt
+                .firstBlocking(preferenceManager2.getWorkspacePaddingHorizontalFactor()), 0f, 1f);
+        workspacePaddingVerticalFactor = Utilities.boundToRange(PreferenceExtensionsKt
+                .firstBlocking(preferenceManager2.getWorkspacePaddingVerticalFactor()), 0f, 1f);
+        widgetPaddingFactor = Utilities.boundToRange(PreferenceExtensionsKt
+                .firstBlocking(preferenceManager2.getWidgetPaddingFactor()), 0f, 2f);
+        drawerPaddingVerticalFactor = Utilities.boundToRange(PreferenceExtensionsKt
+                .firstBlocking(preferenceManager2.getDrawerPaddingVerticalFactor()), 0f, 1f);
         this.inv = inv;
 
         mDeviceProperties = DeviceProperties.Factory.createDeviceProperties(

--- a/src/com/android/launcher3/DeviceProfile.java
+++ b/src/com/android/launcher3/DeviceProfile.java
@@ -338,6 +338,10 @@ public class DeviceProfile {
 
     private final TextFactors mTextFactors;
     private float allAppsCellHeightMultiplier;
+    private float workspacePaddingHorizontalFactor;
+    private float workspacePaddingVerticalFactor;
+    private float widgetPaddingFactor;
+    private float drawerPaddingVerticalFactor;
     private PreferenceManager2 preferenceManager2 = null;
 
     /** TODO: Once we fully migrate to staged split, remove "isMultiWindowMode" */
@@ -353,6 +357,14 @@ public class DeviceProfile {
         preferenceManager2 = PreferenceManager2.INSTANCE.get(context);
         allAppsCellHeightMultiplier = PreferenceExtensionsKt
                 .firstBlocking(preferenceManager2.getDrawerCellHeightFactor());
+        workspacePaddingHorizontalFactor = PreferenceExtensionsKt
+                .firstBlocking(preferenceManager2.getWorkspacePaddingHorizontalFactor());
+        workspacePaddingVerticalFactor = PreferenceExtensionsKt
+                .firstBlocking(preferenceManager2.getWorkspacePaddingVerticalFactor());
+        widgetPaddingFactor = PreferenceExtensionsKt
+                .firstBlocking(preferenceManager2.getWidgetPaddingFactor());
+        drawerPaddingVerticalFactor = PreferenceExtensionsKt
+                .firstBlocking(preferenceManager2.getDrawerPaddingVerticalFactor());
         this.inv = inv;
 
         mDeviceProperties = DeviceProperties.Factory.createDeviceProperties(
@@ -636,6 +648,11 @@ public class DeviceProfile {
         }
 
         desiredWorkspaceHorizontalMarginPx = getHorizontalMarginPx(inv, res);
+        // Lawnchair: scale the horizontal workspace margin at the source so the cell layout
+        // width calculation uses the scaled value too. Otherwise cells keep their original
+        // width and get centered, leaving a visible side gap even at factor 0.
+        desiredWorkspaceHorizontalMarginPx =
+                Math.round(desiredWorkspaceHorizontalMarginPx * workspacePaddingHorizontalFactor);
         desiredWorkspaceHorizontalMarginOriginalPx = desiredWorkspaceHorizontalMarginPx;
 
         splitPlaceholderInset = res.getDimensionPixelSize(R.dimen.split_placeholder_inset);
@@ -684,6 +701,8 @@ public class DeviceProfile {
             allAppsShiftRange =
                     res.getDimensionPixelSize(R.dimen.all_apps_starting_vertical_translate);
         }
+        // Lawnchair: extra user-configurable app drawer vertical padding (additive, default 0).
+        allAppsPadding.top += Math.round(iconSizePx * drawerPaddingVerticalFactor);
         allAppsOpenDuration = res.getInteger(R.integer.config_allAppsOpenDuration);
         allAppsCloseDuration = res.getInteger(R.integer.config_allAppsCloseDuration);
 
@@ -1350,6 +1369,11 @@ public class DeviceProfile {
         } else {
             widgetPadding.setEmpty();
         }
+        // Lawnchair: scale widget padding by user factor (0 = remove, 1 = default).
+        widgetPadding.left = Math.round(widgetPadding.left * widgetPaddingFactor);
+        widgetPadding.right = Math.round(widgetPadding.right * widgetPaddingFactor);
+        widgetPadding.top = Math.round(widgetPadding.top * widgetPaddingFactor);
+        widgetPadding.bottom = Math.round(widgetPadding.bottom * widgetPaddingFactor);
     }
 
     /**
@@ -1718,6 +1742,16 @@ public class DeviceProfile {
                 paddingLeft = isSeascape() ? desiredWorkspaceHorizontalMarginPx : 0;
                 paddingRight = isSeascape() ? 0 : desiredWorkspaceHorizontalMarginPx;
             }
+
+            // Lawnchair: scale vertical workspace padding by user factor.
+            // (Horizontal is applied at the source margin so the cells fill the freed space.)
+            // The dock (hotseatBarSizePx) reservation in the bottom padding must be preserved,
+            // otherwise reducing the factor pulls the last row into the dock and clips it.
+            paddingTop = Math.round(paddingTop * workspacePaddingVerticalFactor);
+            int bottomHotseatReserve = Math.min(hotseatBarSizePx, paddingBottom);
+            paddingBottom = bottomHotseatReserve
+                    + Math.round((paddingBottom - bottomHotseatReserve) * workspacePaddingVerticalFactor);
+
             padding.set(paddingLeft, paddingTop, paddingRight, paddingBottom);
         }
         insetPadding(workspacePadding, cellLayoutPaddingPx);

--- a/src/com/android/launcher3/DeviceProfile.java
+++ b/src/com/android/launcher3/DeviceProfile.java
@@ -341,7 +341,7 @@ public class DeviceProfile {
     private float workspacePaddingHorizontalFactor;
     private float workspacePaddingVerticalFactor;
     private float widgetPaddingFactor;
-    private float drawerPaddingVerticalFactor;
+    private float drawerPaddingTopFactor;
     private PreferenceManager2 preferenceManager2 = null;
 
     /** TODO: Once we fully migrate to staged split, remove "isMultiWindowMode" */
@@ -365,8 +365,8 @@ public class DeviceProfile {
                 .firstBlocking(preferenceManager2.getWorkspacePaddingVerticalFactor()), 0f, 2f);
         widgetPaddingFactor = Utilities.boundToRange(PreferenceExtensionsKt
                 .firstBlocking(preferenceManager2.getWidgetPaddingFactor()), 0f, 2f);
-        drawerPaddingVerticalFactor = Utilities.boundToRange(PreferenceExtensionsKt
-                .firstBlocking(preferenceManager2.getDrawerPaddingVerticalFactor()), 1f, 2f);
+        drawerPaddingTopFactor = Utilities.boundToRange(PreferenceExtensionsKt
+                .firstBlocking(preferenceManager2.getDrawerPaddingTopFactor()), 1f, 2f);
         this.inv = inv;
 
         mDeviceProperties = DeviceProperties.Factory.createDeviceProperties(
@@ -703,9 +703,9 @@ public class DeviceProfile {
             allAppsShiftRange =
                     res.getDimensionPixelSize(R.dimen.all_apps_starting_vertical_translate);
         }
-        // Lawnchair: extra user-configurable app drawer vertical padding. The factor is additive
+        // Lawnchair: extra user-configurable app drawer top padding. The factor is additive
         // and slider-ranged 100%-200% (default 100%), so subtract 1f to keep 100% as no change.
-        allAppsPadding.top += Math.round(iconSizePx * (drawerPaddingVerticalFactor - 1f));
+        allAppsPadding.top += Math.round(iconSizePx * (drawerPaddingTopFactor - 1f));
         allAppsOpenDuration = res.getInteger(R.integer.config_allAppsOpenDuration);
         allAppsCloseDuration = res.getInteger(R.integer.config_allAppsCloseDuration);
 

--- a/src/com/android/launcher3/DeviceProfile.java
+++ b/src/com/android/launcher3/DeviceProfile.java
@@ -360,13 +360,13 @@ public class DeviceProfile {
         // Lawnchair: clamp the user padding factors to their slider ranges so a restored or
         // manually edited preference can't feed out-of-range values into the layout math.
         workspacePaddingHorizontalFactor = Utilities.boundToRange(PreferenceExtensionsKt
-                .firstBlocking(preferenceManager2.getWorkspacePaddingHorizontalFactor()), 0f, 1f);
+                .firstBlocking(preferenceManager2.getWorkspacePaddingHorizontalFactor()), 0f, 2f);
         workspacePaddingVerticalFactor = Utilities.boundToRange(PreferenceExtensionsKt
-                .firstBlocking(preferenceManager2.getWorkspacePaddingVerticalFactor()), 0f, 1f);
+                .firstBlocking(preferenceManager2.getWorkspacePaddingVerticalFactor()), 0f, 2f);
         widgetPaddingFactor = Utilities.boundToRange(PreferenceExtensionsKt
                 .firstBlocking(preferenceManager2.getWidgetPaddingFactor()), 0f, 2f);
         drawerPaddingVerticalFactor = Utilities.boundToRange(PreferenceExtensionsKt
-                .firstBlocking(preferenceManager2.getDrawerPaddingVerticalFactor()), 0f, 1f);
+                .firstBlocking(preferenceManager2.getDrawerPaddingVerticalFactor()), 1f, 2f);
         this.inv = inv;
 
         mDeviceProperties = DeviceProperties.Factory.createDeviceProperties(
@@ -703,8 +703,9 @@ public class DeviceProfile {
             allAppsShiftRange =
                     res.getDimensionPixelSize(R.dimen.all_apps_starting_vertical_translate);
         }
-        // Lawnchair: extra user-configurable app drawer vertical padding (additive, default 0).
-        allAppsPadding.top += Math.round(iconSizePx * drawerPaddingVerticalFactor);
+        // Lawnchair: extra user-configurable app drawer vertical padding. The factor is additive
+        // and slider-ranged 100%-200% (default 100%), so subtract 1f to keep 100% as no change.
+        allAppsPadding.top += Math.round(iconSizePx * (drawerPaddingVerticalFactor - 1f));
         allAppsOpenDuration = res.getInteger(R.integer.config_allAppsOpenDuration);
         allAppsCloseDuration = res.getInteger(R.integer.config_allAppsCloseDuration);
 


### PR DESCRIPTION
## Overview
Adds Nova-style spacing controls to the home screen, widgets, and app drawer.

> [!NOTE]
> Transparent icon backgrounds (originally bundled here) were split out into #6890 per review feedback, so this PR is scoped to the padding controls.

### 1. 🔲 Workspace padding (`DeviceProfile.java`)
Home screen → Layout, directly under **Home screen grid**: horizontal & vertical sliders scaling the original padding, **0–200%** (100% = original).
- The **horizontal** factor is applied to the source margin (`desiredWorkspaceHorizontalMarginPx`) so the cells fill the freed space instead of staying centered with a side gap.
- The **vertical** factor preserves the dock reservation (`hotseatBarSizePx`) in the bottom padding, so reducing it never pulls the last row into the hotseat.

### 2. 🧩 Widget padding (`DeviceProfile.java`)
Home screen → Widgets: a slider scaling the widget padding — 0% removes the forced padding, 100% = default, up to 200%.

### 3. 📥 App drawer vertical padding (`AppDrawerPreferences.kt`)
App drawer → Grid: an additive vertical-padding slider, **100–200%** (100% = no change), complementing the existing horizontal indent. `DeviceProfile` subtracts `1f` from the factor so 100% is neutral, consistent with the multiplicative sliders.

### 4. 📐 Widget resize handles (`AppWidgetResizeFrame.java`)
Respect the overridden resize mode so *Force widget resize* / *Remove size constraints* actually show resize handles even for widgets whose provider declares limited or no resizing.

## New preferences
`workspacePaddingHorizontalFactor`, `workspacePaddingVerticalFactor`, `widgetPaddingFactor`, `drawerPaddingVerticalFactor`. All are clamped to their slider ranges in `DeviceProfile`; defaults keep the current look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced customizable padding controls for home screen workspace and app drawer
  * Added new slider preferences to independently adjust horizontal/vertical workspace spacing, drawer padding, and widget padding as percentages (0–200% range)

* **Bug Fixes**
  * Fixed widget resize handle visibility to better reflect actual resize capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->