### PR TITLE
fix: preserve item positions and widget sizes on grid resize

### DIFF
--- a/src/com/android/launcher3/model/GridSizeMigrationLogic.kt
+++ b/src/com/android/launcher3/model/GridSizeMigrationLogic.kt
@@ -318,9 +318,15 @@ class GridSizeMigrationLogic {
 
         workspaceToBeAdded.sort()
 
-        // First we create a collection of the screens
+        // First we create a collection of the screens. We extend the range to cover the source
+        // items' original screens so each item can be re-placed on its own screen (preserving the
+        // user's layout) instead of being packed onto the first available screens.
+        val lastScreen = maxOf(
+            destReader.mLastScreenId,
+            workspaceToBeAdded.maxOfOrNull { it.screenId } ?: 0,
+        )
         val screens: MutableList<Int> = ArrayList()
-        for (screenId in 0..destReader.mLastScreenId) {
+        for (screenId in 0..lastScreen) {
             screens.add(screenId)
         }
 
@@ -338,6 +344,7 @@ class GridSizeMigrationLogic {
                     trgY,
                     itemsToPlace.mRemainingItemsToPlace,
                     destReader.mWorkspaceEntriesByScreenId[screenId],
+                    preserveOriginal = true,
                 )
             placeItems(itemsToPlace, helper, srcReader, destReader, idsInUse)
             while (itemsToPlace.mPlacementSolution.isNotEmpty()) {
@@ -499,6 +506,7 @@ class GridSizeMigrationLogic {
         trgY: Int,
         sortedItemsToPlace: MutableList<DbEntry>,
         existedEntries: MutableList<DbEntry>?,
+        preserveOriginal: Boolean = false,
     ): WorkspaceItemsToPlace {
         val itemsToPlace = WorkspaceItemsToPlace(sortedItemsToPlace, mutableListOf())
         val occupied = GridOccupancy(trgX, trgY)
@@ -523,6 +531,23 @@ class GridSizeMigrationLogic {
             if (entry.minSpanX > trgX || entry.minSpanY > trgY) {
                 iterator.remove()
                 continue
+            }
+            // Lawnchair: keep the user's existing layout when possible. Items are deferred to
+            // their original screen and kept at their original cell and size if it still fits and
+            // the spot is free; only items that no longer fit fall back to automatic placement.
+            if (preserveOriginal) {
+                if (entry.screenId > screenId) {
+                    // This item belongs to a later screen; leave it for that screen's pass.
+                    continue
+                }
+                if (entry.screenId == screenId &&
+                    canKeepOriginalPlacement(entry, next.y, trg, occupied)
+                ) {
+                    occupied.markCells(entry, true)
+                    itemsToPlace.mPlacementSolution.add(entry)
+                    iterator.remove()
+                    continue
+                }
             }
             findPlacementForEntry(entry, next.x, next.y, trg, occupied)?.let {
                 entry.screenId = screenId
@@ -563,6 +588,24 @@ class GridSizeMigrationLogic {
             newStartPosX = 0
         }
         return null
+    }
+
+    /**
+     * Lawnchair: returns true if [entry] can stay at its original cell with its original size in
+     * the target grid — i.e. it fits within the grid bounds, sits below the reserved top rows
+     * (e.g. the smartspace on the first screen), and its region is currently free.
+     */
+    private fun canKeepOriginalPlacement(
+        entry: DbEntry,
+        reservedTopRows: Int,
+        trg: Point,
+        occupied: GridOccupancy,
+    ): Boolean {
+        if (entry.cellX < 0 || entry.cellY < reservedTopRows) return false
+        if (entry.spanX < 1 || entry.spanY < 1) return false
+        if (entry.cellX + entry.spanX > trg.x) return false
+        if (entry.cellY + entry.spanY > trg.y) return false
+        return occupied.isRegionVacant(entry.cellX, entry.cellY, entry.spanX, entry.spanY)
     }
 
     private data class WorkspaceItemsToPlace(


### PR DESCRIPTION
## Problem
Changing the workspace/hotseat grid size re-flowed every home screen item from the top-left and shrank widgets to their min span, scrambling the user'\''s layout.

## Fix
In `GridSizeMigrationLogic.solveGridPlacement`:
- Items are deferred to their **original screen** instead of being packed onto the earliest screens.
- Each item keeps its **original cell and size** when it still fits in the new grid and the spot is free (new `canKeepOriginalPlacement` helper).
- Only items that no longer fit fall back to the existing automatic placement.
- The screen range is extended to cover the source items'\'' original screens.

## Result
- Growing the grid (or minor changes) keeps all apps/widgets in place and at their size.
- Shrinking the grid only re-places items that no longer fit.
- Tested manually: positions and widget sizes preserved across grid changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved home screen grid migration to better preserve your existing layout and item positions when changing grid sizes. Items will now remain in their original locations whenever possible instead of being automatically repositioned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->