### PR TITLE
feat: subgrid (half-cell) positioning on the workspace

### DIFF
--- a/lawnchair/res/values/config.xml
+++ b/lawnchair/res/values/config.xml
@@ -117,6 +117,7 @@
     <bool name="config_default_dock_search_bar_force_website">false</bool>
     <bool name="config_default_rounded_widgets">true</bool>
     <bool name="config_default_allow_widget_overlap">false</bool>
+    <bool name="config_default_enable_subgrid_positioning">false</bool>
     <bool name="config_default_force_widget_resize">false</bool>
     <bool name="config_default_widget_unlimited_size">false</bool>
     <bool name="config_default_show_status_bar">true</bool>

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -717,6 +717,9 @@
     <string name="force_rounded_widgets">Rounded corners</string>
     <string name="allow_widget_overlap">Allow overlap</string>
 
+    <string name="enable_subgrid_positioning_label">Subgrid positioning</string>
+    <string name="enable_subgrid_positioning_description">Place and resize items at half-cell positions on the home screen. Items are placed freely and may overlap</string>
+
     <string name="force_widget_resize_label">Enforce widget resizing</string>
     <string name="force_widget_resize_description">Allow resizing of widgets that are constrained to a specific size</string>
 

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
@@ -319,6 +319,12 @@ class PreferenceManager2 @Inject constructor(
         onSet = { reloadHelper.reloadGrid() },
     )
 
+    val enableSubgridPositioning = preference(
+        key = booleanPreferencesKey(name = "enable_subgrid_positioning"),
+        defaultValue = context.resources.getBoolean(R.bool.config_default_enable_subgrid_positioning),
+        onSet = { reloadHelper.reloadGrid() },
+    )
+
     val forceWidgetResize = preference(
         key = booleanPreferencesKey(name = "force_widget_resize"),
         defaultValue = context.resources.getBoolean(R.bool.config_default_force_widget_resize),

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/HomeScreenPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/HomeScreenPreferences.kt
@@ -183,6 +183,13 @@ fun HomeScreenPreferences(
             }
             Item {
                 SwitchPreference(
+                    adapter = prefs2.enableSubgridPositioning.getAdapter(),
+                    label = stringResource(id = R.string.enable_subgrid_positioning_label),
+                    description = stringResource(id = R.string.enable_subgrid_positioning_description),
+                )
+            }
+            Item {
+                SwitchPreference(
                     adapter = lockHomeScreenAdapter,
                     label = stringResource(id = R.string.home_screen_lock),
                     description = stringResource(id = R.string.home_screen_lock_description),

--- a/src/com/android/launcher3/AppWidgetResizeFrame.java
+++ b/src/com/android/launcher3/AppWidgetResizeFrame.java
@@ -678,8 +678,14 @@ public class AppWidgetResizeFrame extends AbstractFloatingView implements View.O
 
         if (!onDismiss) {
             // Report the widget's host size ranges using the same base spans the layout uses, so the
-            // framework's size info matches the rendered cell span.
+            // framework's size info matches the rendered cell span. (The widget size-options API is
+            // integer-cell based, so a half-cell span is reported as its whole-cell part.)
             WidgetSizes.updateWidgetSizeRanges(mWidgetView, mLauncher, newSpanX, newSpanY);
+            // Lawnchair: Subgrid positioning — mirror the integer path's resize announcement for a11y.
+            if (mStateAnnouncer != null) {
+                mStateAnnouncer.announce(
+                        mLauncher.getString(R.string.widget_resized, newSpanX, newSpanY));
+            }
         } else {
             // Free placement: persist directly (the reorder/commit path is skipped for subgrid).
             mCellLayout.persistViewGeometry(mWidgetView);

--- a/src/com/android/launcher3/AppWidgetResizeFrame.java
+++ b/src/com/android/launcher3/AppWidgetResizeFrame.java
@@ -127,6 +127,9 @@ public class AppWidgetResizeFrame extends AbstractFloatingView implements View.O
 
     private int mRunningHInc;
     private int mRunningVInc;
+    // Lawnchair: Subgrid positioning — running half-cell increments applied during a resize gesture.
+    private int mRunningHalfHInc;
+    private int mRunningHalfVInc;
     private int mMinHSpan;
     private int mMinVSpan;
     private int mMaxHSpan;
@@ -371,12 +374,23 @@ public class AppWidgetResizeFrame extends AbstractFloatingView implements View.O
         lp.setTmpCellY(presenterPos.cellY);
         lp.cellHSpan = widgetInfo.spanX;
         lp.cellVSpan = widgetInfo.spanY;
+        // Lawnchair: Subgrid positioning — start the resize from the widget's current half-cell state
+        // (kept in sync with the model so the resize frame never uses a stale half offset/size).
+        boolean subgrid = mCellLayout.isSubgridEnabled();
+        lp.setSubX(subgrid ? widgetInfo.subX : 0);
+        lp.setSubY(subgrid ? widgetInfo.subY : 0);
+        lp.setSubSpanX(subgrid ? widgetInfo.subSpanX : 0);
+        lp.setSubSpanY(subgrid ? widgetInfo.subSpanY : 0);
         lp.isLockedToGrid = true;
 
         // When we create the resize frame, we first mark all cells as unoccupied. The appropriate
         // cells (same if not resized, or different) will be marked as occupied when the resize
         // frame is dismissed.
-        mCellLayout.markCellsAsUnoccupiedForView(mWidgetView);
+        // Lawnchair: Subgrid free placement bypasses occupancy, and overlapping half-cell widgets can
+        // share a base cell — unmarking here would clear a neighbour's cell, so skip it.
+        if (!mCellLayout.isSubgridEnabled()) {
+            mCellLayout.markCellsAsUnoccupiedForView(mWidgetView);
+        }
 
         mLauncher.getStatsLogManager()
                 .logger()
@@ -499,6 +513,11 @@ public class AppWidgetResizeFrame extends AbstractFloatingView implements View.O
         float xThreshold = mCellLayout.getCellWidth() + dp.cellLayoutBorderSpacePx.x;
         float yThreshold = mCellLayout.getCellHeight() + dp.cellLayoutBorderSpacePx.y;
 
+        if (mCellLayout.isSubgridEnabled()) {
+            resizeWidgetSubgrid((CellLayoutLayoutParams) wlp, xThreshold, yThreshold, onDismiss);
+            return;
+        }
+
         int hSpanInc = getSpanIncrement((mDeltaX + mDeltaXAddOn) / xThreshold - mRunningHInc);
         int vSpanInc = getSpanIncrement((mDeltaY + mDeltaYAddOn) / yThreshold - mRunningVInc);
 
@@ -570,6 +589,104 @@ public class AppWidgetResizeFrame extends AbstractFloatingView implements View.O
         mWidgetView.requestLayout();
     }
 
+    /**
+     * Lawnchair: Subgrid positioning — resize a widget at half-cell resolution. The same edge-aware
+     * {@link IntRange#applyDeltaAndBound} bounding is reused in HALF-cell units (cell * 2 + half-step),
+     * so left/right/top/bottom growth and min/max clamping behave exactly like the integer path at
+     * double the resolution. Because subgrid placement is free (overlap allowed), the reorder-based
+     * {@link CellLayout#createAreaForResize} step is skipped.
+     */
+    private void resizeWidgetSubgrid(CellLayoutLayoutParams lp, float xThreshold, float yThreshold,
+            boolean onDismiss) {
+        int hHalfInc = getSpanIncrement(
+                (mDeltaX + mDeltaXAddOn) / (xThreshold / 2f) - mRunningHalfHInc);
+        int vHalfInc = getSpanIncrement(
+                (mDeltaY + mDeltaYAddOn) / (yThreshold / 2f) - mRunningHalfVInc);
+
+        if (!onDismiss && hHalfInc == 0 && vHalfInc == 0) return;
+        // No-op dismiss: the frame was opened and closed without any resize — don't write the DB or
+        // re-mark occupancy. (mRunningHalf* != 0 means a resize did happen and must be persisted.)
+        if (onDismiss && hHalfInc == 0 && vHalfInc == 0 && mRunningHalfHInc == 0
+                && mRunningHalfVInc == 0) {
+            return;
+        }
+
+        mDirectionVector[0] = 0;
+        mDirectionVector[1] = 0;
+
+        // Drive live layout from the temporary coordinates (the reorder path normally enables this
+        // via setUseTempCoords; we skip that path for subgrid, so enable it for this view directly).
+        if (!lp.useTmpCoords) {
+            lp.setTmpCellX(lp.getCellX());
+            lp.setTmpCellY(lp.getCellY());
+            lp.useTmpCoords = true;
+        }
+
+        int cellXHalf = lp.getTmpCellX() * 2 + lp.getSubX();
+        int cellYHalf = lp.getTmpCellY() * 2 + lp.getSubY();
+        int spanXHalf = lp.cellHSpan * 2 + lp.getSubSpanX();
+        int spanYHalf = lp.cellVSpan * 2 + lp.getSubSpanY();
+
+        // Widget min/max spans (full cells) expressed in half-cells.
+        mTempRange1.set(cellXHalf, spanXHalf + cellXHalf);
+        int hHalfDelta = mTempRange1.applyDeltaAndBound(mLeftBorderActive, mRightBorderActive,
+                hHalfInc, Math.max(1, mMinHSpan * 2), mMaxHSpan * 2,
+                mCellLayout.getCountX() * 2, mTempRange2);
+        cellXHalf = mTempRange2.start;
+        spanXHalf = mTempRange2.size();
+        if (hHalfDelta != 0) {
+            mDirectionVector[0] = mLeftBorderActive ? -1 : 1;
+        }
+
+        mTempRange1.set(cellYHalf, spanYHalf + cellYHalf);
+        int vHalfDelta = mTempRange1.applyDeltaAndBound(mTopBorderActive, mBottomBorderActive,
+                vHalfInc, Math.max(1, mMinVSpan * 2), mMaxVSpan * 2,
+                mCellLayout.getCountY() * 2, mTempRange2);
+        cellYHalf = mTempRange2.start;
+        spanYHalf = mTempRange2.size();
+        if (vHalfDelta != 0) {
+            mDirectionVector[1] = mTopBorderActive ? -1 : 1;
+        }
+
+        if (!onDismiss && vHalfDelta == 0 && hHalfDelta == 0) return;
+
+        if (onDismiss) {
+            mDirectionVector[0] = mLastDirectionVector[0];
+            mDirectionVector[1] = mLastDirectionVector[1];
+        } else {
+            mLastDirectionVector[0] = mDirectionVector[0];
+            mLastDirectionVector[1] = mDirectionVector[1];
+        }
+
+        // Split the half-cell range back into a base cell/span plus a half-step (0 or 1).
+        int newCellX = Math.floorDiv(cellXHalf, 2);
+        int newCellY = Math.floorDiv(cellYHalf, 2);
+        int newSpanX = Math.floorDiv(spanXHalf, 2);
+        int newSpanY = Math.floorDiv(spanYHalf, 2);
+
+        lp.setTmpCellX(newCellX);
+        lp.setTmpCellY(newCellY);
+        lp.setSubX(cellXHalf - newCellX * 2);
+        lp.setSubY(cellYHalf - newCellY * 2);
+        lp.cellHSpan = newSpanX;
+        lp.cellVSpan = newSpanY;
+        lp.setSubSpanX(spanXHalf - newSpanX * 2);
+        lp.setSubSpanY(spanYHalf - newSpanY * 2);
+
+        mRunningHalfHInc += hHalfDelta;
+        mRunningHalfVInc += vHalfDelta;
+
+        if (!onDismiss) {
+            // Report the widget's host size ranges using the same base spans the layout uses, so the
+            // framework's size info matches the rendered cell span.
+            WidgetSizes.updateWidgetSizeRanges(mWidgetView, mLauncher, newSpanX, newSpanY);
+        } else {
+            // Free placement: persist directly (the reorder/commit path is skipped for subgrid).
+            mCellLayout.persistViewGeometry(mWidgetView);
+        }
+        mWidgetView.requestLayout();
+    }
+
     @Override
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
@@ -588,8 +705,9 @@ public class AppWidgetResizeFrame extends AbstractFloatingView implements View.O
         int xThreshold = mCellLayout.getCellWidth() + dp.cellLayoutBorderSpacePx.x;
         int yThreshold = mCellLayout.getCellHeight() + dp.cellLayoutBorderSpacePx.y;
 
-        mDeltaXAddOn = mRunningHInc * xThreshold;
-        mDeltaYAddOn = mRunningVInc * yThreshold;
+        // Lawnchair: Subgrid positioning tracks increments in half-cells; only one set is ever non-zero.
+        mDeltaXAddOn = mRunningHInc * xThreshold + Math.round(mRunningHalfHInc * (xThreshold / 2f));
+        mDeltaYAddOn = mRunningVInc * yThreshold + Math.round(mRunningHalfVInc * (yThreshold / 2f));
         mDeltaX = 0;
         mDeltaY = 0;
 

--- a/src/com/android/launcher3/CellLayout.java
+++ b/src/com/android/launcher3/CellLayout.java
@@ -31,6 +31,7 @@ import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.graphics.Canvas;
 import android.graphics.Color;
+import android.graphics.DashPathEffect;
 import android.graphics.Paint;
 import android.graphics.Point;
 import android.graphics.Rect;
@@ -164,6 +165,11 @@ public class CellLayout extends ViewGroup {
     private boolean mVisualizeDropLocation = true;
     private RectF mVisualizeGridRect = new RectF();
     private Paint mVisualizeGridPaint = new Paint();
+    // Lawnchair: Subgrid positioning — paint for the faint MAIN-cell grid shown during a drag, plus a
+    // dashed stroke for the drop preview when the target is a half-cell position/size.
+    private final Paint mSubgridGuidePaint = new Paint();
+    private final DashPathEffect mSubgridDashEffect =
+            new DashPathEffect(new float[]{18f, 12f}, 0f);
     private int mGridVisualizationRoundingRadius;
     private float mGridAlpha = 0f;
     private int mGridColor = 0;
@@ -173,6 +179,9 @@ public class CellLayout extends ViewGroup {
     // When a drag operation is in progress, holds the nearest cell to the touch point
     private final int[] mDragCell = new int[2];
     private final int[] mDragCellSpan = new int[2];
+    // Lawnchair: Subgrid positioning — half-cell offset/size of the current drop preview.
+    private final int[] mDragCellSub = new int[2];
+    private final int[] mDragCellSubSpan = new int[2];
 
     private boolean mDragging = false;
     public boolean mHasOnLayoutBeenCalled = false;
@@ -638,13 +647,19 @@ public class CellLayout extends ViewGroup {
             }
         }
 
+        // Lawnchair: Subgrid positioning — reveal the MAIN cell grid while a drag/edit is active. Driven
+        // by the steady spring-loaded progress (not the per-outline animation) so it doesn't flicker
+        // as the item moves between cells.
+        drawSubgridGuides(canvas);
+
         if (mVisualizeDropLocation) {
             for (int i = 0; i < mDragOutlines.length; i++) {
                 final float alpha = mDragOutlineAlphas[i];
                 if (alpha <= 0) continue;
                 CellLayoutLayoutParams params = mDragOutlines[i];
                 cellToRect(params.getCellX(), params.getCellY(), params.cellHSpan, params.cellVSpan,
-                        mTempOnDrawCellToRect);
+                        params.getSubX(), params.getSubY(), params.getSubSpanX(),
+                        params.getSubSpanY(), mTempOnDrawCellToRect);
                 mVisualizeGridRect.set(mTempOnDrawCellToRect);
                 mVisualizeGridRect.inset(paddingX, paddingY);
 
@@ -652,12 +667,49 @@ public class CellLayout extends ViewGroup {
                 mVisualizeGridPaint.setStyle(Paint.Style.STROKE);
                 mVisualizeGridPaint.setColor(Color.argb((int) (alpha),
                         Color.red(mGridColor), Color.green(mGridColor), Color.blue(mGridColor)));
+                // Lawnchair: Subgrid positioning — dash the preview when the target is a half-cell
+                // position/size, so a half placement reads differently from an on-grid one.
+                boolean isHalfTarget = params.getSubX() != 0 || params.getSubY() != 0
+                        || params.getSubSpanX() != 0 || params.getSubSpanY() != 0;
+                mVisualizeGridPaint.setPathEffect(isHalfTarget ? mSubgridDashEffect : null);
 
                 canvas.save();
                 canvas.translate(getMarginForGivenCellParams(params), 0);
                 canvas.drawRoundRect(mVisualizeGridRect, mGridVisualizationRoundingRadius,
                         mGridVisualizationRoundingRadius, mVisualizeGridPaint);
                 canvas.restore();
+                mVisualizeGridPaint.setPathEffect(null);
+            }
+        }
+    }
+
+    /**
+     * Lawnchair: Subgrid positioning. Draws the faint MAIN (whole) cell grid while an item is being
+     * dragged, so the user has the real grid as a reference. A half placement is then obvious because
+     * the (dashed) drop preview sits offset from these whole cells. No-op unless subgrid is enabled.
+     */
+    private void drawSubgridGuides(Canvas canvas) {
+        // Driven by the steady spring-loaded progress so the grid stays put while the item moves.
+        if (!isSubgridEnabled() || mSpringLoadedProgress <= 0f) {
+            return;
+        }
+        DeviceProfile dp = mActivity.getDeviceProfile();
+        int paddingX = Math.min((mCellWidth - dp.iconSizePx) / 2, dp.gridVisualizationPaddingX);
+        int paddingY = Math.min((mCellHeight - dp.iconSizePx) / 2, dp.gridVisualizationPaddingY);
+
+        mSubgridGuidePaint.setStyle(Paint.Style.STROKE);
+        mSubgridGuidePaint.setStrokeWidth(3);
+        // Fainter than the drop outline so the grid reads as a subtle reference.
+        mSubgridGuidePaint.setColor(Color.argb((int) (mSpringLoadedProgress * 0.3f * 255),
+                Color.red(mGridColor), Color.green(mGridColor), Color.blue(mGridColor)));
+
+        for (int c = 0; c < mCountX; c++) {
+            for (int r = 0; r < mCountY; r++) {
+                cellToRect(c, r, 1, 1, mTempOnDrawCellToRect);
+                mVisualizeGridRect.set(mTempOnDrawCellToRect);
+                mVisualizeGridRect.inset(paddingX, paddingY);
+                canvas.drawRoundRect(mVisualizeGridRect, mGridVisualizationRoundingRadius,
+                        mGridVisualizationRoundingRadius, mSubgridGuidePaint);
             }
         }
     }
@@ -751,6 +803,17 @@ public class CellLayout extends ViewGroup {
 
     public int getCountY() {
         return mCountY;
+    }
+
+    /**
+     * Lawnchair: Subgrid (half-cell) positioning. Honored only on the workspace and only when the
+     * preference is enabled. In this mode items are placed freely (the reorder/occupancy engine is
+     * short-circuited, like {@link PreferenceManager2#getAllowWidgetOverlap()}), so half-cell
+     * placement and sizing never fight the integer grid.
+     */
+    public boolean isSubgridEnabled() {
+        return mContainerType == WORKSPACE
+                && PreferenceExtensionsKt.firstBlocking(pref.getEnableSubgridPositioning());
     }
 
     public boolean acceptsWidget() {
@@ -878,6 +941,79 @@ public class CellLayout extends ViewGroup {
         if (result[0] >= xAxis) result[0] = xAxis - 1;
         if (result[1] < 0) result[1] = 0;
         if (result[1] >= yAxis) result[1] = yAxis - 1;
+    }
+
+    /**
+     * Lawnchair: Subgrid positioning. Refines an integer drop target to the nearest half-cell.
+     * Given the base {@code targetCell} chosen by the normal drop logic and the drag visual center
+     * (in this layout's coordinates), writes the possibly-adjusted base cell back into
+     * {@code targetCell} and the half-step (0 or 1) for each axis into {@code outSub}. No-op (sub = 0)
+     * unless subgrid positioning is enabled for this layout.
+     */
+    public void computeSubgridTarget(int[] targetCell, int[] outSub, int spanX, int spanY,
+            int subSpanX, int subSpanY, float visualCenterX, float visualCenterY) {
+        outSub[0] = 0;
+        outSub[1] = 0;
+        if (!isSubgridEnabled()) {
+            return;
+        }
+        Rect rect = new Rect();
+        cellToRect(targetCell[0], targetCell[1], spanX, spanY, rect);
+        float pitchX = mCellWidth + mBorderSpace.x;
+        float pitchY = mCellHeight + mBorderSpace.y;
+        // Desired top-left of the item if its actual (possibly half-sized) footprint were centered on
+        // the drag point — matches the rendered width/height from CellLayoutLayoutParams.setup.
+        float actualSpanX = spanX + subSpanX * 0.5f;
+        float actualSpanY = spanY + subSpanY * 0.5f;
+        float idealLeft = visualCenterX
+                - (actualSpanX * mCellWidth + (actualSpanX - 1) * mBorderSpace.x) / 2f;
+        float idealTop = visualCenterY
+                - (actualSpanY * mCellHeight + (actualSpanY - 1) * mBorderSpace.y) / 2f;
+        outSub[0] = halfSnapAxis((idealLeft - rect.left) / pitchX, targetCell, 0, spanX, subSpanX,
+                mCountX);
+        outSub[1] = halfSnapAxis((idealTop - rect.top) / pitchY, targetCell, 1, spanY, subSpanY,
+                mCountY);
+    }
+
+    /**
+     * Lawnchair: Subgrid positioning. Resolves a fractional offset (in cell units) from a base cell into
+     * a (possibly adjusted) base cell plus a half-step. The whole computation is done in HALF-cells so
+     * that a half-SIZED item ({@code subSpan != 0}, e.g. a 2.5-cell-wide widget) is included in the
+     * fit — otherwise such an item could be placed where its trailing edge spills half a cell past the
+     * page. The item is always kept fully on the page and is snapped flush to the trailing edge rather
+     * than being left a half-cell short of it (no half-cell gap at the boundary). Interior halves and a
+     * half against the leading edge are preserved.
+     */
+    private static int halfSnapAxis(float delta, int[] base, int idx, int span, int subSpan,
+            int count) {
+        int sub;
+        if (delta >= 0.25f) {
+            sub = 1;
+        } else if (delta <= -0.25f) {
+            base[idx] -= 1;
+            sub = 1;
+        } else {
+            sub = 0;
+        }
+
+        final int countHalf = count * 2;
+        final int sizeHalf = span * 2 + subSpan;          // actual extent of the item in half-cells
+        final int maxPosHalf = countHalf - sizeHalf;       // furthest the leading edge can sit (flush)
+        int posHalf = base[idx] * 2 + sub;                 // desired leading edge in half-cells
+
+        // Keep the item fully on the page: clamp the leading edge to the page start and never let the
+        // trailing edge overflow. A half-cell GAP against the trailing edge (e.g. column 4.5 in a
+        // 5-column grid) is a valid interior position and is intentionally kept — only an edge that
+        // would spill past the page (e.g. 5.5) is snapped back flush.
+        if (posHalf > maxPosHalf) {
+            posHalf = maxPosHalf;
+        }
+        if (posHalf < 0) {
+            posHalf = 0;
+        }
+
+        base[idx] = Math.floorDiv(posHalf, 2);
+        return posHalf - base[idx] * 2;
     }
 
     /**
@@ -1178,8 +1314,19 @@ public class CellLayout extends ViewGroup {
 
     void visualizeDropLocation(int cellX, int cellY, int spanX, int spanY,
                                DropTarget.DragObject dragObject) {
+        visualizeDropLocation(cellX, cellY, spanX, spanY, 0, 0, 0, 0, dragObject);
+    }
+
+    /**
+     * Lawnchair: Subgrid positioning. Draws the drop preview at a half-cell offset/size so the user
+     * sees that the item will land "in the middle" (half a column/row) before dropping.
+     */
+    void visualizeDropLocation(int cellX, int cellY, int spanX, int spanY,
+                               int subX, int subY, int subSpanX, int subSpanY,
+                               DropTarget.DragObject dragObject) {
         if (mDragCell[0] != cellX || mDragCell[1] != cellY || mDragCellSpan[0] != spanX
-                || mDragCellSpan[1] != spanY) {
+                || mDragCellSpan[1] != spanY || mDragCellSub[0] != subX || mDragCellSub[1] != subY
+                || mDragCellSubSpan[0] != subSpanX || mDragCellSubSpan[1] != subSpanY) {
             determineIfDragHapticsPlay();
             if (mPlayDragHaptics && Flags.msdlFeedback()) {
                 mMSDLPlayerWrapper.playToken(MSDLToken.DRAG_INDICATOR_DISCRETE);
@@ -1188,6 +1335,10 @@ public class CellLayout extends ViewGroup {
             mDragCell[1] = cellY;
             mDragCellSpan[0] = spanX;
             mDragCellSpan[1] = spanY;
+            mDragCellSub[0] = subX;
+            mDragCellSub[1] = subY;
+            mDragCellSubSpan[0] = subSpanX;
+            mDragCellSubSpan[1] = subSpanY;
 
             final int oldIndex = mDragOutlineCurrent;
             mDragOutlineAnims[oldIndex].animateOut();
@@ -1198,6 +1349,10 @@ public class CellLayout extends ViewGroup {
             cell.setCellY(cellY);
             cell.cellHSpan = spanX;
             cell.cellVSpan = spanY;
+            cell.setSubX(subX);
+            cell.setSubY(subY);
+            cell.setSubSpanX(subSpanX);
+            cell.setSubSpanY(subSpanY);
 
             mDragOutlineAnims[mDragOutlineCurrent].animateIn();
             invalidate();
@@ -1497,6 +1652,42 @@ public class CellLayout extends ViewGroup {
                             screenId, lp.getCellX(), lp.getCellY(), lp.cellHSpan, lp.cellVSpan);
                 }
             }
+        }
+    }
+
+    /**
+     * Lawnchair: Subgrid positioning. Persists a single view's final geometry (including half-cell
+     * offsets/sizes) to the model. Used by the subgrid widget-resize path, which skips the
+     * reorder-based {@link #createAreaForResize} (and therefore {@link #commitTempPlacement}) because
+     * subgrid placement is free. Mirrors the presenter coordinates that {@code commitTempPlacement}
+     * passes to {@link com.android.launcher3.model.ModelWriter#modifyItemInDatabase}.
+     */
+    public void persistViewGeometry(View view) {
+        ItemInfo info = (ItemInfo) view.getTag();
+        if (info == null || view.getParent() != mShortcutsAndWidgets) return;
+        CellLayoutLayoutParams lp = (CellLayoutLayoutParams) view.getLayoutParams();
+
+        int screenId = mCellLayoutContainer.getCellLayoutId(this);
+        int container = Favorites.CONTAINER_DESKTOP;
+        if (mContainerType == HOTSEAT) {
+            screenId = -1;
+            container = Favorites.CONTAINER_HOTSEAT;
+        }
+
+        lp.setCellX(lp.getTmpCellX());
+        lp.setCellY(lp.getTmpCellY());
+        lp.useTmpCoords = false;
+        info.subX = lp.getSubX();
+        info.subY = lp.getSubY();
+        info.subSpanX = lp.getSubSpanX();
+        info.subSpanY = lp.getSubSpanY();
+
+        mActivity.getModelWriter().modifyItemInDatabase(info, container, screenId,
+                lp.getCellX(), lp.getCellY(), lp.cellHSpan, lp.cellVSpan);
+        // Lawnchair: Subgrid free placement bypasses occupancy (and integer marking would ignore the
+        // half-cell offset and could clobber an overlapping neighbour's base cell), so skip it.
+        if (!isSubgridEnabled()) {
+            markCellsAsOccupiedForView(view);
         }
     }
 
@@ -1856,6 +2047,25 @@ public class CellLayout extends ViewGroup {
         resultRect.set(x, y, x + width, y + height);
     }
 
+    /**
+     * Lawnchair: Subgrid positioning. Like {@link #cellToRect(int, int, int, int, Rect)} but offset by
+     * the given half-cell position step and extended by the given half-cell span step (each 0 or 1).
+     * Matches the geometry produced by {@link CellLayoutLayoutParams#setup} so the drop preview lines
+     * up with where the item will actually render.
+     */
+    public void cellToRect(int cellX, int cellY, int cellHSpan, int cellVSpan, int subX, int subY,
+            int subSpanX, int subSpanY, Rect resultRect) {
+        cellToRect(cellX, cellY, cellHSpan, cellVSpan, resultRect);
+        if (subX == 0 && subY == 0 && subSpanX == 0 && subSpanY == 0) {
+            return;
+        }
+        final float pitchX = mCellWidth + mBorderSpace.x;
+        final float pitchY = mCellHeight + mBorderSpace.y;
+        resultRect.offset(Math.round(subX * 0.5f * pitchX), Math.round(subY * 0.5f * pitchY));
+        resultRect.right += Math.round(subSpanX * 0.5f * pitchX);
+        resultRect.bottom += Math.round(subSpanY * 0.5f * pitchY);
+    }
+
     /** Enables successors to provide an X adjustment for the cell. */
     protected int getTranslationXForCell(int cellX, int cellY) {
         return 0;
@@ -1926,7 +2136,9 @@ public class CellLayout extends ViewGroup {
 
     public boolean isOccupied(int x, int y) {
         if (x >= 0 && x < mCountX && y >= 0 && y < mCountY) {
-            return mOccupied.cells[x][y] && !PreferenceExtensionsKt.firstBlocking(pref.getAllowWidgetOverlap());
+            return mOccupied.cells[x][y]
+                    && !PreferenceExtensionsKt.firstBlocking(pref.getAllowWidgetOverlap())
+                    && !isSubgridEnabled();
         }
         if (BuildConfigs.IS_STUDIO_BUILD) {
             throw new RuntimeException("Position exceeds the bound of this CellLayout");
@@ -1946,7 +2158,11 @@ public class CellLayout extends ViewGroup {
 
     @Override
     protected ViewGroup.LayoutParams generateLayoutParams(ViewGroup.LayoutParams p) {
-        return new CellLayoutLayoutParams(p);
+        // Lawnchair: Use the copy constructor for CellLayoutLayoutParams so subgrid half-cell fields
+        // (and tmp coords) are preserved; the ViewGroup.LayoutParams ctor would drop them.
+        return p instanceof CellLayoutLayoutParams
+                ? new CellLayoutLayoutParams((CellLayoutLayoutParams) p)
+                : new CellLayoutLayoutParams(p);
     }
 
     /**
@@ -2009,7 +2225,9 @@ public class CellLayout extends ViewGroup {
     }
 
     public boolean isRegionVacant(int x, int y, int spanX, int spanY) {
-        return mOccupied.isRegionVacant(x, y, spanX, spanY) || PreferenceExtensionsKt.firstBlocking(pref.getAllowWidgetOverlap());
+        return mOccupied.isRegionVacant(x, y, spanX, spanY)
+                || PreferenceExtensionsKt.firstBlocking(pref.getAllowWidgetOverlap())
+                || isSubgridEnabled();
     }
 
     public void setSpaceBetweenCellLayoutsPx(@Px int spaceBetweenCellLayoutsPx) {

--- a/src/com/android/launcher3/Workspace.java
+++ b/src/com/android/launcher3/Workspace.java
@@ -218,6 +218,8 @@ public class Workspace<T extends View & PageIndicator> extends PagedView<T>
      */
     @Thunk
     int[] mTargetCell = new int[2];
+    // Lawnchair: Subgrid positioning — half-cell offset (0/1 per axis) chosen for the current drop.
+    private final int[] mTargetSub = new int[2];
     private int mDragOverX = -1;
     private int mDragOverY = -1;
 
@@ -2318,6 +2320,25 @@ public class Workspace<T extends View & PageIndicator> extends PagedView<T>
                         snappedToNewPage = true;
                     }
                     final ItemInfo info = (ItemInfo) cell.getTag();
+
+                    // Lawnchair: Subgrid positioning — refine the integer target to the nearest
+                    // half-cell (no-op unless enabled for this workspace layout). May adjust
+                    // mTargetCell, so compute before it is consumed below. When the feature is off
+                    // we clear ALL half-steps so a drag fully reverts the item to integer cells
+                    // (keeps cellX/spanX consistent — no stale half-size left behind).
+                    if (dropTargetLayout.isSubgridEnabled()) {
+                        dropTargetLayout.computeSubgridTarget(mTargetCell, mTargetSub, item.spanX,
+                                item.spanY, info.subSpanX, info.subSpanY,
+                                mDragViewVisualCenter[0], mDragViewVisualCenter[1]);
+                        info.subX = mTargetSub[0];
+                        info.subY = mTargetSub[1];
+                    } else {
+                        info.subX = 0;
+                        info.subY = 0;
+                        info.subSpanX = 0;
+                        info.subSpanY = 0;
+                    }
+
                     if (hasMovedLayouts) {
                         // Reparent the view
                         CellLayout parentCell = getParentCellLayoutForView(cell);
@@ -2341,6 +2362,11 @@ public class Workspace<T extends View & PageIndicator> extends PagedView<T>
                     lp.cellHSpan = item.spanX;
                     lp.cellVSpan = item.spanY;
                     lp.isLockedToGrid = true;
+                    // Lawnchair: Subgrid positioning — carry the half-cell offset/size onto the view.
+                    lp.setSubX(info.subX);
+                    lp.setSubY(info.subY);
+                    lp.setSubSpanX(info.subSpanX);
+                    lp.setSubSpanY(info.subSpanY);
 
                     if (container != CONTAINER_HOTSEAT
                             && cell instanceof LauncherAppWidgetHostView) {
@@ -2741,8 +2767,15 @@ public class Workspace<T extends View & PageIndicator> extends PagedView<T>
             mDragTargetLayout.performReorder((int) mDragViewVisualCenter[0],
                     (int) mDragViewVisualCenter[1], minSpanX, minSpanY, item.spanX, item.spanY,
                     child, mTargetCell, span, CellLayout.MODE_SHOW_REORDER_HINT);
-            mDragTargetLayout.visualizeDropLocation(mTargetCell[0], mTargetCell[1], span[0],
-                    span[1], d);
+            // Lawnchair: Subgrid positioning — preview the half-cell position/size before dropping.
+            int[] previewCell = {mTargetCell[0], mTargetCell[1]};
+            int previewSubSpanX = mDragTargetLayout.isSubgridEnabled() ? item.subSpanX : 0;
+            int previewSubSpanY = mDragTargetLayout.isSubgridEnabled() ? item.subSpanY : 0;
+            mDragTargetLayout.computeSubgridTarget(previewCell, mTargetSub, span[0], span[1],
+                    previewSubSpanX, previewSubSpanY,
+                    mDragViewVisualCenter[0], mDragViewVisualCenter[1]);
+            mDragTargetLayout.visualizeDropLocation(previewCell[0], previewCell[1], span[0],
+                    span[1], mTargetSub[0], mTargetSub[1], previewSubSpanX, previewSubSpanY, d);
             nearestDropOccupied = mDragTargetLayout.isNearestDropLocationOccupied((int)
                             mDragViewVisualCenter[0], (int) mDragViewVisualCenter[1], item.spanX,
                     item.spanY, child, mTargetCell);
@@ -2978,8 +3011,19 @@ public class Workspace<T extends View & PageIndicator> extends PagedView<T>
                 setDragMode(DRAG_MODE_REORDER);
             }
 
-            mDragTargetLayout.visualizeDropLocation(mTargetCell[0], mTargetCell[1],
-                    resultSpan[0], resultSpan[1], dragObject);
+            // Lawnchair: Subgrid positioning — preview the half-cell position before dropping.
+            int[] previewCell = {mTargetCell[0], mTargetCell[1]};
+            boolean subgridOn = mDragTargetLayout.isSubgridEnabled();
+            int previewSubSpanX = subgridOn && dragObject.dragInfo != null
+                    ? dragObject.dragInfo.subSpanX : 0;
+            int previewSubSpanY = subgridOn && dragObject.dragInfo != null
+                    ? dragObject.dragInfo.subSpanY : 0;
+            mDragTargetLayout.computeSubgridTarget(previewCell, mTargetSub, resultSpan[0],
+                    resultSpan[1], previewSubSpanX, previewSubSpanY,
+                    mDragViewVisualCenter[0], mDragViewVisualCenter[1]);
+            mDragTargetLayout.visualizeDropLocation(previewCell[0], previewCell[1],
+                    resultSpan[0], resultSpan[1], mTargetSub[0], mTargetSub[1],
+                    previewSubSpanX, previewSubSpanY, dragObject);
         }
     }
 

--- a/src/com/android/launcher3/WorkspaceLayoutManager.java
+++ b/src/com/android/launcher3/WorkspaceLayoutManager.java
@@ -147,6 +147,17 @@ public interface WorkspaceLayoutManager {
         }
         int childId = info.getViewId();
 
+        // Lawnchair: Subgrid positioning — only the workspace honors half-cell offsets/sizes, and only
+        // when the preference is enabled. Hotseat/folder containers and the disabled state keep 0.
+        boolean subgridEnabled = container == LauncherSettings.Favorites.CONTAINER_DESKTOP
+                && PreferenceExtensionsKt.firstBlocking(
+                        PreferenceManager2.getInstance(child.getContext())
+                                .getEnableSubgridPositioning());
+        lp.setSubX(subgridEnabled ? info.subX : 0);
+        lp.setSubY(subgridEnabled ? info.subY : 0);
+        lp.setSubSpanX(subgridEnabled ? info.subSpanX : 0);
+        lp.setSubSpanY(subgridEnabled ? info.subSpanY : 0);
+
         boolean markCellsAsOccupied = !(child instanceof Folder);
         if (!layout.addViewToCellLayout(child, -1, childId, lp, markCellsAsOccupied)) {
             // TODO: This branch occurs when the workspace is adding views

--- a/src/com/android/launcher3/celllayout/CellLayoutLayoutParams.java
+++ b/src/com/android/launcher3/celllayout/CellLayoutLayoutParams.java
@@ -40,6 +40,19 @@ public class CellLayoutLayoutParams extends ViewGroup.MarginLayoutParams {
     private int mTmpCellY;
 
     /**
+     * Lawnchair: Subgrid positioning. Half-cell offsets (0 or 1) added to the cell position, and
+     * extra half-cells (0 or 1) added to the span. Non-zero only on the workspace when the
+     * subgrid-positioning preference is enabled; see {@link #setup}.
+     */
+    private int mSubX;
+
+    private int mSubY;
+
+    private int mSubSpanX;
+
+    private int mSubSpanY;
+
+    /**
      * Indicates that the temporary coordinates should be used to layout the items
      */
     public boolean useTmpCoords;
@@ -98,6 +111,10 @@ public class CellLayoutLayoutParams extends ViewGroup.MarginLayoutParams {
         this.mTmpCellX = source.getTmpCellX();
         this.mTmpCellY = source.getTmpCellY();
         this.useTmpCoords = source.useTmpCoords;
+        this.mSubX = source.mSubX;
+        this.mSubY = source.mSubY;
+        this.mSubSpanX = source.mSubSpanX;
+        this.mSubSpanY = source.mSubSpanY;
     }
 
     public CellLayoutLayoutParams(int cellX, int cellY, int cellHSpan, int cellVSpan) {
@@ -129,25 +146,28 @@ public class CellLayoutLayoutParams extends ViewGroup.MarginLayoutParams {
             int rowCount, float cellScaleX, float cellScaleY, Point borderSpace,
             @Nullable Rect inset) {
         if (isLockedToGrid) {
-            final int myCellHSpan = cellHSpan;
-            final int myCellVSpan = cellVSpan;
-            int myCellX = useTmpCoords ? getTmpCellX() : getCellX();
-            int myCellY = useTmpCoords ? getTmpCellY() : getCellY();
+            // Lawnchair: Subgrid positioning — half-cell offsets/spans are folded in as floats and
+            // rounded once at the end. When all sub-values are 0 (feature off / non-workspace) this
+            // is byte-identical to the original integer arithmetic.
+            final float myCellHSpan = cellHSpan + mSubSpanX * 0.5f;
+            final float myCellVSpan = cellVSpan + mSubSpanY * 0.5f;
+            float myCellX = (useTmpCoords ? getTmpCellX() : getCellX()) + mSubX * 0.5f;
+            float myCellY = (useTmpCoords ? getTmpCellY() : getCellY()) + mSubY * 0.5f;
 
             if (invertHorizontally) {
-                myCellX = colCount - myCellX - cellHSpan;
+                myCellX = colCount - myCellX - myCellHSpan;
             }
 
-            int hBorderSpacing = (myCellHSpan - 1) * borderSpace.x;
-            int vBorderSpacing = (myCellVSpan - 1) * borderSpace.y;
+            float hBorderSpacing = (myCellHSpan - 1) * borderSpace.x;
+            float vBorderSpacing = (myCellVSpan - 1) * borderSpace.y;
 
             float myCellWidth = ((myCellHSpan * cellWidth) + hBorderSpacing) / cellScaleX;
             float myCellHeight = ((myCellVSpan * cellHeight) + vBorderSpacing) / cellScaleY;
 
             width = Math.round(myCellWidth) - leftMargin - rightMargin;
             height = Math.round(myCellHeight) - topMargin - bottomMargin;
-            x = leftMargin + (myCellX * cellWidth) + (myCellX * borderSpace.x);
-            y = topMargin + (myCellY * cellHeight) + (myCellY * borderSpace.y);
+            x = leftMargin + Math.round((myCellX * cellWidth) + (myCellX * borderSpace.x));
+            y = topMargin + Math.round((myCellY * cellHeight) + (myCellY * borderSpace.y));
 
             if (inset != null) {
                 x += inset.left;
@@ -215,5 +235,38 @@ public class CellLayoutLayoutParams extends ViewGroup.MarginLayoutParams {
 
     public void setTmpCellY(int tmpCellY) {
         this.mTmpCellY = tmpCellY;
+    }
+
+    /** Lawnchair: Subgrid positioning — half-cell offsets/spans (each 0 or 1). */
+    public int getSubX() {
+        return mSubX;
+    }
+
+    public void setSubX(int subX) {
+        this.mSubX = subX;
+    }
+
+    public int getSubY() {
+        return mSubY;
+    }
+
+    public void setSubY(int subY) {
+        this.mSubY = subY;
+    }
+
+    public int getSubSpanX() {
+        return mSubSpanX;
+    }
+
+    public void setSubSpanX(int subSpanX) {
+        this.mSubSpanX = subSpanX;
+    }
+
+    public int getSubSpanY() {
+        return mSubSpanY;
+    }
+
+    public void setSubSpanY(int subSpanY) {
+        this.mSubSpanY = subSpanY;
     }
 }

--- a/src/com/android/launcher3/celllayout/ReorderAlgorithm.java
+++ b/src/com/android/launcher3/celllayout/ReorderAlgorithm.java
@@ -133,8 +133,9 @@ public class ReorderAlgorithm {
         ArrayList<View> intersectingViews = new ArrayList<>();
         Rect occupiedRect = new Rect(cellX, cellY, cellX + spanX, cellY + spanY);
 
-        // Lawnchair: Widget overlap
-        if (PreferenceExtensionsKt.firstBlocking(mCellLayout.pref.getAllowWidgetOverlap())) {
+        // Lawnchair: Widget overlap / subgrid free placement
+        if (PreferenceExtensionsKt.firstBlocking(mCellLayout.pref.getAllowWidgetOverlap())
+                || mCellLayout.isSubgridEnabled()) {
             solution.intersectingViews = new ArrayList<>(intersectingViews);
             return true;
         }

--- a/src/com/android/launcher3/model/DbEntry.kt
+++ b/src/com/android/launcher3/model/DbEntry.kt
@@ -66,6 +66,10 @@ class DbEntry : ItemInfo(), Comparable<DbEntry> {
     fun updateContentValues(values: ContentValues) =
         values.apply {
             put(SCREEN, screenId)
+            // Lawnchair: Subgrid positioning is intentionally NOT preserved across a grid-size
+            // migration: the migration re-solves placement in integer cells, so writing the base
+            // (already truncated to an int via the DbReader's getInt) yields clean integer positions.
+            // Half-cell offsets are reset when the grid changes; live placement keeps them.
             put(CELLX, cellX)
             put(CELLY, cellY)
             put(SPANX, spanX)

--- a/src/com/android/launcher3/model/LoaderCursor.java
+++ b/src/com/android/launcher3/model/LoaderCursor.java
@@ -673,10 +673,13 @@ public class LoaderCursor extends CursorWrapper {
                     + " into cell (" + containerIndex + "-" + item.screenId + ":"
                     + item.cellX + "," + item.cellX + "," + item.spanX + "," + item.spanY
                     + ") already occupied");
-            // Lawnchair: Subgrid free placement allows items to share a base cell, so don't drop them.
-            return PreferenceExtensionsKt.firstBlocking(preferenceManager2.getAllowWidgetOverlap())
-                    || PreferenceExtensionsKt.firstBlocking(
+            // Lawnchair: Subgrid free placement lets icons/widgets share a base cell, so don't drop
+            // them. Folders stay on the unchanged integer grid, so keep their overlap check strict.
+            boolean allowSubgridOverlap = item.itemType != Favorites.ITEM_TYPE_FOLDER
+                    && PreferenceExtensionsKt.firstBlocking(
                             preferenceManager2.getEnableSubgridPositioning());
+            return PreferenceExtensionsKt.firstBlocking(preferenceManager2.getAllowWidgetOverlap())
+                    || allowSubgridOverlap;
         }
     }
 

--- a/src/com/android/launcher3/model/LoaderCursor.java
+++ b/src/com/android/launcher3/model/LoaderCursor.java
@@ -536,6 +536,12 @@ public class LoaderCursor extends CursorWrapper {
         info.screenId = getInt(mScreenIndex);
         info.cellX = getInt(mCellXIndex);
         info.cellY = getInt(mCellYIndex);
+        // Lawnchair: Subgrid positioning — recover half-cell offsets/sizes from the (possibly REAL)
+        // columns. Base reads above stay integer (getInt truncates), so legacy behavior is unchanged.
+        info.subX = ItemInfo.decodeSubgridStep(getFloat(mCellXIndex));
+        info.subY = ItemInfo.decodeSubgridStep(getFloat(mCellYIndex));
+        info.subSpanX = ItemInfo.decodeSubgridStep(getFloat(mSpanXIndex));
+        info.subSpanY = ItemInfo.decodeSubgridStep(getFloat(mSpanYIndex));
     }
 
     /**
@@ -667,7 +673,10 @@ public class LoaderCursor extends CursorWrapper {
                     + " into cell (" + containerIndex + "-" + item.screenId + ":"
                     + item.cellX + "," + item.cellX + "," + item.spanX + "," + item.spanY
                     + ") already occupied");
-            return PreferenceExtensionsKt.firstBlocking(preferenceManager2.getAllowWidgetOverlap());
+            // Lawnchair: Subgrid free placement allows items to share a base cell, so don't drop them.
+            return PreferenceExtensionsKt.firstBlocking(preferenceManager2.getAllowWidgetOverlap())
+                    || PreferenceExtensionsKt.firstBlocking(
+                            preferenceManager2.getEnableSubgridPositioning());
         }
     }
 

--- a/src/com/android/launcher3/model/ModelWriter.java
+++ b/src/com/android/launcher3/model/ModelWriter.java
@@ -187,10 +187,11 @@ public class ModelWriter {
         updateItemInfoProps(item, container, screenId, cellX, cellY);
         notifyItemModified(item);
 
+        // Lawnchair: Subgrid positioning — preserve half-cell offsets when moving items.
         enqueueDeleteRunnable(new UpdateItemRunnable(item, () -> new ContentWriter(mContext)
                 .put(Favorites.CONTAINER, item.container)
-                .put(Favorites.CELLX, item.cellX)
-                .put(Favorites.CELLY, item.cellY)
+                .putSubgrid(Favorites.CELLX, item.cellX, item.subX)
+                .putSubgrid(Favorites.CELLY, item.cellY, item.subY)
                 .put(Favorites.RANK, item.rank)
                 .put(Favorites.SCREEN, item.screenId)));
     }
@@ -210,11 +211,13 @@ public class ModelWriter {
             updateItemInfoProps(item, container, screen, item.cellX, item.cellY);
 
             final ContentValues values = new ContentValues();
-            values.put(Favorites.CONTAINER, item.container);
-            values.put(Favorites.CELLX, item.cellX);
-            values.put(Favorites.CELLY, item.cellY);
-            values.put(Favorites.RANK, item.rank);
-            values.put(Favorites.SCREEN, item.screenId);
+            // Lawnchair: Subgrid positioning — preserve half-cell offsets when bulk-moving items.
+            new ContentWriter(values, mContext)
+                    .put(Favorites.CONTAINER, item.container)
+                    .putSubgrid(Favorites.CELLX, item.cellX, item.subX)
+                    .putSubgrid(Favorites.CELLY, item.cellY, item.subY)
+                    .put(Favorites.RANK, item.rank)
+                    .put(Favorites.SCREEN, item.screenId);
 
             contentValues.add(values);
         }
@@ -330,13 +333,14 @@ public class ModelWriter {
         item.spanX = spanX;
         item.spanY = spanY;
         notifyItemModified(item);
+        // Lawnchair: Subgrid positioning — persist half-cell offsets/sizes as REAL when present.
         new UpdateItemRunnable(item, () -> new ContentWriter(mContext)
                 .put(Favorites.CONTAINER, item.container)
-                .put(Favorites.CELLX, item.cellX)
-                .put(Favorites.CELLY, item.cellY)
+                .putSubgrid(Favorites.CELLX, item.cellX, item.subX)
+                .putSubgrid(Favorites.CELLY, item.cellY, item.subY)
                 .put(Favorites.RANK, item.rank)
-                .put(Favorites.SPANX, item.spanX)
-                .put(Favorites.SPANY, item.spanY)
+                .putSubgrid(Favorites.SPANX, item.spanX, item.subSpanX)
+                .putSubgrid(Favorites.SPANY, item.spanY, item.subSpanY)
                 .put(Favorites.SCREEN, item.screenId))
                 .executeOnModelThread();
     }

--- a/src/com/android/launcher3/model/data/ItemInfo.java
+++ b/src/com/android/launcher3/model/data/ItemInfo.java
@@ -148,6 +148,29 @@ public class ItemInfo {
     public int spanY = 1;
 
     /**
+     * Lawnchair: Subgrid (half-cell) positioning. Half-cell offset of the cell position,
+     * 0 = aligned to the integer cell, 1 = shifted by half a cell. Only honored on the
+     * workspace when the subgrid-positioning preference is enabled; 0 otherwise.
+     */
+    public int subX = 0;
+
+    /**
+     * Lawnchair: Subgrid (half-cell) positioning. See {@link #subX}.
+     */
+    public int subY = 0;
+
+    /**
+     * Lawnchair: Subgrid (half-cell) sizing. Extra half cell of horizontal span,
+     * 0 = whole cells, 1 = half-cell larger. Only honored when subgrid positioning is enabled.
+     */
+    public int subSpanX = 0;
+
+    /**
+     * Lawnchair: Subgrid (half-cell) sizing. See {@link #subSpanX}.
+     */
+    public int subSpanY = 0;
+
+    /**
      * Indicates the minimum X cell span.
      */
     public int minSpanX = 1;
@@ -212,6 +235,10 @@ public class ItemInfo {
         cellY = info.cellY;
         spanX = info.spanX;
         spanY = info.spanY;
+        subX = info.subX;
+        subY = info.subY;
+        subSpanX = info.subSpanX;
+        subSpanY = info.subSpanY;
         minSpanX = info.minSpanX;
         minSpanY = info.minSpanY;
         rank = info.rank;
@@ -262,11 +289,12 @@ public class ItemInfo {
         writer.put(LauncherSettings.Favorites.ITEM_TYPE, itemType)
                 .put(LauncherSettings.Favorites.CONTAINER, container)
                 .put(LauncherSettings.Favorites.SCREEN, screenId)
-                .put(LauncherSettings.Favorites.CELLX, cellX)
-                .put(LauncherSettings.Favorites.CELLY, cellY)
-                .put(LauncherSettings.Favorites.SPANX, spanX)
-                .put(LauncherSettings.Favorites.SPANY, spanY)
                 .put(LauncherSettings.Favorites.RANK, rank);
+        // Lawnchair: Subgrid positioning — persist base + 0.5 as a REAL when a half-step is present.
+        writer.putSubgrid(LauncherSettings.Favorites.CELLX, cellX, subX)
+                .putSubgrid(LauncherSettings.Favorites.CELLY, cellY, subY)
+                .putSubgrid(LauncherSettings.Favorites.SPANX, spanX, subSpanX)
+                .putSubgrid(LauncherSettings.Favorites.SPANY, spanY, subSpanY);
     }
 
     public void readFromValues(@NonNull final ContentValues values) {
@@ -278,6 +306,18 @@ public class ItemInfo {
         spanX = values.getAsInteger(LauncherSettings.Favorites.SPANX);
         spanY = values.getAsInteger(LauncherSettings.Favorites.SPANY);
         rank = values.getAsInteger(LauncherSettings.Favorites.RANK);
+        // Lawnchair: Subgrid positioning — recover the half-step from the (possibly REAL) value.
+        subX = decodeSubgridStep(values.getAsFloat(LauncherSettings.Favorites.CELLX));
+        subY = decodeSubgridStep(values.getAsFloat(LauncherSettings.Favorites.CELLY));
+        subSpanX = decodeSubgridStep(values.getAsFloat(LauncherSettings.Favorites.SPANX));
+        subSpanY = decodeSubgridStep(values.getAsFloat(LauncherSettings.Favorites.SPANY));
+    }
+
+    /** Lawnchair: Subgrid positioning. Returns 1 if the value carries a half-cell offset, else 0. */
+    public static int decodeSubgridStep(@Nullable Float value) {
+        if (value == null) return 0;
+        float frac = value - (float) Math.floor(value);
+        return frac >= 0.25f ? 1 : 0;
     }
 
     /**

--- a/src/com/android/launcher3/model/data/ItemInfo.java
+++ b/src/com/android/launcher3/model/data/ItemInfo.java
@@ -317,7 +317,8 @@ public class ItemInfo {
     public static int decodeSubgridStep(@Nullable Float value) {
         if (value == null) return 0;
         float frac = value - (float) Math.floor(value);
-        return frac >= 0.25f ? 1 : 0;
+        // The writer only ever emits a whole number or base + 0.5, so match .5 exactly (with epsilon).
+        return Math.abs(frac - 0.5f) <= 0.01f ? 1 : 0;
     }
 
     /**

--- a/src/com/android/launcher3/util/ContentWriter.java
+++ b/src/com/android/launcher3/util/ContentWriter.java
@@ -59,6 +59,23 @@ public class ContentWriter {
         return this;
     }
 
+    public ContentWriter put(String key, Float value) {
+        mValues.put(key, value);
+        return this;
+    }
+
+    /**
+     * Lawnchair: Subgrid positioning. Stores {@code base + 0.5} as a float (REAL) when a half-step is
+     * present, otherwise the plain integer. Legacy/integer readers truncate the REAL back to the base
+     * cell, so this is backward compatible with no schema change.
+     */
+    public ContentWriter putSubgrid(String key, int base, int sub) {
+        if (sub != 0) {
+            return put(key, base + sub * 0.5f);
+        }
+        return put(key, base);
+    }
+
     public ContentWriter put(String key, Long value) {
         mValues.put(key, value);
         return this;


### PR DESCRIPTION
## Summary

Adds an opt-in **Subgrid positioning** preference (Home screen → Layout) that lets workspace icons and widgets be placed at **half-cell** offsets, and lets widgets be resized at half-cell granularity — similar to Nova Launcher's subgrid positioning.

Off by default, workspace-only, and fully reversible.

## How it works

- **Free placement.** When enabled, the existing `allowWidgetOverlap` short-circuit is reused so the integer reorder/occupancy engine is *bypassed* rather than rewritten. Items are placed freely (and may overlap), so half-cell placement never has to fight the integer grid. Hotseat and folders are unaffected (`CONTAINER_DESKTOP`-gated).
- **Migration-free persistence.** A half-step is stored as a `REAL` value inside the existing `INTEGER` `cellX/cellY/spanX/spanY` columns (`base + 0.5`). Legacy/integer readers (`getInt` / `getAsInteger`) truncate it back to the base cell, so existing layouts and the disabled state are byte-identical — **no schema bump, no migration**. New readers additionally decode the half-step via `getFloat`.
- **Geometry.** `CellLayoutLayoutParams.setup()` folds the half-offset/half-span in as floats and rounds once; with all sub-values `0` it is identical to the original integer arithmetic.
- **Kept on-page.** Placement (including half-*sized* widgets) is always clamped fully within the page.
- **Visual cue.** During a drag the main cell grid is shown, with a dashed drop preview when the target is a half position/size, so a half placement reads differently from an on-grid one.

## Scope

- ✅ Workspace icons & widgets: half-cell **position**
- ✅ Widgets: half-cell **resize**
- ⛔ Hotseat / folders: unchanged (integer grid)
- Grid-size migration intentionally re-solves in integer cells (half-offsets reset on a grid change; live placement keeps them)

## Testing

- Off by default → existing layouts load unchanged; drag/drop/resize behavior identical.
- On → icons/widgets snap to half columns/rows, persist across restart; widgets resize in half steps; items stay on the page; toggling off snaps items back to whole cells.
- Verified on a 5-column RTL device.
- `./gradlew :compileLawnWithQuickstepGithubDebugSources` and `:assembleLawnWithQuickstepGithubDebug` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Subgrid positioning” toggle to home screen layout preferences (off by default).
  * Enables half-cell placement and resizing for widgets and icons, with subgrid-aware drag/drop previews and placement guides.
* **Improved Behavior**
  * Updated reorder and widget overlap handling to work correctly in subgrid mode.
  * Preserves subgrid placement geometry when moving items on the home screen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->