### PR TITLE
ci: Disallow publishing off non-release branch

### DIFF
--- a/.github/workflows/build_release_apk.yml
+++ b/.github/workflows/build_release_apk.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build-release-apk:
     runs-on: ubuntu-latest
-    if: !endsWith(github.ref, '-dev')
+    if: endsWith(github.ref, '-alpha') || endsWith(github.ref, '-beta') || endsWith(github.ref, '-rc') || endsWith(github.ref, '-stable')
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/build_release_apk.yml
+++ b/.github/workflows/build_release_apk.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   build-release-apk:
     runs-on: ubuntu-latest
+    if: !endsWith(github.ref, '-dev')
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6
@@ -35,4 +36,4 @@ jobs:
         with:
           name: Release APK
           path: build/outputs/*
-          
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ on:
   workflow_dispatch:
   workflow_call:
 
+env:
+  # Lawnchair-TODO(Configuration): https://github.com/LawnchairLauncher/lawnchair/issues/6442
+  PUBLISH_NIGHTLY: false
+
 jobs:
   build-debug-apk:
     strategy:
@@ -138,9 +142,7 @@ jobs:
 
   nightly-release:
     runs-on: ubuntu-latest
-    # Lawnchair-TODO(Configuration): Don't publish nightly build until Android 8.0, 8.1 is stable, and (probably) stable to match Lawnchair 15 Beta 1 or 2
-    if: false
-    # if: github.repository_owner == 'LawnchairLauncher' && github.event_name == 'push' && github.ref == 'refs/heads/15-dev'
+    if: env.PUBLISH_NIGHTLY == 'true' && github.repository_owner == 'LawnchairLauncher' && github.event_name == 'push' && startsWith(github.ref, 'refs/heads/') && endsWith(github.ref, '-dev')
     needs: final-status
     permissions:
       contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
 
   nightly-release:
     runs-on: ubuntu-latest
-    if: env.PUBLISH_NIGHTLY == 'true' && github.repository_owner == 'LawnchairLauncher' && github.event_name == 'push' && startsWith(github.ref, 'refs/heads/') && endsWith(github.ref, '-dev')
+    if: env.PUBLISH_NIGHTLY == 'true' && github.repository_owner == 'LawnchairLauncher' && github.event_name == 'push' && startsWith(github.ref, 'refs/heads/') && (endsWith(github.ref, '-dev')
     needs: final-status
     permissions:
       contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,8 @@ jobs:
       - check-style
     runs-on: ubuntu-slim
     if: always()
+    outputs:
+      publish_nightly: ${{ steps.publishing-status.outputs.publish_nightly }}
     steps:
       - name: Check
         run: |
@@ -139,20 +141,16 @@ jobs:
             exit 1
           fi
           echo "All required jobs completed successfully."
+      - id: publishing-status
+        run: echo "publish_nightly=${{ env.PUBLISH_NIGHTLY }}" >> "$GITHUB_OUTPUT"
 
   nightly-release:
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'LawnchairLauncher' && github.event_name == 'push' && startsWith(github.ref, 'refs/heads/') && endsWith(github.ref, '-dev')
     needs: final-status
+    if: needs.final-status.outputs.publish_nightly == 'true' && github.repository_owner == 'LawnchairLauncher' && github.event_name == 'push' && startsWith(github.ref, 'refs/heads/') && endsWith(github.ref, '-dev')
     permissions:
       contents: write
     steps:
-      - name: Prepublishing check
-        run: |
-          if [ "${{ env.PUBLISH_NIGHTLY }}" != "true" ]; then
-            echo "🛑 Publishing is disabled in env."
-            exit 1
-          fi
       - uses: actions/checkout@v6
       - uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,11 +142,17 @@ jobs:
 
   nightly-release:
     runs-on: ubuntu-latest
-    if: env.PUBLISH_NIGHTLY == 'true' && github.repository_owner == 'LawnchairLauncher' && github.event_name == 'push' && startsWith(github.ref, 'refs/heads/') && endsWith(github.ref, '-dev')
+    if: github.repository_owner == 'LawnchairLauncher' && github.event_name == 'push' && startsWith(github.ref, 'refs/heads/') && endsWith(github.ref, '-dev')
     needs: final-status
     permissions:
       contents: write
     steps:
+      - name: Prepublishing check
+        run: |
+          if [ "${{ env.PUBLISH_NIGHTLY }}" != "true" ]; then
+            echo "🛑 Publishing is disabled in env."
+            exit 1
+          fi
       - uses: actions/checkout@v6
       - uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
 
   nightly-release:
     runs-on: ubuntu-latest
-    if: env.PUBLISH_NIGHTLY == 'true' && github.repository_owner == 'LawnchairLauncher' && github.event_name == 'push' && startsWith(github.ref, 'refs/heads/') && (endsWith(github.ref, '-dev')
+    if: env.PUBLISH_NIGHTLY == 'true' && github.repository_owner == 'LawnchairLauncher' && github.event_name == 'push' && startsWith(github.ref, 'refs/heads/') && endsWith(github.ref, '-dev')
     needs: final-status
     permissions:
       contents: write

--- a/.github/workflows/release_update.yml
+++ b/.github/workflows/release_update.yml
@@ -23,6 +23,7 @@ on:
 jobs:
   build-release-apk:
     runs-on: ubuntu-latest
+    if: !endsWith(github.ref, '-dev')
     permissions:
       id-token: write
       attestations: write

--- a/.github/workflows/release_update.yml
+++ b/.github/workflows/release_update.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   build-release-apk:
     runs-on: ubuntu-latest
-    if: !endsWith(github.ref, '-dev')
+    if: endsWith(github.ref, '-alpha') || endsWith(github.ref, '-beta') || endsWith(github.ref, '-rc') || endsWith(github.ref, '-stable')
     permissions:
       id-token: write
       attestations: write

--- a/build.gradle
+++ b/build.gradle
@@ -130,7 +130,11 @@ final def buildCommit = providers.exec {
 final def ciBuild = System.getenv("CI") == "true"
 final def ciRef = System.getenv("GITHUB_REF") ?: ""
 final def ciRunNumber = System.getenv("GITHUB_RUN_NUMBER") ?: ""
-final def isReleaseBuild = ciBuild && ciRef.contains("beta")
+final def isReleaseBuild = ciBuild
+        && (ciRef.endsWith("-alpha")
+        || ciRef.endsWith("-beta")
+        || ciRef.endsWith("-rc")
+        || ciRef.endsWith("-stable"))
 final def devReleaseName = ciBuild ? "Dev.(#${ciRunNumber})" : "Dev.(${buildCommit})"
 
 final def version = "16"


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Only allow release CI to publish a release when a branch ends with `-alpha`, `-beta`, `-rc`, `-stable` not `-dev` or anything else which is when the build process start treating it as release development APK.

Additionally make Nightly CI more easy to control.
`
### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Manual

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **New feature** (A non-breaking change that adds functionality)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows so release APK build steps run only for refs ending in `-alpha`, `-beta`, `-rc`, or `-stable`, and aligned Gradle “release build” detection with these suffixes.
  * Added a nightly publishing toggle in CI; nightly release now runs only when enabled and for `-dev` branch pushes.
  * Minor workflow formatting cleanup around the artifact upload section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->