### PR TITLE
fix: threading & lifecycle bugs found in code review

### DIFF
--- a/lawnchair/src/app/lawnchair/AccentColorExtractor.java
+++ b/lawnchair/src/app/lawnchair/AccentColorExtractor.java
@@ -49,7 +49,12 @@ public class AccentColorExtractor extends LocalColorExtractor implements ThemePr
     @Override
     public void setListener(@Nullable Listener listener) {
         mListener = listener;
-        notifyListener();
+        if (listener != null) {
+            mThemeProvider.addListener(this);
+            notifyListener();
+        } else {
+            mThemeProvider.removeListener(this);
+        }
     }
 
     @Nullable

--- a/lawnchair/src/app/lawnchair/bugreport/UploaderService.kt
+++ b/lawnchair/src/app/lawnchair/bugreport/UploaderService.kt
@@ -12,8 +12,8 @@ import androidx.core.content.ContextCompat
 import app.lawnchair.util.requireSystemService
 import com.android.launcher3.R
 import com.android.launcher3.Utilities
-import java.util.LinkedList
 import java.util.Queue
+import java.util.concurrent.ConcurrentLinkedQueue
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -23,9 +23,9 @@ import kotlinx.coroutines.plus
 
 class UploaderService : Service() {
 
-    private var job: Job? = null
+    @Volatile private var job: Job? = null
     private val scope = CoroutineScope(Dispatchers.IO) + CoroutineName("UploaderService")
-    private val uploadQueue: Queue<BugReport> = LinkedList()
+    private val uploadQueue: Queue<BugReport> = ConcurrentLinkedQueue()
 
     override fun onBind(intent: Intent): IBinder {
         TODO("not implemented")
@@ -33,11 +33,16 @@ class UploaderService : Service() {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         if (intent == null) return START_REDELIVER_INTENT
-        uploadQueue.offer(intent.getParcelableExtra("report"))
+        val report = intent.getParcelableExtra<BugReport>("report") ?: return START_STICKY
+        uploadQueue.offer(report)
         if (job == null) {
             job = scope.launch {
-                startUpload()
-                stopSelf()
+                try {
+                    startUpload()
+                } finally {
+                    job = null
+                    stopSelf()
+                }
             }
         }
         return START_STICKY
@@ -45,7 +50,7 @@ class UploaderService : Service() {
 
     private suspend fun startUpload() {
         while (uploadQueue.isNotEmpty()) {
-            var report = uploadQueue.poll()!!
+            var report = uploadQueue.poll() ?: break
             try {
                 report = report.copy(link = UploaderUtils.upload(report))
             } catch (e: Throwable) {

--- a/lawnchair/src/app/lawnchair/bugreport/UploaderService.kt
+++ b/lawnchair/src/app/lawnchair/bugreport/UploaderService.kt
@@ -23,7 +23,10 @@ import kotlinx.coroutines.plus
 
 class UploaderService : Service() {
 
+    private val lock = Any()
+
     @Volatile private var job: Job? = null
+    private var latestStartId = 0
     private val scope = CoroutineScope(Dispatchers.IO) + CoroutineName("UploaderService")
     private val uploadQueue: Queue<BugReport> = ConcurrentLinkedQueue()
 
@@ -34,23 +37,26 @@ class UploaderService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         if (intent == null) return START_REDELIVER_INTENT
         val report = intent.getParcelableExtra<BugReport>("report") ?: return START_STICKY
-        uploadQueue.offer(report)
-        if (job == null) {
-            job = scope.launch {
-                try {
-                    startUpload()
-                } finally {
-                    job = null
-                    stopSelf()
-                }
+        synchronized(lock) {
+            uploadQueue.offer(report)
+            latestStartId = startId
+            if (job == null) {
+                job = scope.launch { startUpload() }
             }
         }
         return START_STICKY
     }
 
     private suspend fun startUpload() {
-        while (uploadQueue.isNotEmpty()) {
-            var report = uploadQueue.poll() ?: break
+        while (true) {
+            // Atomically take the next report, or clear the job and stop looping once
+            // the queue is drained, so a report enqueued concurrently is never dropped.
+            var report = synchronized(lock) {
+                uploadQueue.poll() ?: run {
+                    job = null
+                    null
+                }
+            } ?: break
             try {
                 report = report.copy(link = UploaderUtils.upload(report))
             } catch (e: Throwable) {
@@ -62,6 +68,12 @@ class UploaderService : Service() {
                         .setAction(BugReportReceiver.UPLOAD_COMPLETE_ACTION)
                         .putExtra("report", report),
                 )
+            }
+        }
+        // Only stop the service if no new worker was started while draining.
+        synchronized(lock) {
+            if (job == null) {
+                stopSelf(latestStartId)
             }
         }
     }

--- a/lawnchair/src/app/lawnchair/data/iconoverride/IconOverrideRepository.kt
+++ b/lawnchair/src/app/lawnchair/data/iconoverride/IconOverrideRepository.kt
@@ -26,6 +26,8 @@ class IconOverrideRepository @Inject constructor(
 
     private val scope = MainScope() + CoroutineName("IconOverrideRepository")
     private val dao = AppDatabase.INSTANCE.get(context).iconOverrideDao()
+
+    @Volatile
     private var _overridesMap = mapOf<ComponentKey, IconPickerItem>()
     val overridesMap get() = _overridesMap
 

--- a/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/SyncLiveInformation.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/SyncLiveInformation.kt
@@ -4,9 +4,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import app.lawnchair.preferences2.asState
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @Composable
 fun SyncLiveInformation(
@@ -16,7 +15,7 @@ fun SyncLiveInformation(
 
     LaunchedEffect(enabled) {
         if (enabled) {
-            CoroutineScope(Dispatchers.IO).launch {
+            withContext(Dispatchers.IO) {
                 getLiveInformation()?.let { liveInformation ->
                     liveInformationManager.liveInformation.set(liveInformation)
                 }

--- a/lawnchair/src/app/lawnchair/wallpaper/WallpaperManagerCompat.kt
+++ b/lawnchair/src/app/lawnchair/wallpaper/WallpaperManagerCompat.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.launch
 sealed class WallpaperManagerCompat(val context: Context) {
 
     private val listeners = mutableListOf<OnColorsChangedListener>()
+    private val scope = CoroutineScope(Dispatchers.IO)
     private val colorHints: Int get() = wallpaperColors?.colorHints ?: 0
     val wallpaperManager: WallpaperManager = context.requireSystemService()
     val service = WallpaperService(context)
@@ -31,8 +32,10 @@ sealed class WallpaperManagerCompat(val context: Context) {
     }
 
     protected fun notifyChange() {
-        if (service.getTopWallpapers().isEmpty()) {
-            CoroutineScope(Dispatchers.IO).launch {
+        // Querying/saving wallpapers touches Room, so keep it off the main thread
+        // (notifyChange is invoked from the WallpaperManager color callback on the main looper).
+        scope.launch {
+            if (service.getTopWallpapers().isEmpty()) {
                 service.saveWallpaper(wallpaperManager)
             }
         }

--- a/lawnchair/src/app/lawnchair/wallpaper/WallpaperManagerCompat.kt
+++ b/lawnchair/src/app/lawnchair/wallpaper/WallpaperManagerCompat.kt
@@ -9,12 +9,13 @@ import app.lawnchair.wallpaper.WallpaperColorsCompat.Companion.HINT_SUPPORTS_DAR
 import com.android.launcher3.Utilities
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 
 sealed class WallpaperManagerCompat(val context: Context) {
 
     private val listeners = mutableListOf<OnColorsChangedListener>()
-    private val scope = CoroutineScope(Dispatchers.IO)
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val colorHints: Int get() = wallpaperColors?.colorHints ?: 0
     val wallpaperManager: WallpaperManager = context.requireSystemService()
     val service = WallpaperService(context)


### PR DESCRIPTION
## Summary

Five small, self-contained fixes for threading/lifecycle bugs found while reviewing Lawnchair-owned code. No feature or behavior changes — stability and correctness only.

## Changes

- **fix(bugreport): thread-safe upload queue** — `UploaderService` used a plain `LinkedList` written from the main thread (`onStartCommand`) and read from an IO coroutine, which can corrupt the list or drop reports. Switched to `ConcurrentLinkedQueue`, ignore null `report` extras instead of crashing on `poll()!!`, and reset the job when the upload loop finishes so reports queued afterwards are still processed.
- **fix(theme): register AccentColorExtractor for live color updates** — it implements `ThemeProvider.ColorSchemeChangeListener` but never registered itself, so `onColorSchemeChanged()` was never called and themed widget/RemoteViews colors did not update on color-scheme changes. Register on `setListener(listener)` and unregister on `setListener(null)`, matching the `LocalColorExtractor` lifecycle.
- **fix(wallpaper): keep Room access off the main thread** — `WallpaperManagerCompat.notifyChange()` runs on the main looper (WallpaperManager color callback) and called `service.getTopWallpapers()`, a blocking Room query (`runBlocking`) on the main thread. Moved the query/save into a background coroutine.
- **fix(preferences): avoid leaking a detached coroutine in SyncLiveInformation** — launching `CoroutineScope(Dispatchers.IO)` inside `LaunchedEffect` creates a scope that is never cancelled when the effect restarts/leaves composition; use the effect's scope with `withContext(Dispatchers.IO)`.
- **fix(icons): publish IconOverrideRepository.overridesMap across threads** — `_overridesMap` is written on the main scope and read from icon-loading threads; mark it `@Volatile` so readers observe the latest reference.

## Testing

- `./gradlew compileLawnWithQuickstepGithubDebugKotlin` — BUILD SUCCESSFUL
- `./gradlew spotlessCheck` — passes
- Built a debug APK and smoke-tested on a device; no regressions observed.

## Attribution

These fixes were produced by an AI-assisted code review and written entirely with **Claude Opus 4.8** (ultracode mode) via [Claude Code](https://claude.com/claude-code). Each finding was verified against the source and the change set compiles and passes `spotlessCheck`.

🤖 Written with Claude Opus 4.8 (ultracode) — [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread safety and concurrency handling across background services.
  * Enhanced bug report upload reliability with better queue management.
  * Optimized coroutine lifecycle management for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->