### PR TITLE
fix(wallpaper): downsample carousel thumbnails and scope image loads to the view

### DIFF
--- a/lawnchair/src/app/lawnchair/search/adapter/SearchTargetFactory.kt
+++ b/lawnchair/src/app/lawnchair/search/adapter/SearchTargetFactory.kt
@@ -30,6 +30,7 @@ import app.lawnchair.search.algorithms.data.RecentKeyword
 import app.lawnchair.search.algorithms.data.SettingInfo
 import app.lawnchair.search.algorithms.engine.provider.web.WebSearchProvider
 import app.lawnchair.theme.color.tokens.ColorTokens
+import app.lawnchair.util.calculateInSampleSize
 import app.lawnchair.util.createTextBitmap
 import app.lawnchair.util.file2Uri
 import app.lawnchair.util.mimeCompat
@@ -494,29 +495,6 @@ object FilesTarget {
             Log.w("FilesTarget", "Failed to decode thumbnail", e)
             null
         }
-    }
-
-    /**
-     * We calculate the In Sample Size by a power of 2 so that the decoded bitmap will be as small as
-     * possible while both dimensions remain >= [reqWidth] / [reqHeight]
-     */
-    private fun calculateInSampleSize(
-        rawWidth: Int,
-        rawHeight: Int,
-        reqWidth: Int,
-        reqHeight: Int,
-    ): Int {
-        var inSampleSize = 1
-        if (rawHeight > reqHeight || rawWidth > reqWidth) {
-            // If so we calculate the image at half the dimensions
-            val halfHeight = rawHeight / 2
-            val halfWidth = rawWidth / 2
-            // Then we loop until we find the right sample size by the power of 2
-            while (halfHeight / inSampleSize >= reqHeight && halfWidth / inSampleSize >= reqWidth) {
-                inSampleSize *= 2
-            }
-        }
-        return inSampleSize
     }
 }
 

--- a/lawnchair/src/app/lawnchair/ui/popup/WallpaperCarouselView.kt
+++ b/lawnchair/src/app/lawnchair/ui/popup/WallpaperCarouselView.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.LifecycleOwner
 import app.lawnchair.data.wallpaper.Wallpaper
 import app.lawnchair.data.wallpaper.model.WallpaperViewModel
 import app.lawnchair.launcher
+import app.lawnchair.util.decodeSampledBitmapFromFile
 import app.lawnchair.util.observeOnce
 import app.lawnchair.views.component.IconFrame
 import com.android.launcher3.R
@@ -132,24 +133,7 @@ class WallpaperCarouselView @JvmOverloads constructor(
         val file = File(path).takeIf { it.exists() } ?: return null
         if (reqWidth <= 0) return BitmapFactory.decodeFile(file.path)
         val reqHeight = height.takeIf { it > 0 } ?: reqWidth
-        val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
-        BitmapFactory.decodeFile(file.path, bounds)
-        val options = BitmapFactory.Options().apply {
-            inSampleSize = calculateInSampleSize(bounds.outWidth, bounds.outHeight, reqWidth, reqHeight)
-        }
-        return BitmapFactory.decodeFile(file.path, options)
-    }
-
-    private fun calculateInSampleSize(srcWidth: Int, srcHeight: Int, reqWidth: Int, reqHeight: Int): Int {
-        var inSampleSize = 1
-        if (srcHeight > reqHeight || srcWidth > reqWidth) {
-            val halfHeight = srcHeight / 2
-            val halfWidth = srcWidth / 2
-            while (halfHeight / inSampleSize >= reqHeight && halfWidth / inSampleSize >= reqWidth) {
-                inSampleSize *= 2
-            }
-        }
-        return inSampleSize
+        return decodeSampledBitmapFromFile(file.path, reqWidth, reqHeight)
     }
 
     private fun addImageView(cardView: CardView, bitmap: Bitmap?, isCurrent: Boolean) {

--- a/lawnchair/src/app/lawnchair/ui/popup/WallpaperCarouselView.kt
+++ b/lawnchair/src/app/lawnchair/ui/popup/WallpaperCarouselView.kt
@@ -117,9 +117,12 @@ class WallpaperCarouselView @JvmOverloads constructor(
     }
 
     private fun loadWallpaperImage(wallpaper: Wallpaper, cardView: CardView, isCurrent: Boolean) {
+        // Read view dimensions on the main thread before decoding off-thread.
+        val reqWidth = cardView.layoutParams?.width ?: 0
+        val reqHeight = height.takeIf { it > 0 } ?: reqWidth
         viewScope.launch {
             val bitmap = withContext(Dispatchers.IO) {
-                decodeSampledWallpaper(wallpaper.imagePath, cardView.layoutParams?.width ?: 0)
+                decodeSampledWallpaper(wallpaper.imagePath, reqWidth, reqHeight)
             }
             addImageView(cardView, bitmap, isCurrent)
         }
@@ -129,10 +132,9 @@ class WallpaperCarouselView @JvmOverloads constructor(
      * Decode the wallpaper roughly at the size it is shown at. Carousel thumbnails are small, so
      * decoding full-resolution wallpapers (which can be several megabytes each) risks OutOfMemory.
      */
-    private fun decodeSampledWallpaper(path: String, reqWidth: Int): Bitmap? {
+    private fun decodeSampledWallpaper(path: String, reqWidth: Int, reqHeight: Int): Bitmap? {
         val file = File(path).takeIf { it.exists() } ?: return null
         if (reqWidth <= 0) return BitmapFactory.decodeFile(file.path)
-        val reqHeight = height.takeIf { it > 0 } ?: reqWidth
         return decodeSampledBitmapFromFile(file.path, reqWidth, reqHeight)
     }
 

--- a/lawnchair/src/app/lawnchair/ui/popup/WallpaperCarouselView.kt
+++ b/lawnchair/src/app/lawnchair/ui/popup/WallpaperCarouselView.kt
@@ -27,6 +27,8 @@ import com.android.launcher3.util.Themes
 import java.io.File
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -45,6 +47,7 @@ class WallpaperCarouselView @JvmOverloads constructor(
         setBackgroundWithRadius(Themes.getColorAccent(context), 100F)
     }
     private val loadingView = ProgressBar(context).apply { isIndeterminate = true }
+    private val viewScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
     init {
         orientation = HORIZONTAL
@@ -113,10 +116,40 @@ class WallpaperCarouselView @JvmOverloads constructor(
     }
 
     private fun loadWallpaperImage(wallpaper: Wallpaper, cardView: CardView, isCurrent: Boolean) {
-        CoroutineScope(Dispatchers.IO).launch {
-            val bitmap = File(wallpaper.imagePath).takeIf { it.exists() }?.let { BitmapFactory.decodeFile(it.path) }
-            withContext(Dispatchers.Main) { addImageView(cardView, bitmap, isCurrent) }
+        viewScope.launch {
+            val bitmap = withContext(Dispatchers.IO) {
+                decodeSampledWallpaper(wallpaper.imagePath, cardView.layoutParams?.width ?: 0)
+            }
+            addImageView(cardView, bitmap, isCurrent)
         }
+    }
+
+    /**
+     * Decode the wallpaper roughly at the size it is shown at. Carousel thumbnails are small, so
+     * decoding full-resolution wallpapers (which can be several megabytes each) risks OutOfMemory.
+     */
+    private fun decodeSampledWallpaper(path: String, reqWidth: Int): Bitmap? {
+        val file = File(path).takeIf { it.exists() } ?: return null
+        if (reqWidth <= 0) return BitmapFactory.decodeFile(file.path)
+        val reqHeight = height.takeIf { it > 0 } ?: reqWidth
+        val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeFile(file.path, bounds)
+        val options = BitmapFactory.Options().apply {
+            inSampleSize = calculateInSampleSize(bounds.outWidth, bounds.outHeight, reqWidth, reqHeight)
+        }
+        return BitmapFactory.decodeFile(file.path, options)
+    }
+
+    private fun calculateInSampleSize(srcWidth: Int, srcHeight: Int, reqWidth: Int, reqHeight: Int): Int {
+        var inSampleSize = 1
+        if (srcHeight > reqHeight || srcWidth > reqWidth) {
+            val halfHeight = srcHeight / 2
+            val halfWidth = srcWidth / 2
+            while (halfHeight / inSampleSize >= reqHeight && halfWidth / inSampleSize >= reqWidth) {
+                inSampleSize *= 2
+            }
+        }
+        return inSampleSize
     }
 
     private fun addImageView(cardView: CardView, bitmap: Bitmap?, isCurrent: Boolean) {
@@ -176,6 +209,11 @@ class WallpaperCarouselView @JvmOverloads constructor(
                 gravity = Gravity.CENTER
             },
         )
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        viewScope.cancel()
     }
 
     override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {

--- a/lawnchair/src/app/lawnchair/util/LawnchairUtils.kt
+++ b/lawnchair/src/app/lawnchair/util/LawnchairUtils.kt
@@ -29,6 +29,7 @@ import android.content.pm.PackageManager
 import android.content.pm.ResolveInfo
 import android.content.res.Resources
 import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.RectF
@@ -418,3 +419,32 @@ inline fun <T> listWhileNotNull(generator: () -> T?): List<T> = mutableListOf<T>
 fun String.toTitleCase(): String = splitToSequence(" ")
     .map { word -> word.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() } }
     .joinToString(" ")
+
+/**
+ * Calculate an `inSampleSize` as a power of 2 so that a decoded bitmap stays as small as possible
+ * while both dimensions remain >= [reqWidth] / [reqHeight].
+ */
+fun calculateInSampleSize(rawWidth: Int, rawHeight: Int, reqWidth: Int, reqHeight: Int): Int {
+    var inSampleSize = 1
+    if (rawHeight > reqHeight || rawWidth > reqWidth) {
+        val halfHeight = rawHeight / 2
+        val halfWidth = rawWidth / 2
+        while (halfHeight / inSampleSize >= reqHeight && halfWidth / inSampleSize >= reqWidth) {
+            inSampleSize *= 2
+        }
+    }
+    return inSampleSize
+}
+
+/**
+ * Decode a bitmap from [path] downsampled to roughly [reqWidth] x [reqHeight] to avoid loading
+ * full-resolution images into small views. Returns null if the file cannot be decoded.
+ */
+fun decodeSampledBitmapFromFile(path: String, reqWidth: Int, reqHeight: Int): Bitmap? {
+    val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+    BitmapFactory.decodeFile(path, bounds)
+    val options = BitmapFactory.Options().apply {
+        inSampleSize = calculateInSampleSize(bounds.outWidth, bounds.outHeight, reqWidth, reqHeight)
+    }
+    return BitmapFactory.decodeFile(path, options)
+}


### PR DESCRIPTION
## Summary

Follow-up from a code review, focused on `WallpaperCarouselView`.

- **Downsample thumbnails (OOM fix)** — the carousel decoded full-resolution wallpapers (often several MB each) into small thumbnail cards via `BitmapFactory.decodeFile(path)` with no `inSampleSize`. With many/large wallpapers this risks `OutOfMemory`. It now decodes with an `inSampleSize` computed from the thumbnail width.
- **Scope image loads to the view** — each thumbnail load created a fresh `CoroutineScope(Dispatchers.IO)` that was never cancelled. Image loads now run on a single view-scoped `CoroutineScope` that is cancelled in `onDetachedFromWindow`.

The user-initiated `setWallpaper` path is intentionally left as-is so that setting the wallpaper still completes even if the popup is dismissed.

## Testing

- `./gradlew compileLawnWithQuickstepGithubDebugKotlin` — BUILD SUCCESSFUL
- `./gradlew spotlessCheck` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved wallpaper thumbnail loading using more efficient downsampled bitmap decoding.
  * Updated wallpaper preview rendering to better handle in-flight work as the view attaches/detaches.
  * Standardized downsampling logic for thumbnails/icons to reduce duplicated processing and improve consistency.
* **Bug Fixes**
  * Prevented unnecessary thumbnail/background work after leaving the wallpaper selection view for more reliable cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->