### PR TITLE
fix(qsb): launch Startpage app from dock search bar

### DIFF
--- a/lawnchair/src/app/lawnchair/qsb/providers/Startpage.kt
+++ b/lawnchair/src/app/lawnchair/qsb/providers/Startpage.kt
@@ -1,9 +1,6 @@
 package app.lawnchair.qsb.providers
 
-import app.lawnchair.animateToAllApps
-import app.lawnchair.preferences.PreferenceManager
 import app.lawnchair.qsb.ThemingMethod
-import com.android.launcher3.Launcher
 import com.android.launcher3.R
 
 data object Startpage : QsbSearchProvider(
@@ -11,20 +8,8 @@ data object Startpage : QsbSearchProvider(
     name = R.string.search_provider_startpage,
     icon = R.drawable.ic_startpage,
     themingMethod = ThemingMethod.TINT,
-    packageName = "",
+    packageName = "com.startpage.app",
+    className = "org.chromium.chrome.browser.searchwidget.SearchActivity",
     website = "https://startpage.com/?segment=startpage.lawnchair",
-    type = QsbSearchProviderType.LOCAL,
     sponsored = false,
-) {
-    override suspend fun launch(launcher: Launcher, forceWebsite: Boolean) {
-        val prefs = PreferenceManager.getInstance(launcher)
-        val useWebSuggestions = prefs.searchResultStartPageSuggestion.get()
-
-        if (useWebSuggestions) {
-            launcher.animateToAllApps()
-            launcher.appsView.searchUiManager.editText?.showKeyboard()
-        } else {
-            super.launch(launcher, forceWebsite)
-        }
-    }
-}
+)


### PR DESCRIPTION
## Summary

Fixes the Startpage QSB provider so tapping the dock search bar launches the Startpage app instead of opening Lawnchair's app drawer search.

## Problem

The Startpage provider was configured as a local provider with no package name. Because of this, when Startpage was selected as the dock search provider, tapping the search bar opened Lawnchair's app drawer search instead of launching Startpage.

## Solution

Configure Startpage with its Android package and search activity:

- `packageName = "com.startpage.app"`
- `className = "org.chromium.chrome.browser.searchwidget.SearchActivity"`

Also removed the custom `launch()` override so the provider uses the default `QsbSearchProvider` launch behavior.

## Testing

Tested on:

- Device: Google Pixel 8
- Android version: 16
- SDK version: 36
- Startpage version: 147.0.7727.55.107
- Search provider: Startpage

### Steps tested

1. Added the search bar to the dock
2. Set the search provider to Startpage
3. Returned to the home screen
4. Tapped the dock search bar
5. Confirmed the Startpage search activity launches instead of app drawer search

### Additional verification

Verified the Startpage search activity can be launched directly via ADB:

```bash
adb shell am start -n com.startpage.app/org.chromium.chrome.browser.searchwidget.SearchActivity
```

ADB output:

```text
Starting: Intent { cmp=com.startpage.app/org.chromium.chrome.browser.searchwidget.SearchActivity }
```

A subsequent launch correctly brought the existing Startpage task to the foreground:

```text
Warning: Activity not started, its current task has been brought to the front
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal architecture of the Startpage search provider by transitioning from custom launch logic to a configuration-driven approach, improving code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->