### PR TITLE
feat(icons): transparent icon backgrounds for adaptive icons

### DIFF
--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -278,8 +278,8 @@
     <string name="twoline_label">Use multiple lines</string>
 
     <!-- Icon-related settings -->
-    <string name="transparent_background_icons_label">Transparent themed icons</string>
-    <string name="transparent_background_icons_description">Use transparent background on themed icons</string>
+    <string name="transparent_background_icons_label">Transparent icon backgrounds</string>
+    <string name="transparent_background_icons_description">Remove the automatic white background added behind icons with transparent areas</string>
 
     <string name="auto_adaptive_icons_label">Auto-adaptive icons</string>
     <string name="auto_adaptive_icons_description">For all non-adaptive icons</string>

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -279,7 +279,7 @@
 
     <!-- Icon-related settings -->
     <string name="transparent_background_icons_label">Transparent icon backgrounds</string>
-    <string name="transparent_background_icons_description">Remove the automatic white background added behind icons with transparent areas</string>
+    <string name="transparent_background_icons_description">For themed icons and auto-adaptive icons</string>
 
     <string name="auto_adaptive_icons_label">Auto-adaptive icons</string>
     <string name="auto_adaptive_icons_description">For all non-adaptive icons</string>

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/GeneralPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/GeneralPreferences.kt
@@ -158,9 +158,10 @@ fun GeneralPreferences() {
                     subtitle = iconStyleSubtitle,
                 )
             }
+            val transparentIconBackground = prefs.transparentIconBackground.getAdapter()
             Item {
                 SwitchPreference(
-                    adapter = prefs.transparentIconBackground.getAdapter(),
+                    adapter = transparentIconBackground,
                     label = stringResource(id = R.string.transparent_background_icons_label),
                     description = stringResource(id = R.string.transparent_background_icons_description),
                 )
@@ -190,7 +191,7 @@ fun GeneralPreferences() {
             }
             Item(
                 "wrap_adaptive_icons",
-                wrapAdaptiveIcons.state.value,
+                wrapAdaptiveIcons.state.value && !transparentIconBackground.state.value,
             ) {
                 SliderPreference(
                     label = stringResource(id = R.string.background_lightness_label),

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/GeneralPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/GeneralPreferences.kt
@@ -158,10 +158,7 @@ fun GeneralPreferences() {
                     subtitle = iconStyleSubtitle,
                 )
             }
-            Item(
-                "themed_icon",
-                themedIconsEnabled,
-            ) {
+            Item {
                 SwitchPreference(
                     adapter = prefs.transparentIconBackground.getAdapter(),
                     label = stringResource(id = R.string.transparent_background_icons_label),


### PR DESCRIPTION
Adds a **Transparent icon backgrounds** toggle (General → Icons) that removes the automatic white plate Lawnchair draws behind **themed and auto-adaptive icons** (the paths where it generates a wrapper background).

- The preference description reads *"For themed icons and auto-adaptive icons"* to match the actual behavior (it doesn't affect icons that aren't wrapped/themed).
- While the toggle is on, the **Background lightness** slider is hidden — the wrapper colour is forced transparent, so lightness has no effect.
- Depends on the framework half in **LawnchairLauncher/platform_frameworks_libs_systemui#30** (transparent-background changes in `IconPreferences` / `BaseIconFactory`).

> The Samsung Theme Park / Good Lock themed-icon fix that was originally bundled here is split into its own PR — **LawnchairLauncher/platform_frameworks_libs_systemui#31** — with a before/after demo. This PR is scoped to transparent backgrounds only.

> [!NOTE]
> Draft until the framework PR (LawnchairLauncher/platform_frameworks_libs_systemui#30) merges, since the submodule points at that branch; will mark ready and re-point to the merged commit then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Clarified the label and description for the transparent icon background option to better reflect its behavior with themed and auto-adaptive icons.
  * Updated the icons preferences so the transparent background toggle is always available, and the adaptive icon wrapping control is shown only when it won’t conflict with transparency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->