### PR TITLE
perf: Cache PreferenceManager2 in memory

### DIFF
--- a/lawnchair/src/app/lawnchair/DeviceProfileOverrides.kt
+++ b/lawnchair/src/app/lawnchair/DeviceProfileOverrides.kt
@@ -96,20 +96,20 @@ class DeviceProfileOverrides @Inject constructor(
             prefs2: PreferenceManager2,
             defaultGrid: InvariantDeviceProfile.GridOption,
         ) : this(
-            numAllAppsColumns = prefs2.drawerColumns.firstCached(gridOption = defaultGrid, prefs2 = prefs2),
+            numAllAppsColumns = prefs2.drawerColumns.firstCached(gridOption = defaultGrid),
             numFolderRows = prefs.folderRows.get(defaultGrid),
-            numFolderColumns = prefs2.folderColumns.firstCached(gridOption = defaultGrid, prefs2 = prefs2),
+            numFolderColumns = prefs2.folderColumns.firstCached(gridOption = defaultGrid),
 
-            iconSizeFactor = prefs2.homeIconSizeFactor.firstCached(prefs2),
-            allAppsIconSizeFactor = prefs2.drawerIconSizeFactor.firstCached(prefs2),
+            iconSizeFactor = prefs2.homeIconSizeFactor.firstCached(),
+            allAppsIconSizeFactor = prefs2.drawerIconSizeFactor.firstCached(),
             allAppsIconTextSizeFactor =
-            if (prefs2.showIconLabelsInDrawer.firstCached(prefs2)) {
-                prefs2.drawerIconLabelSizeFactor.firstCached(prefs2)
+            if (prefs2.showIconLabelsInDrawer.firstCached()) {
+                prefs2.drawerIconLabelSizeFactor.firstCached()
             } else {
                 0f
             },
 
-            enableTaskbarOnPhone = prefs2.enableTaskbarOnPhone.firstCached(prefs2),
+            enableTaskbarOnPhone = prefs2.enableTaskbarOnPhone.firstCached(),
         )
 
         fun applyUi(idp: InvariantDeviceProfile) {
@@ -145,12 +145,12 @@ class DeviceProfileOverrides @Inject constructor(
         constructor(
             prefs2: PreferenceManager2,
         ) : this(
-            enableIconText = prefs2.showIconLabelsOnHomeScreen.firstCached(prefs2),
-            iconTextSizeFactor = prefs2.homeIconLabelSizeFactor.firstCached(prefs2),
-            enableIconTextFolder = prefs2.showIconLabelsOnHomeScreenFolder.firstCached(prefs2),
-            iconFolderTextSizeFactor = prefs2.homeIconLabelFolderSizeFactor.firstCached(prefs2),
-            enableAllAppsIconText = prefs2.showIconLabelsInDrawer.firstCached(prefs2),
-            allAppsIconTextSizeFactor = prefs2.drawerIconLabelSizeFactor.firstCached(prefs2),
+            enableIconText = prefs2.showIconLabelsOnHomeScreen.firstCached(),
+            iconTextSizeFactor = prefs2.homeIconLabelSizeFactor.firstCached(),
+            enableIconTextFolder = prefs2.showIconLabelsOnHomeScreenFolder.firstCached(),
+            iconFolderTextSizeFactor = prefs2.homeIconLabelFolderSizeFactor.firstCached(),
+            enableAllAppsIconText = prefs2.showIconLabelsInDrawer.firstCached(),
+            allAppsIconTextSizeFactor = prefs2.drawerIconLabelSizeFactor.firstCached(),
         )
 
         constructor(

--- a/lawnchair/src/app/lawnchair/DeviceProfileOverrides.kt
+++ b/lawnchair/src/app/lawnchair/DeviceProfileOverrides.kt
@@ -3,7 +3,7 @@ package app.lawnchair
 import android.content.Context
 import app.lawnchair.preferences.PreferenceManager
 import app.lawnchair.preferences2.PreferenceManager2
-import app.lawnchair.preferences2.firstBlocking
+import app.lawnchair.preferences2.firstCached
 import com.android.launcher3.InvariantDeviceProfile
 import com.android.launcher3.InvariantDeviceProfile.INDEX_DEFAULT
 import com.android.launcher3.InvariantDeviceProfile.INDEX_LANDSCAPE
@@ -14,7 +14,6 @@ import com.android.launcher3.dagger.LauncherAppComponent
 import com.android.launcher3.dagger.LauncherAppSingleton
 import com.android.launcher3.util.DaggerSingletonObject
 import com.android.launcher3.util.SafeCloseable
-import com.patrykmichalik.opto.core.firstBlocking
 import javax.inject.Inject
 
 @LauncherAppSingleton
@@ -97,20 +96,20 @@ class DeviceProfileOverrides @Inject constructor(
             prefs2: PreferenceManager2,
             defaultGrid: InvariantDeviceProfile.GridOption,
         ) : this(
-            numAllAppsColumns = prefs2.drawerColumns.firstBlocking(gridOption = defaultGrid),
+            numAllAppsColumns = prefs2.drawerColumns.firstCached(gridOption = defaultGrid, prefs2 = prefs2),
             numFolderRows = prefs.folderRows.get(defaultGrid),
-            numFolderColumns = prefs2.folderColumns.firstBlocking(gridOption = defaultGrid),
+            numFolderColumns = prefs2.folderColumns.firstCached(gridOption = defaultGrid, prefs2 = prefs2),
 
-            iconSizeFactor = prefs2.homeIconSizeFactor.firstBlocking(),
-            allAppsIconSizeFactor = prefs2.drawerIconSizeFactor.firstBlocking(),
+            iconSizeFactor = prefs2.homeIconSizeFactor.firstCached(prefs2),
+            allAppsIconSizeFactor = prefs2.drawerIconSizeFactor.firstCached(prefs2),
             allAppsIconTextSizeFactor =
-            if (prefs2.showIconLabelsInDrawer.firstBlocking()) {
-                prefs2.drawerIconLabelSizeFactor.firstBlocking()
+            if (prefs2.showIconLabelsInDrawer.firstCached(prefs2)) {
+                prefs2.drawerIconLabelSizeFactor.firstCached(prefs2)
             } else {
                 0f
             },
 
-            enableTaskbarOnPhone = prefs2.enableTaskbarOnPhone.firstBlocking(),
+            enableTaskbarOnPhone = prefs2.enableTaskbarOnPhone.firstCached(prefs2),
         )
 
         fun applyUi(idp: InvariantDeviceProfile) {
@@ -146,12 +145,12 @@ class DeviceProfileOverrides @Inject constructor(
         constructor(
             prefs2: PreferenceManager2,
         ) : this(
-            enableIconText = prefs2.showIconLabelsOnHomeScreen.firstBlocking(),
-            iconTextSizeFactor = prefs2.homeIconLabelSizeFactor.firstBlocking(),
-            enableIconTextFolder = prefs2.showIconLabelsOnHomeScreenFolder.firstBlocking(),
-            iconFolderTextSizeFactor = prefs2.homeIconLabelFolderSizeFactor.firstBlocking(),
-            enableAllAppsIconText = prefs2.showIconLabelsInDrawer.firstBlocking(),
-            allAppsIconTextSizeFactor = prefs2.drawerIconLabelSizeFactor.firstBlocking(),
+            enableIconText = prefs2.showIconLabelsOnHomeScreen.firstCached(prefs2),
+            iconTextSizeFactor = prefs2.homeIconLabelSizeFactor.firstCached(prefs2),
+            enableIconTextFolder = prefs2.showIconLabelsOnHomeScreenFolder.firstCached(prefs2),
+            iconFolderTextSizeFactor = prefs2.homeIconLabelFolderSizeFactor.firstCached(prefs2),
+            enableAllAppsIconText = prefs2.showIconLabelsInDrawer.firstCached(prefs2),
+            allAppsIconTextSizeFactor = prefs2.drawerIconLabelSizeFactor.firstCached(prefs2),
         )
 
         constructor(

--- a/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
+++ b/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
@@ -324,7 +324,7 @@ class LawnchairLauncher : QuickstepLauncher() {
     }
 
     override fun showDefaultOptions(x: Float, y: Float) {
-        val showWallpaperCarousel = "+carousel" in preferenceManager2.launcherPopupOrder.firstCached(preferenceManager2)
+        val showWallpaperCarousel = "+carousel" in preferenceManager2.launcherPopupOrder.firstCached()
 
         if (showWallpaperCarousel) {
             show<LawnchairLauncher>(
@@ -494,7 +494,7 @@ class LawnchairLauncher : QuickstepLauncher() {
      */
     private fun reloadIconsIfNeeded() {
         if (
-            preferenceManager2.alwaysReloadIcons.firstCached(preferenceManager2)
+            preferenceManager2.alwaysReloadIcons.firstCached()
         ) {
             LauncherAppState.getInstance(this).model.reloadIfActive()
         }

--- a/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
+++ b/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
@@ -81,7 +81,7 @@ import com.android.launcher3.widget.RoundedCornerEnforcement
 import com.android.systemui.plugins.shared.LauncherOverlayManager
 import com.android.systemui.shared.system.QuickStepContract
 import com.kieronquinn.app.smartspacer.sdk.client.SmartspacerClient
-import com.patrykmichalik.opto.core.firstBlocking
+import app.lawnchair.preferences2.firstCached
 import com.patrykmichalik.opto.core.onEach
 import dev.kdrag0n.monet.theme.ColorScheme
 import java.util.stream.Stream
@@ -324,7 +324,7 @@ class LawnchairLauncher : QuickstepLauncher() {
     }
 
     override fun showDefaultOptions(x: Float, y: Float) {
-        val showWallpaperCarousel = "+carousel" in preferenceManager2.launcherPopupOrder.firstBlocking()
+        val showWallpaperCarousel = "+carousel" in preferenceManager2.launcherPopupOrder.firstCached(preferenceManager2)
 
         if (showWallpaperCarousel) {
             show<LawnchairLauncher>(
@@ -494,7 +494,7 @@ class LawnchairLauncher : QuickstepLauncher() {
      */
     private fun reloadIconsIfNeeded() {
         if (
-            preferenceManager2.alwaysReloadIcons.firstBlocking()
+            preferenceManager2.alwaysReloadIcons.firstCached(preferenceManager2)
         ) {
             LauncherAppState.getInstance(this).model.reloadIfActive()
         }

--- a/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
+++ b/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
@@ -42,6 +42,7 @@ import app.lawnchair.gestures.ui.LawnchairShortcutActivity
 import app.lawnchair.nexuslauncher.OverlayCallbackImpl
 import app.lawnchair.preferences.PreferenceManager
 import app.lawnchair.preferences2.PreferenceManager2
+import app.lawnchair.preferences2.firstCached
 import app.lawnchair.root.RootHelperManager
 import app.lawnchair.root.RootNotAvailableException
 import app.lawnchair.theme.ThemeProvider
@@ -81,7 +82,6 @@ import com.android.launcher3.widget.RoundedCornerEnforcement
 import com.android.systemui.plugins.shared.LauncherOverlayManager
 import com.android.systemui.shared.system.QuickStepContract
 import com.kieronquinn.app.smartspacer.sdk.client.SmartspacerClient
-import app.lawnchair.preferences2.firstCached
 import com.patrykmichalik.opto.core.onEach
 import dev.kdrag0n.monet.theme.ColorScheme
 import java.util.stream.Stream

--- a/lawnchair/src/app/lawnchair/allapps/AllAppsSearchInput.kt
+++ b/lawnchair/src/app/lawnchair/allapps/AllAppsSearchInput.kt
@@ -127,7 +127,7 @@ class AllAppsSearchInput(context: Context, attrs: AttributeSet?) :
         micIcon = ViewCompat.requireViewById(this, R.id.mic_btn)
         lensIcon = ViewCompat.requireViewById(this, R.id.lens_btn)
 
-        val shouldShowIcons = prefs2.matchHotseatQsbStyle.firstCached(prefs2)
+        val shouldShowIcons = prefs2.matchHotseatQsbStyle.firstCached()
 
         val searchProvider = getSearchProvider(context, prefs2)
         val isGoogle = searchProvider == Google || searchProvider == GoogleGo || searchProvider == PixelSearch
@@ -190,7 +190,7 @@ class AllAppsSearchInput(context: Context, attrs: AttributeSet?) :
         val currentPaddingRight = initialPaddingRight
         input.onFocusChangeListener = OnFocusChangeListener { _, hasFocus ->
             if (hasFocus) {
-                if (prefs2.searchAlgorithm.firstCached(prefs2) != LawnchairSearchAlgorithm.APP_SEARCH) {
+                if (prefs2.searchAlgorithm.firstCached() != LawnchairSearchAlgorithm.APP_SEARCH) {
                     input.setHint(R.string.all_apps_device_search_hint)
                 } else {
                     input.setHint(R.string.all_apps_search_bar_hint)
@@ -246,7 +246,7 @@ class AllAppsSearchInput(context: Context, attrs: AttributeSet?) :
             },
         )
 
-        val hide = prefs2.hideAppDrawerSearchBar.firstCached(prefs2)
+        val hide = prefs2.hideAppDrawerSearchBar.firstCached()
         if (hide) {
             isInvisible = true
             layoutParams.height = 0

--- a/lawnchair/src/app/lawnchair/allapps/AllAppsSearchInput.kt
+++ b/lawnchair/src/app/lawnchair/allapps/AllAppsSearchInput.kt
@@ -149,7 +149,7 @@ class AllAppsSearchInput(context: Context, attrs: AttributeSet?) :
             }
         }
 
-        prefs2.themedHotseatQsb.subscribeBlocking(scope = viewAttachedScope) { themed ->
+        prefs2.themedHotseatQsb.subscribeBlocking(prefs2 = prefs2, scope = viewAttachedScope) { themed ->
             with(searchIcon) {
                 isVisible = true
 

--- a/lawnchair/src/app/lawnchair/allapps/AllAppsSearchInput.kt
+++ b/lawnchair/src/app/lawnchair/allapps/AllAppsSearchInput.kt
@@ -54,7 +54,7 @@ import com.android.launcher3.allapps.search.AllAppsSearchBarController
 import com.android.launcher3.search.SearchCallback
 import com.android.launcher3.util.Themes
 import com.android.systemui.shared.system.BlurUtils
-import com.patrykmichalik.opto.core.firstBlocking
+import app.lawnchair.preferences2.firstCached
 import java.util.Locale
 import kotlin.math.max
 import kotlinx.coroutines.launch
@@ -127,7 +127,7 @@ class AllAppsSearchInput(context: Context, attrs: AttributeSet?) :
         micIcon = ViewCompat.requireViewById(this, R.id.mic_btn)
         lensIcon = ViewCompat.requireViewById(this, R.id.lens_btn)
 
-        val shouldShowIcons = prefs2.matchHotseatQsbStyle.firstBlocking()
+        val shouldShowIcons = prefs2.matchHotseatQsbStyle.firstCached(prefs2)
 
         val searchProvider = getSearchProvider(context, prefs2)
         val isGoogle = searchProvider == Google || searchProvider == GoogleGo || searchProvider == PixelSearch
@@ -190,7 +190,7 @@ class AllAppsSearchInput(context: Context, attrs: AttributeSet?) :
         val currentPaddingRight = initialPaddingRight
         input.onFocusChangeListener = OnFocusChangeListener { _, hasFocus ->
             if (hasFocus) {
-                if (prefs2.searchAlgorithm.firstBlocking() != LawnchairSearchAlgorithm.APP_SEARCH) {
+                if (prefs2.searchAlgorithm.firstCached(prefs2) != LawnchairSearchAlgorithm.APP_SEARCH) {
                     input.setHint(R.string.all_apps_device_search_hint)
                 } else {
                     input.setHint(R.string.all_apps_search_bar_hint)
@@ -246,7 +246,7 @@ class AllAppsSearchInput(context: Context, attrs: AttributeSet?) :
             },
         )
 
-        val hide = prefs2.hideAppDrawerSearchBar.firstBlocking()
+        val hide = prefs2.hideAppDrawerSearchBar.firstCached(prefs2)
         if (hide) {
             isInvisible = true
             layoutParams.height = 0

--- a/lawnchair/src/app/lawnchair/allapps/AllAppsSearchInput.kt
+++ b/lawnchair/src/app/lawnchair/allapps/AllAppsSearchInput.kt
@@ -28,6 +28,7 @@ import androidx.lifecycle.lifecycleScope
 import app.lawnchair.launcher
 import app.lawnchair.preferences.PreferenceManager
 import app.lawnchair.preferences2.PreferenceManager2
+import app.lawnchair.preferences2.firstCached
 import app.lawnchair.preferences2.subscribeBlocking
 import app.lawnchair.qsb.AssistantIconView
 import app.lawnchair.qsb.LawnQsbLayout.Companion.getLensIntent
@@ -54,7 +55,6 @@ import com.android.launcher3.allapps.search.AllAppsSearchBarController
 import com.android.launcher3.search.SearchCallback
 import com.android.launcher3.util.Themes
 import com.android.systemui.shared.system.BlurUtils
-import app.lawnchair.preferences2.firstCached
 import java.util.Locale
 import kotlin.math.max
 import kotlinx.coroutines.launch

--- a/lawnchair/src/app/lawnchair/gestures/IconGestureListener.kt
+++ b/lawnchair/src/app/lawnchair/gestures/IconGestureListener.kt
@@ -7,7 +7,6 @@ import app.lawnchair.gestures.config.GestureHandlerConfig
 import app.lawnchair.gestures.type.GestureType
 import app.lawnchair.launcher
 import app.lawnchair.preferences2.PreferenceManager2
-
 import com.android.launcher3.util.ComponentKey
 import com.android.launcher3.util.VibratorWrapper
 import kotlinx.coroutines.launch

--- a/lawnchair/src/app/lawnchair/gestures/IconGestureListener.kt
+++ b/lawnchair/src/app/lawnchair/gestures/IconGestureListener.kt
@@ -7,7 +7,7 @@ import app.lawnchair.gestures.config.GestureHandlerConfig
 import app.lawnchair.gestures.type.GestureType
 import app.lawnchair.launcher
 import app.lawnchair.preferences2.PreferenceManager2
-import app.lawnchair.util.firstBlocking
+
 import com.android.launcher3.util.ComponentKey
 import com.android.launcher3.util.VibratorWrapper
 import kotlinx.coroutines.launch
@@ -61,7 +61,7 @@ class IconGestureListener(
      * @param gestureType The type of gesture to resolve for the current component */
     private fun resolveGesture(gestureType: GestureType): GestureHandlerConfig? {
         val currentComponentKey = componentKey ?: return null
-        val gesture = prefs.getGestureForApp(currentComponentKey, gestureType).firstBlocking()
+        val gesture = prefs.getGestureForAppCached(currentComponentKey, gestureType)
         return gesture.takeUnless { it is GestureHandlerConfig.NoOp }
     }
 }

--- a/lawnchair/src/app/lawnchair/gestures/ui/CreateActionsScreen.kt
+++ b/lawnchair/src/app/lawnchair/gestures/ui/CreateActionsScreen.kt
@@ -16,7 +16,6 @@ import app.lawnchair.ui.preferences.components.controls.ClickablePreference
 import app.lawnchair.ui.preferences.components.layout.PreferenceLayoutLazyColumn
 import app.lawnchair.ui.preferences.components.layout.preferenceGroupItems
 import com.android.launcher3.R
-import com.patrykmichalik.opto.core.firstBlocking
 import kotlinx.coroutines.launch
 
 @Composable

--- a/lawnchair/src/app/lawnchair/icons/LawnchairThemeManager.kt
+++ b/lawnchair/src/app/lawnchair/icons/LawnchairThemeManager.kt
@@ -86,14 +86,14 @@ constructor(
 
     private fun parseIconStateV2(oldState: IconState?): IconState {
         val currentAppShape: IconShape = try {
-            prefs2.iconShape.firstCached(prefs2)
+            prefs2.iconShape.firstCached()
         } catch (e: Exception) {
             Log.d(TAG, "Error getting icon shape", e)
             IconShape.Circle
         }
 
         val currentFolderShape: IconShape = try {
-            prefs2.folderShape.firstCached(prefs2)
+            prefs2.folderShape.firstCached()
         } catch (e: Exception) {
             Log.d(TAG, "Error getting folder shape", e)
             IconShape.Circle

--- a/lawnchair/src/app/lawnchair/icons/LawnchairThemeManager.kt
+++ b/lawnchair/src/app/lawnchair/icons/LawnchairThemeManager.kt
@@ -14,7 +14,7 @@ import com.android.launcher3.dagger.LauncherAppSingleton
 import com.android.launcher3.graphics.ThemeManager
 import com.android.launcher3.util.DaggerSingletonTracker
 import com.android.launcher3.util.LooperExecutor
-import com.patrykmichalik.opto.core.firstBlocking
+import app.lawnchair.preferences2.firstCached
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.MainScope
@@ -86,14 +86,14 @@ constructor(
 
     private fun parseIconStateV2(oldState: IconState?): IconState {
         val currentAppShape: IconShape = try {
-            prefs2.iconShape.firstBlocking()
+            prefs2.iconShape.firstCached(prefs2)
         } catch (e: Exception) {
             Log.d(TAG, "Error getting icon shape", e)
             IconShape.Circle
         }
 
         val currentFolderShape: IconShape = try {
-            prefs2.folderShape.firstBlocking()
+            prefs2.folderShape.firstCached(prefs2)
         } catch (e: Exception) {
             Log.d(TAG, "Error getting folder shape", e)
             IconShape.Circle

--- a/lawnchair/src/app/lawnchair/icons/LawnchairThemeManager.kt
+++ b/lawnchair/src/app/lawnchair/icons/LawnchairThemeManager.kt
@@ -7,6 +7,7 @@ import app.lawnchair.icons.shape.PathShapeDelegate
 import app.lawnchair.preferences.PreferenceChangeListener
 import app.lawnchair.preferences.PreferenceManager
 import app.lawnchair.preferences2.PreferenceManager2
+import app.lawnchair.preferences2.firstCached
 import com.android.launcher3.LauncherPrefs
 import com.android.launcher3.concurrent.annotations.Ui
 import com.android.launcher3.dagger.ApplicationContext
@@ -14,7 +15,6 @@ import com.android.launcher3.dagger.LauncherAppSingleton
 import com.android.launcher3.graphics.ThemeManager
 import com.android.launcher3.util.DaggerSingletonTracker
 import com.android.launcher3.util.LooperExecutor
-import app.lawnchair.preferences2.firstCached
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.MainScope

--- a/lawnchair/src/app/lawnchair/icons/shape/IconShapeManager.kt
+++ b/lawnchair/src/app/lawnchair/icons/shape/IconShapeManager.kt
@@ -58,7 +58,7 @@ class IconShapeManager @Inject constructor(
         @JvmStatic
         fun getWindowTransitionRadius(context: Context): Float {
             val prefs = PreferenceManager2.getInstance(context)
-            return prefs.iconShape.firstCached(prefs).windowTransitionRadius
+            return prefs.iconShape.firstCached().windowTransitionRadius
         }
     }
 }

--- a/lawnchair/src/app/lawnchair/icons/shape/IconShapeManager.kt
+++ b/lawnchair/src/app/lawnchair/icons/shape/IconShapeManager.kt
@@ -22,13 +22,13 @@ package app.lawnchair.icons.shape
 import android.content.Context
 import android.graphics.drawable.AdaptiveIconDrawable
 import app.lawnchair.preferences2.PreferenceManager2
+import app.lawnchair.preferences2.firstCached
 import com.android.launcher3.Utilities
 import com.android.launcher3.dagger.ApplicationContext
 import com.android.launcher3.dagger.LauncherAppComponent
 import com.android.launcher3.dagger.LauncherAppSingleton
 import com.android.launcher3.util.DaggerSingletonObject
 import com.android.launcher3.util.SafeCloseable
-import app.lawnchair.preferences2.firstCached
 import javax.inject.Inject
 
 @LauncherAppSingleton

--- a/lawnchair/src/app/lawnchair/icons/shape/IconShapeManager.kt
+++ b/lawnchair/src/app/lawnchair/icons/shape/IconShapeManager.kt
@@ -28,7 +28,7 @@ import com.android.launcher3.dagger.LauncherAppComponent
 import com.android.launcher3.dagger.LauncherAppSingleton
 import com.android.launcher3.util.DaggerSingletonObject
 import com.android.launcher3.util.SafeCloseable
-import com.patrykmichalik.opto.core.firstBlocking
+import app.lawnchair.preferences2.firstCached
 import javax.inject.Inject
 
 @LauncherAppSingleton
@@ -56,6 +56,9 @@ class IconShapeManager @Inject constructor(
         fun getSystemIconShape(context: Context) = INSTANCE.get(context).systemIconShape
 
         @JvmStatic
-        fun getWindowTransitionRadius(context: Context) = PreferenceManager2.getInstance(context).iconShape.firstBlocking().windowTransitionRadius
+        fun getWindowTransitionRadius(context: Context): Float {
+            val prefs = PreferenceManager2.getInstance(context)
+            return prefs.iconShape.firstCached(prefs).windowTransitionRadius
+        }
     }
 }

--- a/lawnchair/src/app/lawnchair/nexuslauncher/OverlayCallbackImpl.kt
+++ b/lawnchair/src/app/lawnchair/nexuslauncher/OverlayCallbackImpl.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import app.lawnchair.FeedBridge
 import app.lawnchair.LawnchairLauncher
 import app.lawnchair.preferences2.PreferenceManager2
+import app.lawnchair.preferences2.firstCached
 import com.android.launcher3.Launcher
 import com.android.launcher3.LauncherPrefs
 import com.android.systemui.plugins.shared.LauncherOverlayManager
@@ -17,7 +18,6 @@ import com.google.android.libraries.launcherclient.LauncherClient
 import com.google.android.libraries.launcherclient.LauncherClientCallbacks
 import com.google.android.libraries.launcherclient.LauncherClientService
 import com.google.android.libraries.launcherclient.StaticInteger
-import app.lawnchair.preferences2.firstCached
 
 /**
  * Implements [LauncherOverlay] and passes all the corresponding events to [LauncherClient],

--- a/lawnchair/src/app/lawnchair/nexuslauncher/OverlayCallbackImpl.kt
+++ b/lawnchair/src/app/lawnchair/nexuslauncher/OverlayCallbackImpl.kt
@@ -38,7 +38,7 @@ class OverlayCallbackImpl(private val mLauncher: LawnchairLauncher) :
 
     init {
         val prefs = PreferenceManager2.getInstance(mLauncher)
-        val enableFeed = prefs.enableFeed.firstCached(prefs)
+        val enableFeed = prefs.enableFeed.firstCached()
         mClient = LauncherClient(
             mLauncher,
             this,

--- a/lawnchair/src/app/lawnchair/nexuslauncher/OverlayCallbackImpl.kt
+++ b/lawnchair/src/app/lawnchair/nexuslauncher/OverlayCallbackImpl.kt
@@ -17,7 +17,7 @@ import com.google.android.libraries.launcherclient.LauncherClient
 import com.google.android.libraries.launcherclient.LauncherClientCallbacks
 import com.google.android.libraries.launcherclient.LauncherClientService
 import com.google.android.libraries.launcherclient.StaticInteger
-import com.patrykmichalik.opto.core.firstBlocking
+import app.lawnchair.preferences2.firstCached
 
 /**
  * Implements [LauncherOverlay] and passes all the corresponding events to [LauncherClient],
@@ -37,7 +37,8 @@ class OverlayCallbackImpl(private val mLauncher: LawnchairLauncher) :
     private var mFlags = 0
 
     init {
-        val enableFeed = PreferenceManager2.getInstance(mLauncher).enableFeed.firstBlocking()
+        val prefs = PreferenceManager2.getInstance(mLauncher)
+        val enableFeed = prefs.enableFeed.firstCached(prefs)
         mClient = LauncherClient(
             mLauncher,
             this,

--- a/lawnchair/src/app/lawnchair/preferences/PreferenceAdapter.kt
+++ b/lawnchair/src/app/lawnchair/preferences/PreferenceAdapter.kt
@@ -28,7 +28,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.lawnchair.preferences2.IdpPreference
 import app.lawnchair.preferences2.asState
-import app.lawnchair.preferences2.firstBlocking
+import app.lawnchair.preferences2.firstCached
+import app.lawnchair.preferences2.preferenceManager2
 import com.android.launcher3.InvariantDeviceProfile
 import com.patrykmichalik.opto.domain.Preference
 import kotlin.reflect.KProperty
@@ -127,7 +128,8 @@ fun IdpPreference.getAdapter(): PreferenceAdapter<Int> {
     val context = LocalContext.current
     val idp = remember { InvariantDeviceProfile.INSTANCE.get(context) }
     val defaultGrid = idp.closestProfile
-    val state = get(defaultGrid).collectAsStateWithLifecycle(initialValue = firstBlocking(defaultGrid))
+    val prefs2 = preferenceManager2()
+    val state = get(defaultGrid).collectAsStateWithLifecycle(initialValue = firstCached(defaultGrid, prefs2))
     return createStateAdapter(state = state, set = { set(it, defaultGrid) })
 }
 

--- a/lawnchair/src/app/lawnchair/preferences2/IdpPreference.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/IdpPreference.kt
@@ -1,5 +1,6 @@
 package app.lawnchair.preferences2
 
+import androidx.annotation.Discouraged
 import androidx.compose.runtime.Composable
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
@@ -41,6 +42,7 @@ class IdpPreference(
     }
 }
 
+@Discouraged("This is a blocking read, use firstCached() for non-blocking reads")
 fun IdpPreference.firstBlocking(gridOption: InvariantDeviceProfile.GridOption) = runBlocking { get(gridOption = gridOption).first() }
 
 @JvmOverloads

--- a/lawnchair/src/app/lawnchair/preferences2/IdpPreference.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/IdpPreference.kt
@@ -5,7 +5,9 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import app.lawnchair.LawnchairApp
 import com.android.launcher3.InvariantDeviceProfile
+import kotlin.jvm.JvmOverloads
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.runBlocking
@@ -41,9 +43,10 @@ class IdpPreference(
 
 fun IdpPreference.firstBlocking(gridOption: InvariantDeviceProfile.GridOption) = runBlocking { get(gridOption = gridOption).first() }
 
+@JvmOverloads
 fun IdpPreference.firstCached(
     gridOption: InvariantDeviceProfile.GridOption,
-    prefs2: PreferenceManager2,
+    prefs2: PreferenceManager2 = PreferenceManager2.getInstance(LawnchairApp.instance),
 ): Int {
     val cached = prefs2.getCachedPreferences()
     val value = cached[key]

--- a/lawnchair/src/app/lawnchair/preferences2/IdpPreference.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/IdpPreference.kt
@@ -41,6 +41,19 @@ class IdpPreference(
 
 fun IdpPreference.firstBlocking(gridOption: InvariantDeviceProfile.GridOption) = runBlocking { get(gridOption = gridOption).first() }
 
+fun IdpPreference.firstCached(
+    gridOption: InvariantDeviceProfile.GridOption,
+    prefs2: PreferenceManager2,
+): Int {
+    val cached = prefs2.getCachedPreferences()
+    val value = cached[key]
+    return if (value == null || value == -1) {
+        defaultSelector(gridOption)
+    } else {
+        value
+    }
+}
+
 @Composable
 fun IdpPreference.state(
     gridOption: InvariantDeviceProfile.GridOption,

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceCacheExtensions.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceCacheExtensions.kt
@@ -1,11 +1,19 @@
 package app.lawnchair.preferences2
 
+import app.lawnchair.LawnchairApp
 import com.patrykmichalik.opto.core.PreferenceImpl
 import com.patrykmichalik.opto.core.getFromPreferences
+import kotlin.jvm.JvmOverloads
 
 /**
  * Returns the current value of this preference from the in-memory cache.
+ *
+ * Warning: During initialisation of [PreferenceManager2], pass [this] of [PreferenceManager2] instead
+ * of leaving it blank or else we would be initialising it too early and cause a [StackOverflowError]
  */
-fun <C, S> PreferenceImpl<C, S>.firstCached(prefs2: PreferenceManager2): C {
+@JvmOverloads
+fun <C, S> PreferenceImpl<C, S>.firstCached(
+    prefs2: PreferenceManager2 = PreferenceManager2.getInstance(LawnchairApp.instance),
+): C {
     return getFromPreferences(prefs2.getCachedPreferences())
 }

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceCacheExtensions.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceCacheExtensions.kt
@@ -1,0 +1,11 @@
+package app.lawnchair.preferences2
+
+import com.patrykmichalik.opto.core.PreferenceImpl
+import com.patrykmichalik.opto.core.getFromPreferences
+
+/**
+ * Returns the current value of this preference from the in-memory cache.
+ */
+fun <C, S> PreferenceImpl<C, S>.firstCached(prefs2: PreferenceManager2): C {
+    return getFromPreferences(prefs2.getCachedPreferences())
+}

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
@@ -73,10 +73,15 @@ import com.patrykmichalik.opto.core.PreferenceManager
 import com.patrykmichalik.opto.core.firstBlocking
 import com.patrykmichalik.opto.core.setBlocking
 import javax.inject.Inject
-import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -87,7 +92,7 @@ class PreferenceManager2 @Inject constructor(
 ) : PreferenceManager,
     SafeCloseable {
 
-    private val scope = MainScope()
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private val resourceProvider = DynamicResource.provider(context)
     private var liveInformationManager: LiveInformationManager =
         LiveInformationManager.getInstance(context)
@@ -104,6 +109,14 @@ class PreferenceManager2 @Inject constructor(
     )
 
     override val preferencesDataStore = context.preferencesDataStore
+
+    @Volatile
+    private var cachedPreferences: Preferences = runBlocking {
+        preferencesDataStore.data.first()
+    }
+
+    fun getCachedPreferences(): Preferences = cachedPreferences
+
     private val reloadHelper = ReloadHelper(context)
 
     val darkStatusBar = preference(
@@ -814,7 +827,11 @@ class PreferenceManager2 @Inject constructor(
     )
 
     init {
-        initializeIconShape(iconShape.firstBlocking())
+        preferencesDataStore.data
+            .onEach { cachedPreferences = it }
+            .launchIn(scope)
+
+        initializeIconShape(iconShape.firstCached(this))
         iconShape.get()
             .drop(1)
             .distinctUntilChanged()
@@ -849,6 +866,16 @@ class PreferenceManager2 @Inject constructor(
         }
     }
 
+    fun getGestureForAppCached(key: ComponentKey, gestureType: GestureType): GestureHandlerConfig {
+        val cmp = Converters().fromComponentKey(key)
+        val key = stringPreferencesKey("$cmp:${gestureType.name}")
+        val prefs = getCachedPreferences()
+        return prefs[key]?.let {
+            runCatching { kotlinxJson.decodeFromString<GestureHandlerConfig>(it) }
+                .getOrDefault(GestureHandlerConfig.NoOp)
+        } ?: GestureHandlerConfig.NoOp
+    }
+
     private fun initializeIconShape(shape: IconShape) {
         CustomAdaptiveIconDrawable.sInitialized = true
         CustomAdaptiveIconDrawable.sMaskId = shape.getHashString()
@@ -856,6 +883,7 @@ class PreferenceManager2 @Inject constructor(
     }
 
     override fun close() {
+        scope.cancel()
     }
 
     private fun getRemoteDefault(key: String): String? = liveInformationManager.liveInformation

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
@@ -74,10 +74,9 @@ import com.patrykmichalik.opto.core.firstBlocking
 import com.patrykmichalik.opto.core.setBlocking
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
@@ -85,6 +84,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.runBlocking
 
 @LauncherAppSingleton
 class PreferenceManager2 @Inject constructor(

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceUtils.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceUtils.kt
@@ -3,8 +3,8 @@ package app.lawnchair.preferences2
 import androidx.compose.runtime.Composable
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.lawnchair.util.subscribeBlocking
-import com.patrykmichalik.opto.core.firstBlocking
 import com.patrykmichalik.opto.core.PreferenceImpl
+import com.patrykmichalik.opto.core.firstBlocking
 import com.patrykmichalik.opto.domain.Preference
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.distinctUntilChanged

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceUtils.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceUtils.kt
@@ -4,11 +4,32 @@ import androidx.compose.runtime.Composable
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.lawnchair.util.subscribeBlocking
 import com.patrykmichalik.opto.core.firstBlocking
+import com.patrykmichalik.opto.core.PreferenceImpl
 import com.patrykmichalik.opto.domain.Preference
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 
 @Composable
 fun <C, S> Preference<C, S, *>.asState() = get().collectAsStateWithLifecycle(initialValue = firstBlocking())
+
+@Composable
+fun <C, S> PreferenceImpl<C, S>.asState() = get().collectAsStateWithLifecycle(initialValue = firstCached(preferenceManager2()))
+
+fun <C, S> PreferenceImpl<C, S>.subscribeBlocking(
+    prefs2: PreferenceManager2,
+    scope: CoroutineScope,
+    block: (C) -> Unit,
+) {
+    block(firstCached(prefs2))
+    get()
+        .onEach { block(it) }
+        .drop(1)
+        .distinctUntilChanged()
+        .launchIn(scope = scope)
+}
 
 fun <C, S> Preference<C, S, *>.subscribeBlocking(
     scope: CoroutineScope,

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceUtils.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceUtils.kt
@@ -8,7 +8,7 @@ import com.patrykmichalik.opto.core.firstBlocking
 import com.patrykmichalik.opto.domain.Preference
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.dropWhile
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
@@ -23,11 +23,12 @@ fun <C, S> PreferenceImpl<C, S>.subscribeBlocking(
     scope: CoroutineScope,
     block: (C) -> Unit,
 ) {
-    block(firstCached(prefs2))
+    val initial = firstCached(prefs2)
+    block(initial)
     get()
-        .onEach { block(it) }
-        .drop(1)
         .distinctUntilChanged()
+        .dropWhile { it == initial }
+        .onEach { block(it) }
         .launchIn(scope = scope)
 }
 

--- a/lawnchair/src/app/lawnchair/qsb/LawnQsbLayout.kt
+++ b/lawnchair/src/app/lawnchair/qsb/LawnQsbLayout.kt
@@ -39,7 +39,7 @@ import com.android.launcher3.R
 import com.android.launcher3.qsb.QsbContainerView
 import com.android.launcher3.util.Themes
 import com.android.launcher3.views.ActivityContext
-import com.patrykmichalik.opto.core.firstBlocking
+import app.lawnchair.preferences2.firstCached
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flatMapLatest
@@ -105,7 +105,7 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
         setOnClickListener {
             val launcher = context.launcher
             launcher.lifecycleScope.launch {
-                if (preferenceManager2.matchHotseatQsbStyle.firstBlocking()) {
+                if (preferenceManager2.matchHotseatQsbStyle.firstCached(preferenceManager2)) {
                     launcher.appsView.searchUiManager.editText?.showKeyboard()
                     launcher.animateToAllApps()
                 } else {
@@ -237,7 +237,7 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
             context: Context,
             preferenceManager: PreferenceManager2,
         ): QsbSearchProvider {
-            val provider = preferenceManager.hotseatQsbProvider.firstBlocking()
+            val provider = preferenceManager.hotseatQsbProvider.firstCached(preferenceManager)
 
             return if (provider == AppSearch ||
                 resolveIntent(context, provider.createSearchIntent()) ||

--- a/lawnchair/src/app/lawnchair/qsb/LawnQsbLayout.kt
+++ b/lawnchair/src/app/lawnchair/qsb/LawnQsbLayout.kt
@@ -105,7 +105,7 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
         setOnClickListener {
             val launcher = context.launcher
             launcher.lifecycleScope.launch {
-                if (preferenceManager2.matchHotseatQsbStyle.firstCached(preferenceManager2)) {
+                if (preferenceManager2.matchHotseatQsbStyle.firstCached()) {
                     launcher.appsView.searchUiManager.editText?.showKeyboard()
                     launcher.animateToAllApps()
                 } else {
@@ -237,7 +237,7 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
             context: Context,
             preferenceManager: PreferenceManager2,
         ): QsbSearchProvider {
-            val provider = preferenceManager.hotseatQsbProvider.firstCached(preferenceManager)
+            val provider = preferenceManager.hotseatQsbProvider.firstCached()
 
             return if (provider == AppSearch ||
                 resolveIntent(context, provider.createSearchIntent()) ||

--- a/lawnchair/src/app/lawnchair/qsb/LawnQsbLayout.kt
+++ b/lawnchair/src/app/lawnchair/qsb/LawnQsbLayout.kt
@@ -71,7 +71,7 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
         preferenceManager2 = PreferenceManager2.getInstance(context)
 
         val attachedScope = viewAttachedScope
-        preferenceManager2.strokeColorStyle.subscribeBlocking(scope = attachedScope) {
+        preferenceManager2.strokeColorStyle.subscribeBlocking(prefs2 = preferenceManager2, scope = attachedScope) {
             strokeColor = it
             setUpBackground()
         }
@@ -82,7 +82,7 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
         val isGoogle = searchProvider == Google || searchProvider == GoogleGo || searchProvider == PixelSearch
         val supportsLens = searchProvider == Google || searchProvider == PixelSearch
 
-        preferenceManager2.themedHotseatQsb.subscribeBlocking(scope = attachedScope) { themed ->
+        preferenceManager2.themedHotseatQsb.subscribeBlocking(prefs2 = preferenceManager2, scope = attachedScope) { themed ->
             setUpBackground(themed)
 
             val iconRes = if (themed) searchProvider.themedIcon else searchProvider.icon

--- a/lawnchair/src/app/lawnchair/qsb/LawnQsbLayout.kt
+++ b/lawnchair/src/app/lawnchair/qsb/LawnQsbLayout.kt
@@ -23,6 +23,7 @@ import app.lawnchair.launcher
 import app.lawnchair.launcherNullable
 import app.lawnchair.preferences.PreferenceManager
 import app.lawnchair.preferences2.PreferenceManager2
+import app.lawnchair.preferences2.firstCached
 import app.lawnchair.preferences2.subscribeBlocking
 import app.lawnchair.qsb.providers.AppSearch
 import app.lawnchair.qsb.providers.Google
@@ -39,7 +40,6 @@ import com.android.launcher3.R
 import com.android.launcher3.qsb.QsbContainerView
 import com.android.launcher3.util.Themes
 import com.android.launcher3.views.ActivityContext
-import app.lawnchair.preferences2.firstCached
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flatMapLatest

--- a/lawnchair/src/app/lawnchair/search/algorithms/LawnchairLocalSearchAlgorithm.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/LawnchairLocalSearchAlgorithm.kt
@@ -101,7 +101,7 @@ class LawnchairLocalSearchAlgorithm(context: Context) : LawnchairSearchAlgorithm
         } else {
             currentJob = coroutineScope.launch {
                 val prefs2 = PreferenceManager2.getInstance(context)
-                val maxHistory = prefs2.maxRecentResultCount.firstCached(prefs2)
+                val maxHistory = prefs2.maxRecentResultCount.firstCached()
 
                 val historyResults = historySearchProvider.getRecentKeywords(context, maxHistory)
 
@@ -136,7 +136,7 @@ class LawnchairLocalSearchAlgorithm(context: Context) : LawnchairSearchAlgorithm
         val prefs2 = PreferenceManager2.getInstance(context)
 
         if (prefs.searchResultStartPageSuggestion.get()) {
-            val provider = prefs2.webSuggestionProvider.firstCached(prefs2)
+            val provider = prefs2.webSuggestionProvider.firstCached()
             val webProvider = provider.configure(context)
 
             val providerName = if (webProvider is CustomWebSearchProvider) {

--- a/lawnchair/src/app/lawnchair/search/algorithms/LawnchairLocalSearchAlgorithm.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/LawnchairLocalSearchAlgorithm.kt
@@ -3,6 +3,7 @@ package app.lawnchair.search.algorithms
 import android.content.Context
 import app.lawnchair.preferences.PreferenceManager
 import app.lawnchair.preferences2.PreferenceManager2
+import app.lawnchair.preferences2.firstCached
 import app.lawnchair.search.adapter.SearchLinksTarget
 import app.lawnchair.search.adapter.SearchTargetCompat
 import app.lawnchair.search.adapter.SearchTargetFactory
@@ -32,7 +33,6 @@ import com.android.launcher3.LauncherAppState
 import com.android.launcher3.R
 import com.android.launcher3.allapps.BaseAllAppsAdapter
 import com.android.launcher3.search.SearchCallback
-import app.lawnchair.preferences2.firstCached
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job

--- a/lawnchair/src/app/lawnchair/search/algorithms/LawnchairLocalSearchAlgorithm.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/LawnchairLocalSearchAlgorithm.kt
@@ -32,7 +32,7 @@ import com.android.launcher3.LauncherAppState
 import com.android.launcher3.R
 import com.android.launcher3.allapps.BaseAllAppsAdapter
 import com.android.launcher3.search.SearchCallback
-import com.patrykmichalik.opto.core.firstBlocking
+import app.lawnchair.preferences2.firstCached
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -101,7 +101,7 @@ class LawnchairLocalSearchAlgorithm(context: Context) : LawnchairSearchAlgorithm
         } else {
             currentJob = coroutineScope.launch {
                 val prefs2 = PreferenceManager2.getInstance(context)
-                val maxHistory = prefs2.maxRecentResultCount.firstBlocking()
+                val maxHistory = prefs2.maxRecentResultCount.firstCached(prefs2)
 
                 val historyResults = historySearchProvider.getRecentKeywords(context, maxHistory)
 
@@ -136,7 +136,7 @@ class LawnchairLocalSearchAlgorithm(context: Context) : LawnchairSearchAlgorithm
         val prefs2 = PreferenceManager2.getInstance(context)
 
         if (prefs.searchResultStartPageSuggestion.get()) {
-            val provider = prefs2.webSuggestionProvider.firstBlocking()
+            val provider = prefs2.webSuggestionProvider.firstCached(prefs2)
             val webProvider = provider.configure(context)
 
             val providerName = if (webProvider is CustomWebSearchProvider) {

--- a/lawnchair/src/app/lawnchair/search/algorithms/LawnchairSearchAlgorithm.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/LawnchairSearchAlgorithm.kt
@@ -5,6 +5,7 @@ import app.lawnchair.LawnchairApp
 import app.lawnchair.allapps.views.SearchItemBackground
 import app.lawnchair.allapps.views.SearchResultView.Companion.EXTRA_QUICK_LAUNCH
 import app.lawnchair.preferences2.PreferenceManager2
+import app.lawnchair.preferences2.firstCached
 import app.lawnchair.search.LawnchairSearchAdapterProvider
 import app.lawnchair.search.adapter.START_PAGE
 import app.lawnchair.search.adapter.SearchAdapterItem
@@ -31,7 +32,6 @@ import com.android.launcher3.Utilities
 import com.android.launcher3.allapps.BaseAllAppsAdapter
 import com.android.launcher3.search.SearchAlgorithm
 import com.android.launcher3.search.SearchCallback
-import app.lawnchair.preferences2.firstCached
 
 sealed class LawnchairSearchAlgorithm(
     protected val context: Context,

--- a/lawnchair/src/app/lawnchair/search/algorithms/LawnchairSearchAlgorithm.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/LawnchairSearchAlgorithm.kt
@@ -237,7 +237,7 @@ sealed class LawnchairSearchAlgorithm(
 
         fun create(context: Context): LawnchairSearchAlgorithm {
             val prefs = PreferenceManager2.getInstance(context)
-            val searchAlgorithm = prefs.searchAlgorithm.firstCached(prefs)
+            val searchAlgorithm = prefs.searchAlgorithm.firstCached()
 
             return when {
                 searchAlgorithm == ASI_SEARCH && isASISearchEnabled(context) -> LawnchairASISearchAlgorithm(

--- a/lawnchair/src/app/lawnchair/search/algorithms/LawnchairSearchAlgorithm.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/LawnchairSearchAlgorithm.kt
@@ -31,7 +31,7 @@ import com.android.launcher3.Utilities
 import com.android.launcher3.allapps.BaseAllAppsAdapter
 import com.android.launcher3.search.SearchAlgorithm
 import com.android.launcher3.search.SearchCallback
-import com.patrykmichalik.opto.core.firstBlocking
+import app.lawnchair.preferences2.firstCached
 
 sealed class LawnchairSearchAlgorithm(
     protected val context: Context,
@@ -237,7 +237,7 @@ sealed class LawnchairSearchAlgorithm(
 
         fun create(context: Context): LawnchairSearchAlgorithm {
             val prefs = PreferenceManager2.getInstance(context)
-            val searchAlgorithm = prefs.searchAlgorithm.firstBlocking()
+            val searchAlgorithm = prefs.searchAlgorithm.firstCached(prefs)
 
             return when {
                 searchAlgorithm == ASI_SEARCH && isASISearchEnabled(context) -> LawnchairASISearchAlgorithm(

--- a/lawnchair/src/app/lawnchair/search/algorithms/engine/SectionBuilder.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/engine/SectionBuilder.kt
@@ -6,7 +6,7 @@ import app.lawnchair.search.adapter.SPACE
 import app.lawnchair.search.adapter.SearchTargetCompat
 import app.lawnchair.search.adapter.SearchTargetFactory
 import com.android.launcher3.R
-import com.patrykmichalik.opto.core.firstBlocking
+import app.lawnchair.preferences2.firstCached
 
 sealed interface SectionBuilder {
     /**
@@ -131,7 +131,8 @@ data object HistorySectionBuilder : SectionBuilder {
         factory: SearchTargetFactory,
         results: List<SearchResult>,
     ): List<SearchTargetCompat> {
-        val webSuggestion = PreferenceManager2.getInstance(context).webSuggestionProvider.firstBlocking()
+        val prefs = PreferenceManager2.getInstance(context)
+        val webSuggestion = prefs.webSuggestionProvider.firstCached(prefs)
 
         val history = results.filterIsInstance<SearchResult.History>()
         if (history.isEmpty()) {

--- a/lawnchair/src/app/lawnchair/search/algorithms/engine/SectionBuilder.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/engine/SectionBuilder.kt
@@ -132,7 +132,7 @@ data object HistorySectionBuilder : SectionBuilder {
         results: List<SearchResult>,
     ): List<SearchTargetCompat> {
         val prefs = PreferenceManager2.getInstance(context)
-        val webSuggestion = prefs.webSuggestionProvider.firstCached(prefs)
+        val webSuggestion = prefs.webSuggestionProvider.firstCached()
 
         val history = results.filterIsInstance<SearchResult.History>()
         if (history.isEmpty()) {

--- a/lawnchair/src/app/lawnchair/search/algorithms/engine/SectionBuilder.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/engine/SectionBuilder.kt
@@ -2,11 +2,11 @@ package app.lawnchair.search.algorithms.engine
 
 import android.content.Context
 import app.lawnchair.preferences2.PreferenceManager2
+import app.lawnchair.preferences2.firstCached
 import app.lawnchair.search.adapter.SPACE
 import app.lawnchair.search.adapter.SearchTargetCompat
 import app.lawnchair.search.adapter.SearchTargetFactory
 import com.android.launcher3.R
-import app.lawnchair.preferences2.firstCached
 
 sealed interface SectionBuilder {
     /**

--- a/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/ContactsSearchProvider.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/ContactsSearchProvider.kt
@@ -37,7 +37,7 @@ object ContactsSearchProvider : SearchProvider, SearchPermission {
             return@flow
         }
 
-        val maxResults = prefs2.maxPeopleResultCount.firstCached(prefs2)
+        val maxResults = prefs2.maxPeopleResultCount.firstCached()
 
         // Call the newly encapsulated, private function.
         val contactInfoList = findContactsByName(context, query, maxResults)

--- a/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/ContactsSearchProvider.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/ContactsSearchProvider.kt
@@ -11,7 +11,7 @@ import app.lawnchair.search.algorithms.data.ContactInfo
 import app.lawnchair.search.algorithms.engine.SearchPermission
 import app.lawnchair.search.algorithms.engine.SearchProvider
 import app.lawnchair.search.algorithms.engine.SearchResult
-import com.patrykmichalik.opto.core.firstBlocking
+import app.lawnchair.preferences2.firstCached
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -37,7 +37,7 @@ object ContactsSearchProvider : SearchProvider, SearchPermission {
             return@flow
         }
 
-        val maxResults = prefs2.maxPeopleResultCount.firstBlocking()
+        val maxResults = prefs2.maxPeopleResultCount.firstCached(prefs2)
 
         // Call the newly encapsulated, private function.
         val contactInfoList = findContactsByName(context, query, maxResults)

--- a/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/ContactsSearchProvider.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/ContactsSearchProvider.kt
@@ -7,11 +7,11 @@ import android.provider.ContactsContract
 import android.util.Log
 import app.lawnchair.preferences.PreferenceManager
 import app.lawnchair.preferences2.PreferenceManager2
+import app.lawnchair.preferences2.firstCached
 import app.lawnchair.search.algorithms.data.ContactInfo
 import app.lawnchair.search.algorithms.engine.SearchPermission
 import app.lawnchair.search.algorithms.engine.SearchProvider
 import app.lawnchair.search.algorithms.engine.SearchResult
-import app.lawnchair.preferences2.firstCached
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow

--- a/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/FileSearchProvider.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/FileSearchProvider.kt
@@ -7,6 +7,7 @@ import android.provider.MediaStore
 import android.util.Log
 import app.lawnchair.preferences.PreferenceManager
 import app.lawnchair.preferences2.PreferenceManager2
+import app.lawnchair.preferences2.firstCached
 import app.lawnchair.search.algorithms.data.FileInfo
 import app.lawnchair.search.algorithms.data.FolderInfo
 import app.lawnchair.search.algorithms.data.IFileInfo
@@ -22,7 +23,6 @@ import app.lawnchair.util.isHidden
 import app.lawnchair.util.isRegularFile
 import app.lawnchair.util.mimeType2Extension
 import app.lawnchair.util.videoFileTypes
-import app.lawnchair.preferences2.firstCached
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope

--- a/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/FileSearchProvider.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/FileSearchProvider.kt
@@ -22,7 +22,7 @@ import app.lawnchair.util.isHidden
 import app.lawnchair.util.isRegularFile
 import app.lawnchair.util.mimeType2Extension
 import app.lawnchair.util.videoFileTypes
-import com.patrykmichalik.opto.core.firstBlocking
+import app.lawnchair.preferences2.firstCached
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -54,7 +54,7 @@ object FileSearchProvider : SearchProvider {
         }
 
         val prefs2 = PreferenceManager2.getInstance(context)
-        val maxResults = prefs2.maxFileResultCount.firstBlocking()
+        val maxResults = prefs2.maxFileResultCount.firstCached(prefs2)
 
         // check for permissions:
         val fileAccessManager = FileAccessManager.getInstance(context)

--- a/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/FileSearchProvider.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/FileSearchProvider.kt
@@ -54,7 +54,7 @@ object FileSearchProvider : SearchProvider {
         }
 
         val prefs2 = PreferenceManager2.getInstance(context)
-        val maxResults = prefs2.maxFileResultCount.firstCached(prefs2)
+        val maxResults = prefs2.maxFileResultCount.firstCached()
 
         // check for permissions:
         val fileAccessManager = FileAccessManager.getInstance(context)

--- a/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/SettingsSearchProvider.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/SettingsSearchProvider.kt
@@ -8,7 +8,7 @@ import app.lawnchair.preferences2.PreferenceManager2
 import app.lawnchair.search.algorithms.data.SettingInfo
 import app.lawnchair.search.algorithms.engine.SearchProvider
 import app.lawnchair.search.algorithms.engine.SearchResult
-import com.patrykmichalik.opto.core.firstBlocking
+import app.lawnchair.preferences2.firstCached
 import java.lang.reflect.Modifier
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.Dispatchers
@@ -33,7 +33,7 @@ object SettingsSearchProvider : SearchProvider {
             return@flow
         }
 
-        val maxResults = prefs2.maxSettingsEntryResultCount.firstBlocking()
+        val maxResults = prefs2.maxSettingsEntryResultCount.firstCached(prefs2)
         val settingsInfoList = findSettingsByNameAndAction(query, maxResults)
 
         val searchResults = settingsInfoList.map { settingInfo ->

--- a/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/SettingsSearchProvider.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/SettingsSearchProvider.kt
@@ -5,10 +5,10 @@ import android.provider.Settings
 import android.util.Log
 import app.lawnchair.preferences.PreferenceManager
 import app.lawnchair.preferences2.PreferenceManager2
+import app.lawnchair.preferences2.firstCached
 import app.lawnchair.search.algorithms.data.SettingInfo
 import app.lawnchair.search.algorithms.engine.SearchProvider
 import app.lawnchair.search.algorithms.engine.SearchResult
-import app.lawnchair.preferences2.firstCached
 import java.lang.reflect.Modifier
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.Dispatchers

--- a/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/SettingsSearchProvider.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/SettingsSearchProvider.kt
@@ -33,7 +33,7 @@ object SettingsSearchProvider : SearchProvider {
             return@flow
         }
 
-        val maxResults = prefs2.maxSettingsEntryResultCount.firstCached(prefs2)
+        val maxResults = prefs2.maxSettingsEntryResultCount.firstCached()
         val settingsInfoList = findSettingsByNameAndAction(query, maxResults)
 
         val searchResults = settingsInfoList.map { settingInfo ->

--- a/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/apps/AppSearchProvider.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/apps/AppSearchProvider.kt
@@ -2,12 +2,12 @@ package app.lawnchair.search.algorithms.engine.provider.apps
 
 import android.content.Context
 import app.lawnchair.preferences2.PreferenceManager2
+import app.lawnchair.preferences2.firstCached
 import app.lawnchair.search.algorithms.engine.SearchResult
 import app.lawnchair.search.algorithms.filterHiddenApps
 import com.android.launcher3.model.AllAppsList
 import com.android.launcher3.model.data.AppInfo
 import com.android.launcher3.search.StringMatcherUtility
-import app.lawnchair.preferences2.firstCached
 import java.util.Locale
 
 object AppSearchProvider {

--- a/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/apps/AppSearchProvider.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/apps/AppSearchProvider.kt
@@ -7,17 +7,17 @@ import app.lawnchair.search.algorithms.filterHiddenApps
 import com.android.launcher3.model.AllAppsList
 import com.android.launcher3.model.data.AppInfo
 import com.android.launcher3.search.StringMatcherUtility
-import com.patrykmichalik.opto.core.firstBlocking
+import app.lawnchair.preferences2.firstCached
 import java.util.Locale
 
 object AppSearchProvider {
 
     fun search(context: Context, query: String, allApps: AllAppsList): List<SearchResult.App> {
         val prefs = PreferenceManager2.getInstance(context)
-        val hiddenApps = prefs.hiddenApps.firstBlocking()
-        val hiddenAppsInSearch = prefs.hiddenAppsInSearch.firstBlocking()
-        val maxAppResults = prefs.maxAppSearchResultCount.firstBlocking()
-        val enableFuzzySearch = prefs.enableFuzzySearch.firstBlocking()
+        val hiddenApps = prefs.hiddenApps.firstCached(prefs)
+        val hiddenAppsInSearch = prefs.hiddenAppsInSearch.firstCached(prefs)
+        val maxAppResults = prefs.maxAppSearchResultCount.firstCached(prefs)
+        val enableFuzzySearch = prefs.enableFuzzySearch.firstCached(prefs)
 
         val appResults = if (enableFuzzySearch) {
             fuzzySearch(allApps.data, query, maxAppResults, hiddenApps, hiddenAppsInSearch)

--- a/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/apps/AppSearchProvider.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/apps/AppSearchProvider.kt
@@ -14,10 +14,10 @@ object AppSearchProvider {
 
     fun search(context: Context, query: String, allApps: AllAppsList): List<SearchResult.App> {
         val prefs = PreferenceManager2.getInstance(context)
-        val hiddenApps = prefs.hiddenApps.firstCached(prefs)
-        val hiddenAppsInSearch = prefs.hiddenAppsInSearch.firstCached(prefs)
-        val maxAppResults = prefs.maxAppSearchResultCount.firstCached(prefs)
-        val enableFuzzySearch = prefs.enableFuzzySearch.firstCached(prefs)
+        val hiddenApps = prefs.hiddenApps.firstCached()
+        val hiddenAppsInSearch = prefs.hiddenAppsInSearch.firstCached()
+        val maxAppResults = prefs.maxAppSearchResultCount.firstCached()
+        val enableFuzzySearch = prefs.enableFuzzySearch.firstCached()
 
         val appResults = if (enableFuzzySearch) {
             fuzzySearch(allApps.data, query, maxAppResults, hiddenApps, hiddenAppsInSearch)

--- a/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/web/CustomWebSearchProvider.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/web/CustomWebSearchProvider.kt
@@ -5,7 +5,7 @@ import android.net.Uri
 import android.util.Log
 import app.lawnchair.preferences2.PreferenceManager2
 import com.android.launcher3.R
-import com.patrykmichalik.opto.core.firstBlocking
+import app.lawnchair.preferences2.firstCached
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -48,9 +48,9 @@ object CustomWebSearchProvider : WebSearchProvider {
 
     override fun configure(context: Context): WebSearchProvider {
         val prefs = PreferenceManager2.getInstance(context)
-        searchUrlTemplate = prefs.webSuggestionProviderUrl.firstBlocking()
-        suggestionsUrlTemplate = prefs.webSuggestionProviderSuggestionsUrl.firstBlocking()
-        displayName = prefs.webSuggestionProviderName.firstBlocking()
+        searchUrlTemplate = prefs.webSuggestionProviderUrl.firstCached(prefs)
+        suggestionsUrlTemplate = prefs.webSuggestionProviderSuggestionsUrl.firstCached(prefs)
+        displayName = prefs.webSuggestionProviderName.firstCached(prefs)
         return this
     }
 

--- a/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/web/CustomWebSearchProvider.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/web/CustomWebSearchProvider.kt
@@ -4,8 +4,8 @@ import android.content.Context
 import android.net.Uri
 import android.util.Log
 import app.lawnchair.preferences2.PreferenceManager2
-import com.android.launcher3.R
 import app.lawnchair.preferences2.firstCached
+import com.android.launcher3.R
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow

--- a/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/web/CustomWebSearchProvider.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/web/CustomWebSearchProvider.kt
@@ -48,9 +48,9 @@ object CustomWebSearchProvider : WebSearchProvider {
 
     override fun configure(context: Context): WebSearchProvider {
         val prefs = PreferenceManager2.getInstance(context)
-        searchUrlTemplate = prefs.webSuggestionProviderUrl.firstCached(prefs)
-        suggestionsUrlTemplate = prefs.webSuggestionProviderSuggestionsUrl.firstCached(prefs)
-        displayName = prefs.webSuggestionProviderName.firstCached(prefs)
+        searchUrlTemplate = prefs.webSuggestionProviderUrl.firstCached()
+        suggestionsUrlTemplate = prefs.webSuggestionProviderSuggestionsUrl.firstCached()
+        displayName = prefs.webSuggestionProviderName.firstCached()
         return this
     }
 

--- a/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/web/WebSuggestionProvider.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/web/WebSuggestionProvider.kt
@@ -6,7 +6,7 @@ import app.lawnchair.preferences.PreferenceManager
 import app.lawnchair.preferences2.PreferenceManager2
 import app.lawnchair.search.algorithms.engine.SearchProvider
 import app.lawnchair.search.algorithms.engine.SearchResult
-import com.patrykmichalik.opto.core.firstBlocking
+import app.lawnchair.preferences2.firstCached
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.flow.Flow
@@ -29,9 +29,9 @@ object WebSuggestionProvider : SearchProvider {
             return flow { emit(emptyList()) }
         }
 
-        val provider = prefs2.webSuggestionProvider.firstBlocking()
-        val timeout = prefs2.maxWebSuggestionDelay.firstBlocking()
-        val maxResults = prefs2.maxWebSuggestionResultCount.firstBlocking()
+        val provider = prefs2.webSuggestionProvider.firstCached(prefs2)
+        val timeout = prefs2.maxWebSuggestionDelay.firstCached(prefs2)
+        val maxResults = prefs2.maxWebSuggestionResultCount.firstCached(prefs2)
 
         val webProvider = provider
             .configure(context)

--- a/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/web/WebSuggestionProvider.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/web/WebSuggestionProvider.kt
@@ -29,9 +29,9 @@ object WebSuggestionProvider : SearchProvider {
             return flow { emit(emptyList()) }
         }
 
-        val provider = prefs2.webSuggestionProvider.firstCached(prefs2)
-        val timeout = prefs2.maxWebSuggestionDelay.firstCached(prefs2)
-        val maxResults = prefs2.maxWebSuggestionResultCount.firstCached(prefs2)
+        val provider = prefs2.webSuggestionProvider.firstCached()
+        val timeout = prefs2.maxWebSuggestionDelay.firstCached()
+        val maxResults = prefs2.maxWebSuggestionResultCount.firstCached()
 
         val webProvider = provider
             .configure(context)

--- a/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/web/WebSuggestionProvider.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/web/WebSuggestionProvider.kt
@@ -4,9 +4,9 @@ import android.content.Context
 import android.util.Log
 import app.lawnchair.preferences.PreferenceManager
 import app.lawnchair.preferences2.PreferenceManager2
+import app.lawnchair.preferences2.firstCached
 import app.lawnchair.search.algorithms.engine.SearchProvider
 import app.lawnchair.search.algorithms.engine.SearchResult
-import app.lawnchair.preferences2.firstCached
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.flow.Flow

--- a/lawnchair/src/app/lawnchair/smartspace/SmartspacerView.kt
+++ b/lawnchair/src/app/lawnchair/smartspace/SmartspacerView.kt
@@ -33,7 +33,7 @@ class SmartspacerView(context: Context, attrs: AttributeSet?) : BcSmartspaceView
     private var targetCount = 5
 
     init {
-        prefs2.smartspacerMaxCount.subscribeBlocking(coroutineScope) {
+        prefs2.smartspacerMaxCount.subscribeBlocking(prefs2 = prefs2, scope = coroutineScope) {
             targetCount = it
         }
 

--- a/lawnchair/src/app/lawnchair/theme/ThemeProvider.kt
+++ b/lawnchair/src/app/lawnchair/theme/ThemeProvider.kt
@@ -41,8 +41,8 @@ class ThemeProvider @Inject constructor(
     private val wallpaperManager = WallpaperManagerCompat.INSTANCE.get(context)
     private val coroutineScope = CoroutineScope(Dispatchers.Default)
 
-    private var accentColor: ColorOption = preferenceManager2.accentColor.firstCached(preferenceManager2)
-    private var colorStyle: ColorStyle = preferenceManager2.colorStyle.firstCached(preferenceManager2)
+    private var accentColor: ColorOption = preferenceManager2.accentColor.firstCached()
+    private var colorStyle: ColorStyle = preferenceManager2.colorStyle.firstCached()
 
     private val colorSchemeMap = HashMap<Pair<Int, Style>, ColorScheme>()
     private val listeners = mutableListOf<ColorSchemeChangeListener>()

--- a/lawnchair/src/app/lawnchair/theme/ThemeProvider.kt
+++ b/lawnchair/src/app/lawnchair/theme/ThemeProvider.kt
@@ -9,6 +9,7 @@ import android.os.Looper
 import android.os.PatternMatcher
 import androidx.core.graphics.ColorUtils
 import app.lawnchair.preferences2.PreferenceManager2
+import app.lawnchair.preferences2.firstCached
 import app.lawnchair.theme.color.AndroidColor
 import app.lawnchair.theme.color.ColorOption
 import app.lawnchair.theme.color.ColorStyle
@@ -23,7 +24,6 @@ import com.android.launcher3.dagger.LauncherAppSingleton
 import com.android.launcher3.util.DaggerSingletonObject
 import com.android.launcher3.util.SafeCloseable
 import com.android.systemui.monet.Style
-import app.lawnchair.preferences2.firstCached
 import com.patrykmichalik.opto.core.onEach
 import dev.kdrag0n.colorkt.Color
 import dev.kdrag0n.colorkt.conversion.ConversionGraph.convert

--- a/lawnchair/src/app/lawnchair/theme/ThemeProvider.kt
+++ b/lawnchair/src/app/lawnchair/theme/ThemeProvider.kt
@@ -23,7 +23,7 @@ import com.android.launcher3.dagger.LauncherAppSingleton
 import com.android.launcher3.util.DaggerSingletonObject
 import com.android.launcher3.util.SafeCloseable
 import com.android.systemui.monet.Style
-import com.patrykmichalik.opto.core.firstBlocking
+import app.lawnchair.preferences2.firstCached
 import com.patrykmichalik.opto.core.onEach
 import dev.kdrag0n.colorkt.Color
 import dev.kdrag0n.colorkt.conversion.ConversionGraph.convert
@@ -41,8 +41,8 @@ class ThemeProvider @Inject constructor(
     private val wallpaperManager = WallpaperManagerCompat.INSTANCE.get(context)
     private val coroutineScope = CoroutineScope(Dispatchers.Default)
 
-    private var accentColor: ColorOption = preferenceManager2.accentColor.firstBlocking()
-    private var colorStyle: ColorStyle = preferenceManager2.colorStyle.firstBlocking()
+    private var accentColor: ColorOption = preferenceManager2.accentColor.firstCached(preferenceManager2)
+    private var colorStyle: ColorStyle = preferenceManager2.colorStyle.firstCached(preferenceManager2)
 
     private val colorSchemeMap = HashMap<Pair<Int, Style>, ColorScheme>()
     private val listeners = mutableListOf<ColorSchemeChangeListener>()

--- a/lawnchair/src/app/lawnchair/theme/drawable/DrawableTokens.kt
+++ b/lawnchair/src/app/lawnchair/theme/drawable/DrawableTokens.kt
@@ -159,7 +159,7 @@ object DrawableTokens {
 
         // Get custom color from preferences
         val prefs2 = PreferenceManager2.getInstance(context)
-        val colorOption = prefs2.workProfileTabBackgroundColor.firstCached(prefs2)
+        val colorOption = prefs2.workProfileTabBackgroundColor.firstCached()
         val customColor = colorOption.colorPreferenceEntry.lightColor.invoke(context)
 
         val selectedColor = if (customColor != 0) {

--- a/lawnchair/src/app/lawnchair/theme/drawable/DrawableTokens.kt
+++ b/lawnchair/src/app/lawnchair/theme/drawable/DrawableTokens.kt
@@ -10,9 +10,9 @@ import android.graphics.drawable.RippleDrawable
 import android.graphics.drawable.StateListDrawable
 import androidx.appcompat.content.res.AppCompatResources
 import app.lawnchair.preferences2.PreferenceManager2
+import app.lawnchair.preferences2.firstCached
 import app.lawnchair.theme.color.tokens.ColorTokens
 import com.android.launcher3.R
-import com.patrykmichalik.opto.core.firstBlocking
 
 object DrawableTokens {
 
@@ -159,7 +159,7 @@ object DrawableTokens {
 
         // Get custom color from preferences
         val prefs2 = PreferenceManager2.getInstance(context)
-        val colorOption = prefs2.workProfileTabBackgroundColor.firstBlocking()
+        val colorOption = prefs2.workProfileTabBackgroundColor.firstCached(prefs2)
         val customColor = colorOption.colorPreferenceEntry.lightColor.invoke(context)
 
         val selectedColor = if (customColor != 0) {

--- a/lawnchair/src/app/lawnchair/ui/popup/LauncherOptionsPopup.kt
+++ b/lawnchair/src/app/lawnchair/ui/popup/LauncherOptionsPopup.kt
@@ -5,13 +5,13 @@ import android.widget.Toast
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import app.lawnchair.preferences2.PreferenceManager2.Companion.getInstance
+import app.lawnchair.preferences2.firstCached
 import com.android.launcher3.Launcher
 import com.android.launcher3.R
 import com.android.launcher3.Utilities
 import com.android.launcher3.logging.StatsLogManager.LauncherEvent
 import com.android.launcher3.popup.SystemShortcut
 import com.android.launcher3.views.OptionsPopupView.OptionItem
-import com.patrykmichalik.opto.core.firstBlocking
 import com.patrykmichalik.opto.core.setBlocking
 
 object LauncherOptionsPopup {
@@ -32,7 +32,7 @@ object LauncherOptionsPopup {
     ) {
         val prefs2 = getInstance(launcher)
 
-        val currentOrder = prefs2.launcherPopupOrder.firstBlocking()
+        val currentOrder = prefs2.launcherPopupOrder.firstCached(prefs2)
         val currentOptions = currentOrder.toLauncherOptions()
 
         // check for missing items in current options; if so, add them
@@ -61,9 +61,9 @@ object LauncherOptionsPopup {
         onStartHomeSettings: (View) -> Boolean,
     ): ArrayList<OptionItem> {
         val prefs2 = getInstance(launcher!!)
-        val lockHomeScreen = prefs2.lockHomeScreen.firstBlocking()
+        val lockHomeScreen = prefs2.lockHomeScreen.firstCached(prefs2)
         val optionOrder = prefs2
-            .launcherPopupOrder.firstBlocking().toLauncherOptions()
+            .launcherPopupOrder.firstCached(prefs2).toLauncherOptions()
 
         val wallpaperResString =
             if (Utilities.existsStyleWallpapers(launcher)) R.string.styles_wallpaper_button_text else R.string.wallpapers
@@ -220,17 +220,17 @@ object LauncherOptionsPopup {
     ) {
         val prefs2 = getInstance(launcher)
 
-        val lockHomeScreenButtonOnPopUp = prefs2.lockHomeScreenButtonOnPopUp.firstBlocking()
-        val editHomeScreenButtonOnPopUp = prefs2.editHomeScreenButtonOnPopUp.firstBlocking()
-        val showSystemSettingsEntryOnPopUp = prefs2.showSystemSettingsEntryOnPopUp.firstBlocking()
+        val lockHomeScreenButtonOnPopUp = prefs2.lockHomeScreenButtonOnPopUp.firstCached(prefs2)
+        val editHomeScreenButtonOnPopUp = prefs2.editHomeScreenButtonOnPopUp.firstCached(prefs2)
+        val showSystemSettingsEntryOnPopUp = prefs2.showSystemSettingsEntryOnPopUp.firstCached(prefs2)
 
         val optionOrder = prefs2.launcherPopupOrder
-        val legacyPopupOptionsMigrated = prefs2.legacyPopupOptionsMigrated.firstBlocking()
+        val legacyPopupOptionsMigrated = prefs2.legacyPopupOptionsMigrated.firstCached(prefs2)
 
         if (!legacyPopupOptionsMigrated) {
             prefs2.legacyPopupOptionsMigrated.setBlocking(true)
 
-            val options = optionOrder.firstBlocking().toLauncherOptions()
+            val options = optionOrder.firstCached(prefs2).toLauncherOptions()
 
             options.forEachIndexed { index, item ->
                 if (item.identifier == "lock") {

--- a/lawnchair/src/app/lawnchair/ui/popup/LauncherOptionsPopup.kt
+++ b/lawnchair/src/app/lawnchair/ui/popup/LauncherOptionsPopup.kt
@@ -32,7 +32,7 @@ object LauncherOptionsPopup {
     ) {
         val prefs2 = getInstance(launcher)
 
-        val currentOrder = prefs2.launcherPopupOrder.firstCached(prefs2)
+        val currentOrder = prefs2.launcherPopupOrder.firstCached()
         val currentOptions = currentOrder.toLauncherOptions()
 
         // check for missing items in current options; if so, add them
@@ -61,9 +61,9 @@ object LauncherOptionsPopup {
         onStartHomeSettings: (View) -> Boolean,
     ): ArrayList<OptionItem> {
         val prefs2 = getInstance(launcher!!)
-        val lockHomeScreen = prefs2.lockHomeScreen.firstCached(prefs2)
+        val lockHomeScreen = prefs2.lockHomeScreen.firstCached()
         val optionOrder = prefs2
-            .launcherPopupOrder.firstCached(prefs2).toLauncherOptions()
+            .launcherPopupOrder.firstCached().toLauncherOptions()
 
         val wallpaperResString =
             if (Utilities.existsStyleWallpapers(launcher)) R.string.styles_wallpaper_button_text else R.string.wallpapers
@@ -220,17 +220,17 @@ object LauncherOptionsPopup {
     ) {
         val prefs2 = getInstance(launcher)
 
-        val lockHomeScreenButtonOnPopUp = prefs2.lockHomeScreenButtonOnPopUp.firstCached(prefs2)
-        val editHomeScreenButtonOnPopUp = prefs2.editHomeScreenButtonOnPopUp.firstCached(prefs2)
-        val showSystemSettingsEntryOnPopUp = prefs2.showSystemSettingsEntryOnPopUp.firstCached(prefs2)
+        val lockHomeScreenButtonOnPopUp = prefs2.lockHomeScreenButtonOnPopUp.firstCached()
+        val editHomeScreenButtonOnPopUp = prefs2.editHomeScreenButtonOnPopUp.firstCached()
+        val showSystemSettingsEntryOnPopUp = prefs2.showSystemSettingsEntryOnPopUp.firstCached()
 
         val optionOrder = prefs2.launcherPopupOrder
-        val legacyPopupOptionsMigrated = prefs2.legacyPopupOptionsMigrated.firstCached(prefs2)
+        val legacyPopupOptionsMigrated = prefs2.legacyPopupOptionsMigrated.firstCached()
 
         if (!legacyPopupOptionsMigrated) {
             prefs2.legacyPopupOptionsMigrated.setBlocking(true)
 
-            val options = optionOrder.firstCached(prefs2).toLauncherOptions()
+            val options = optionOrder.firstCached().toLauncherOptions()
 
             options.forEachIndexed { index, item ->
                 if (item.identifier == "lock") {

--- a/lawnchair/src/app/lawnchair/ui/popup/LawnchairShortcut.kt
+++ b/lawnchair/src/app/lawnchair/ui/popup/LawnchairShortcut.kt
@@ -44,7 +44,7 @@ class LawnchairShortcut {
         val CUSTOMIZE =
             SystemShortcut.Factory { activity: LawnchairLauncher, itemInfo, originalView ->
                 val prefs2 = PreferenceManager2.getInstance(activity)
-                if (prefs2.lockHomeScreen.firstCached(prefs2)) {
+                if (prefs2.lockHomeScreen.firstCached()) {
                     null
                 } else {
                     getAppInfo(activity, itemInfo)?.let { Customize(activity, it, itemInfo, originalView) }
@@ -61,7 +61,7 @@ class LawnchairShortcut {
         val UNINSTALL =
             SystemShortcut.Factory { activity: ActivityContext, itemInfo: ItemInfo, view: View ->
                 val prefs2 = PreferenceManager2.INSTANCE.get(activity.asContext())
-                if (prefs2.lockHomeScreen.firstCached(prefs2)) {
+                if (prefs2.lockHomeScreen.firstCached()) {
                     return@Factory null
                 }
                 if (itemInfo.targetComponent == null) {

--- a/lawnchair/src/app/lawnchair/ui/popup/LawnchairShortcut.kt
+++ b/lawnchair/src/app/lawnchair/ui/popup/LawnchairShortcut.kt
@@ -34,7 +34,7 @@ import com.android.launcher3.util.ApplicationInfoWrapper
 import com.android.launcher3.util.ComponentKey
 import com.android.launcher3.util.PackageManagerHelper
 import com.android.launcher3.views.ActivityContext
-import com.patrykmichalik.opto.core.firstBlocking
+import app.lawnchair.preferences2.firstCached
 import java.net.URISyntaxException
 
 class LawnchairShortcut {
@@ -43,7 +43,8 @@ class LawnchairShortcut {
 
         val CUSTOMIZE =
             SystemShortcut.Factory { activity: LawnchairLauncher, itemInfo, originalView ->
-                if (PreferenceManager2.getInstance(activity).lockHomeScreen.firstBlocking()) {
+                val prefs2 = PreferenceManager2.getInstance(activity)
+                if (prefs2.lockHomeScreen.firstCached(prefs2)) {
                     null
                 } else {
                     getAppInfo(activity, itemInfo)?.let { Customize(activity, it, itemInfo, originalView) }
@@ -59,7 +60,8 @@ class LawnchairShortcut {
 
         val UNINSTALL =
             SystemShortcut.Factory { activity: ActivityContext, itemInfo: ItemInfo, view: View ->
-                if (PreferenceManager2.INSTANCE.get(activity.asContext()).lockHomeScreen.firstBlocking()) {
+                val prefs2 = PreferenceManager2.INSTANCE.get(activity.asContext())
+                if (prefs2.lockHomeScreen.firstCached(prefs2)) {
                     return@Factory null
                 }
                 if (itemInfo.targetComponent == null) {

--- a/lawnchair/src/app/lawnchair/ui/popup/LawnchairShortcut.kt
+++ b/lawnchair/src/app/lawnchair/ui/popup/LawnchairShortcut.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.unit.dp
 import app.lawnchair.LawnchairLauncher
 import app.lawnchair.override.CustomizeAppDialog
 import app.lawnchair.preferences2.PreferenceManager2
+import app.lawnchair.preferences2.firstCached
 import app.lawnchair.views.ComposeBottomSheet
 import com.android.launcher3.AbstractFloatingView
 import com.android.launcher3.LauncherSettings.Favorites.ITEM_TYPE_APPLICATION
@@ -34,7 +35,6 @@ import com.android.launcher3.util.ApplicationInfoWrapper
 import com.android.launcher3.util.ComponentKey
 import com.android.launcher3.util.PackageManagerHelper
 import com.android.launcher3.views.ActivityContext
-import app.lawnchair.preferences2.firstCached
 import java.net.URISyntaxException
 
 class LawnchairShortcut {

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/AboutViewModel.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/AboutViewModel.kt
@@ -62,7 +62,7 @@ class AboutViewModel(
         // Check if the build variant is Nightly
         // AND check if user has enabled auto updater (available to Nightly variant)
         // OR check if user has overridden it in debug flags (available to All variant)
-        if (BuildConfig.APPLICATION_ID.contains("nightly") && prefs2.autoUpdaterNightly.firstCached(prefs2)) {
+        if (BuildConfig.APPLICATION_ID.contains("nightly") && prefs2.autoUpdaterNightly.firstCached()) {
             nightlyBuildsRepository.checkForUpdate()
             viewModelScope.launch {
                 nightlyBuildsRepository.updateState.collect { state ->

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/AboutViewModel.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/AboutViewModel.kt
@@ -5,9 +5,9 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import app.lawnchair.preferences.PreferenceManager
 import app.lawnchair.preferences2.PreferenceManager2
+import app.lawnchair.preferences2.firstCached
 import com.android.launcher3.BuildConfig
 import com.android.launcher3.R
-import app.lawnchair.preferences2.firstCached
 import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/AboutViewModel.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/AboutViewModel.kt
@@ -7,7 +7,7 @@ import app.lawnchair.preferences.PreferenceManager
 import app.lawnchair.preferences2.PreferenceManager2
 import com.android.launcher3.BuildConfig
 import com.android.launcher3.R
-import com.patrykmichalik.opto.core.firstBlocking
+import app.lawnchair.preferences2.firstCached
 import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -62,7 +62,7 @@ class AboutViewModel(
         // Check if the build variant is Nightly
         // AND check if user has enabled auto updater (available to Nightly variant)
         // OR check if user has overridden it in debug flags (available to All variant)
-        if (BuildConfig.APPLICATION_ID.contains("nightly") && prefs2.autoUpdaterNightly.firstBlocking()) {
+        if (BuildConfig.APPLICATION_ID.contains("nightly") && prefs2.autoUpdaterNightly.firstCached(prefs2)) {
             nightlyBuildsRepository.checkForUpdate()
             viewModelScope.launch {
                 nightlyBuildsRepository.updateState.collect { state ->

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/GestureHandlerPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/GestureHandlerPreference.kt
@@ -39,7 +39,6 @@ import app.lawnchair.ui.preferences.components.layout.PreferenceDivider
 import app.lawnchair.ui.preferences.components.layout.PreferenceTemplate
 import app.lawnchair.ui.util.LocalBottomSheetHandler
 import com.android.launcher3.util.ComponentKey
-import com.patrykmichalik.opto.core.firstBlocking
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/GeneralPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/GeneralPreferences.kt
@@ -53,7 +53,6 @@ import app.lawnchair.ui.preferences.navigation.GeneralIconShape
 import com.android.launcher3.BuildConfig
 import com.android.launcher3.R
 import com.android.launcher3.Utilities
-import com.patrykmichalik.opto.core.firstBlocking
 
 @Composable
 fun GeneralPreferences() {

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/PreferencesDashboard.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/PreferencesDashboard.kt
@@ -140,7 +140,7 @@ fun PreferencesDashboard(
                 )
             }
 
-            val isSmartspaceEnabled = prefs2.enableSmartspace.firstCached(prefs2)
+            val isSmartspaceEnabled = prefs2.enableSmartspace.firstCached()
             Item {
                 PreferenceCategory(
                     label = stringResource(id = R.string.smartspace_widget),

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/PreferencesDashboard.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/PreferencesDashboard.kt
@@ -76,7 +76,7 @@ import app.lawnchair.util.isDefaultLauncher
 import app.lawnchair.util.restartLauncher
 import com.android.launcher3.BuildConfig
 import com.android.launcher3.R
-import com.patrykmichalik.opto.core.firstBlocking
+import app.lawnchair.preferences2.firstCached
 
 @Composable
 fun PreferencesDashboard(
@@ -140,7 +140,7 @@ fun PreferencesDashboard(
                 )
             }
 
-            val isSmartspaceEnabled = prefs2.enableSmartspace.firstBlocking()
+            val isSmartspaceEnabled = prefs2.enableSmartspace.firstCached(prefs2)
             Item {
                 PreferenceCategory(
                     label = stringResource(id = R.string.smartspace_widget),

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/PreferencesDashboard.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/PreferencesDashboard.kt
@@ -45,6 +45,7 @@ import app.lawnchair.backup.ui.restoreBackupOpener
 import app.lawnchair.preferences.getAdapter
 import app.lawnchair.preferences.observeAsState
 import app.lawnchair.preferences.preferenceManager
+import app.lawnchair.preferences2.firstCached
 import app.lawnchair.preferences2.preferenceManager2
 import app.lawnchair.ui.OverflowMenuGrouped
 import app.lawnchair.ui.preferences.LocalNavController
@@ -76,7 +77,6 @@ import app.lawnchair.util.isDefaultLauncher
 import app.lawnchair.util.restartLauncher
 import com.android.launcher3.BuildConfig
 import com.android.launcher3.R
-import app.lawnchair.preferences2.firstCached
 
 @Composable
 fun PreferencesDashboard(

--- a/lawnchair/src/app/lawnchair/util/FlowUtils.kt
+++ b/lawnchair/src/app/lawnchair/util/FlowUtils.kt
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import androidx.annotation.Discouraged
 import androidx.compose.runtime.Composable
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -22,7 +23,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
-@Deprecated("Use firstCached() instead for non-blocking reads")
+@Discouraged("This is a blocking read, use firstCached() for non-blocking reads")
 fun <T> Flow<T>.firstBlocking() = runBlocking { first() }
 
 @Composable

--- a/lawnchair/src/app/lawnchair/util/FlowUtils.kt
+++ b/lawnchair/src/app/lawnchair/util/FlowUtils.kt
@@ -22,6 +22,10 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
+@Deprecated(
+    "Use firstCached() instead for non-blocking reads",
+    ReplaceWith("firstCached(prefs2)", "app.lawnchair.preferences2.firstCached"),
+)
 fun <T> Flow<T>.firstBlocking() = runBlocking { first() }
 
 @Composable

--- a/lawnchair/src/app/lawnchair/util/FlowUtils.kt
+++ b/lawnchair/src/app/lawnchair/util/FlowUtils.kt
@@ -22,10 +22,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
-@Deprecated(
-    "Use firstCached() instead for non-blocking reads",
-    ReplaceWith("firstCached(prefs2)", "app.lawnchair.preferences2.firstCached"),
-)
+@Deprecated("Use firstCached() instead for non-blocking reads")
 fun <T> Flow<T>.firstBlocking() = runBlocking { first() }
 
 @Composable

--- a/lawnchair/src/app/lawnchair/util/LawnchairUtils.kt
+++ b/lawnchair/src/app/lawnchair/util/LawnchairUtils.kt
@@ -50,6 +50,7 @@ import androidx.core.graphics.luminance
 import androidx.core.os.UserManagerCompat
 import app.lawnchair.preferences.PreferenceManager
 import app.lawnchair.preferences2.PreferenceManager2
+import app.lawnchair.preferences2.firstCached
 import app.lawnchair.theme.color.ColorOption
 import app.lawnchair.theme.color.tokens.ColorTokens
 import com.android.launcher3.BaseActivity
@@ -60,7 +61,6 @@ import com.android.launcher3.util.Executors.MAIN_EXECUTOR
 import com.android.launcher3.util.Themes
 import com.android.launcher3.views.ActivityContext
 import com.android.systemui.shared.system.QuickStepContract
-import app.lawnchair.preferences2.firstCached
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.util.Locale

--- a/lawnchair/src/app/lawnchair/util/LawnchairUtils.kt
+++ b/lawnchair/src/app/lawnchair/util/LawnchairUtils.kt
@@ -178,18 +178,18 @@ val View?.pendingIntent get() = this?.getTag(pendingIntentTagId) as? PendingInte
 
 fun getFolderPreviewAlpha(context: Context): Int {
     val prefs2 = PreferenceManager2.getInstance(context)
-    return (prefs2.folderPreviewBackgroundOpacity.firstCached(prefs2) * 255).toInt()
+    return (prefs2.folderPreviewBackgroundOpacity.firstCached() * 255).toInt()
 }
 
 fun getFolderBackgroundAlpha(context: Context): Int {
     val prefs2 = PreferenceManager2.getInstance(context)
-    return (prefs2.folderBackgroundOpacity.firstCached(prefs2) * 255).toInt()
+    return (prefs2.folderBackgroundOpacity.firstCached() * 255).toInt()
 }
 
 /** Apply Lawnchair custom allapps colour to the provided colour */
 private fun getAllAppsBaseColor(context: Context, defaultColor: Int): Int {
     val prefs2 = PreferenceManager2.getInstance(context)
-    val colorOptions: ColorOption = prefs2.appDrawerBackgroundColor.firstCached(prefs2)
+    val colorOptions: ColorOption = prefs2.appDrawerBackgroundColor.firstCached()
     val color = colorOptions.colorPreferenceEntry.lightColor.invoke(context)
     val baseColor = if (color != 0) color else defaultColor
     return ColorUtils.setAlphaComponent(baseColor, 255)

--- a/lawnchair/src/app/lawnchair/util/LawnchairUtils.kt
+++ b/lawnchair/src/app/lawnchair/util/LawnchairUtils.kt
@@ -60,7 +60,7 @@ import com.android.launcher3.util.Executors.MAIN_EXECUTOR
 import com.android.launcher3.util.Themes
 import com.android.launcher3.views.ActivityContext
 import com.android.systemui.shared.system.QuickStepContract
-import com.patrykmichalik.opto.core.firstBlocking
+import app.lawnchair.preferences2.firstCached
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.util.Locale
@@ -178,18 +178,18 @@ val View?.pendingIntent get() = this?.getTag(pendingIntentTagId) as? PendingInte
 
 fun getFolderPreviewAlpha(context: Context): Int {
     val prefs2 = PreferenceManager2.getInstance(context)
-    return (prefs2.folderPreviewBackgroundOpacity.firstBlocking() * 255).toInt()
+    return (prefs2.folderPreviewBackgroundOpacity.firstCached(prefs2) * 255).toInt()
 }
 
 fun getFolderBackgroundAlpha(context: Context): Int {
     val prefs2 = PreferenceManager2.getInstance(context)
-    return (prefs2.folderBackgroundOpacity.firstBlocking() * 255).toInt()
+    return (prefs2.folderBackgroundOpacity.firstCached(prefs2) * 255).toInt()
 }
 
 /** Apply Lawnchair custom allapps colour to the provided colour */
 private fun getAllAppsBaseColor(context: Context, defaultColor: Int): Int {
     val prefs2 = PreferenceManager2.getInstance(context)
-    val colorOptions: ColorOption = prefs2.appDrawerBackgroundColor.firstBlocking()
+    val colorOptions: ColorOption = prefs2.appDrawerBackgroundColor.firstCached(prefs2)
     val color = colorOptions.colorPreferenceEntry.lightColor.invoke(context)
     val baseColor = if (color != 0) color else defaultColor
     return ColorUtils.setAlphaComponent(baseColor, 255)

--- a/lawnchair/src/app/lawnchair/views/FullScreenOverlayView.kt
+++ b/lawnchair/src/app/lawnchair/views/FullScreenOverlayView.kt
@@ -196,7 +196,7 @@ fun Activity.showFullScreenOverlay(
     onOverlayReady: () -> Unit,
 ) {
     val pref2 = PreferenceManager2.getInstance(this)
-    val animationMode = pref2.closingAppOverlay.firstCached(pref2)
+    val animationMode = pref2.closingAppOverlay.firstCached()
     val overlayView = FullScreenOverlayView(this)
     val targetRootView = rootView ?: window.decorView.findViewById<ViewGroup>(android.R.id.content)
 

--- a/lawnchair/src/app/lawnchair/views/FullScreenOverlayView.kt
+++ b/lawnchair/src/app/lawnchair/views/FullScreenOverlayView.kt
@@ -20,8 +20,8 @@ import android.view.animation.PathInterpolator
 import android.widget.FrameLayout
 import app.lawnchair.preferences2.PreferenceManager2
 import app.lawnchair.theme.color.tokens.ColorTokens
+import app.lawnchair.preferences2.firstCached
 import app.lawnchair.views.overlay.FullScreenOverlayMode
-import com.patrykmichalik.opto.core.firstBlocking
 
 class FullScreenOverlayView @JvmOverloads constructor(
     context: Context,
@@ -196,7 +196,7 @@ fun Activity.showFullScreenOverlay(
     onOverlayReady: () -> Unit,
 ) {
     val pref2 = PreferenceManager2.getInstance(this)
-    val animationMode = pref2.closingAppOverlay.firstBlocking()
+    val animationMode = pref2.closingAppOverlay.firstCached(pref2)
     val overlayView = FullScreenOverlayView(this)
     val targetRootView = rootView ?: window.decorView.findViewById<ViewGroup>(android.R.id.content)
 

--- a/lawnchair/src/app/lawnchair/views/FullScreenOverlayView.kt
+++ b/lawnchair/src/app/lawnchair/views/FullScreenOverlayView.kt
@@ -19,8 +19,8 @@ import android.view.animation.DecelerateInterpolator
 import android.view.animation.PathInterpolator
 import android.widget.FrameLayout
 import app.lawnchair.preferences2.PreferenceManager2
-import app.lawnchair.theme.color.tokens.ColorTokens
 import app.lawnchair.preferences2.firstCached
+import app.lawnchair.theme.color.tokens.ColorTokens
 import app.lawnchair.views.overlay.FullScreenOverlayMode
 
 class FullScreenOverlayView @JvmOverloads constructor(

--- a/quickstep/src/com/android/launcher3/appprediction/PredictionRowView.java
+++ b/quickstep/src/com/android/launcher3/appprediction/PredictionRowView.java
@@ -122,7 +122,7 @@ public class PredictionRowView<T extends Context & ActivityContext>
     }
 
     private void updateVisibility() {
-        boolean enabled = mPredictionsEnabled && PreferenceCacheExtensionsKt.firstCached(prefs2.getShowSuggestedAppsInDrawer(), prefs2);
+        boolean enabled = mPredictionsEnabled && PreferenceCacheExtensionsKt.firstCached(prefs2.getShowSuggestedAppsInDrawer());
         setVisibility(enabled ? VISIBLE : GONE);
         if (mActivityContext.getAppsView() != null) {
             if (enabled) {

--- a/quickstep/src/com/android/launcher3/appprediction/PredictionRowView.java
+++ b/quickstep/src/com/android/launcher3/appprediction/PredictionRowView.java
@@ -48,7 +48,7 @@ import com.android.launcher3.model.data.ItemInfoWithIcon;
 import com.android.launcher3.model.data.WorkspaceItemInfo;
 import com.android.launcher3.views.ActivityContext;
 
-import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
@@ -122,7 +122,7 @@ public class PredictionRowView<T extends Context & ActivityContext>
     }
 
     private void updateVisibility() {
-        boolean enabled = mPredictionsEnabled && PreferenceExtensionsKt.firstBlocking(prefs2.getShowSuggestedAppsInDrawer());
+        boolean enabled = mPredictionsEnabled && PreferenceCacheExtensionsKt.firstCached(prefs2.getShowSuggestedAppsInDrawer(), prefs2);
         setVisibility(enabled ? VISIBLE : GONE);
         if (mActivityContext.getAppsView() != null) {
             if (enabled) {

--- a/quickstep/src/com/android/launcher3/hybridhotseat/HotseatPredictionController.java
+++ b/quickstep/src/com/android/launcher3/hybridhotseat/HotseatPredictionController.java
@@ -66,7 +66,7 @@ import com.android.launcher3.uioverrides.PredictedAppIcon;
 import com.android.launcher3.uioverrides.QuickstepLauncher;
 import com.android.launcher3.views.Snackbar;
 
-import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -394,7 +394,7 @@ public class HotseatPredictionController implements DragController.DragListener,
     public SystemShortcut<QuickstepLauncher> getShortcut(QuickstepLauncher activity,
             ItemInfo itemInfo, View originalView) {
         PreferenceManager2 prefs = PreferenceManager2.getInstance(activity);
-        if (PreferenceExtensionsKt.firstBlocking(prefs.getLockHomeScreen())) {
+        if (PreferenceCacheExtensionsKt.firstCached(prefs.getLockHomeScreen(), prefs)) {
             return null;
         }
         if (itemInfo.container != LauncherSettings.Favorites.CONTAINER_HOTSEAT_PREDICTION) {

--- a/quickstep/src/com/android/launcher3/hybridhotseat/HotseatPredictionController.java
+++ b/quickstep/src/com/android/launcher3/hybridhotseat/HotseatPredictionController.java
@@ -394,7 +394,7 @@ public class HotseatPredictionController implements DragController.DragListener,
     public SystemShortcut<QuickstepLauncher> getShortcut(QuickstepLauncher activity,
             ItemInfo itemInfo, View originalView) {
         PreferenceManager2 prefs = PreferenceManager2.getInstance(activity);
-        if (PreferenceCacheExtensionsKt.firstCached(prefs.getLockHomeScreen(), prefs)) {
+        if (PreferenceCacheExtensionsKt.firstCached(prefs.getLockHomeScreen())) {
             return null;
         }
         if (itemInfo.container != LauncherSettings.Favorites.CONTAINER_HOTSEAT_PREDICTION) {

--- a/quickstep/src/com/android/launcher3/statehandlers/DepthController.java
+++ b/quickstep/src/com/android/launcher3/statehandlers/DepthController.java
@@ -44,7 +44,7 @@ import com.android.quickstep.util.BaseDepthController;
 import java.io.PrintWriter;
 import java.util.function.Consumer;
 
-import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 import app.lawnchair.compat.LawnchairQuickstepCompat;
 import app.lawnchair.preferences2.PreferenceManager2;
 
@@ -74,8 +74,9 @@ public class DepthController extends BaseDepthController implements StateHandler
 
     public DepthController(QuickstepLauncher launcher) {
         super(launcher);
-        var pref = PreferenceManager2.getInstance(launcher).getWallpaperDepthEffect();
-        mEnableDepth = PreferenceExtensionsKt.firstBlocking(pref);
+        var prefs = PreferenceManager2.getInstance(launcher);
+        var pref = prefs.getWallpaperDepthEffect();
+        mEnableDepth = PreferenceCacheExtensionsKt.firstCached(pref, prefs);
     }
 
     private void onLauncherDraw() {

--- a/quickstep/src/com/android/launcher3/statehandlers/DepthController.java
+++ b/quickstep/src/com/android/launcher3/statehandlers/DepthController.java
@@ -76,7 +76,7 @@ public class DepthController extends BaseDepthController implements StateHandler
         super(launcher);
         var prefs = PreferenceManager2.getInstance(launcher);
         var pref = prefs.getWallpaperDepthEffect();
-        mEnableDepth = PreferenceCacheExtensionsKt.firstCached(pref, prefs);
+        mEnableDepth = PreferenceCacheExtensionsKt.firstCached(pref);
     }
 
     private void onLauncherDraw() {

--- a/quickstep/src/com/android/launcher3/taskbar/TaskbarView.java
+++ b/quickstep/src/com/android/launcher3/taskbar/TaskbarView.java
@@ -167,7 +167,7 @@ public class TaskbarView extends FrameLayout implements FolderIcon.FolderIconPar
             int defStyleRes) {
         super(context, attrs, defStyleAttr, defStyleRes);
         PreferenceManager2 preferenceManager2 = PreferenceManager2.getInstance(context);
-        HotseatMode hotseatMode = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getHotseatMode(), preferenceManager2);
+        HotseatMode hotseatMode = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getHotseatMode());
         mActivityContext = ActivityContext.lookupContext(context);
         mIconLayoutBounds = mActivityContext.getTransientTaskbarBounds();
         Resources resources = getResources();

--- a/quickstep/src/com/android/launcher3/taskbar/TaskbarView.java
+++ b/quickstep/src/com/android/launcher3/taskbar/TaskbarView.java
@@ -78,7 +78,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
-import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 import app.lawnchair.hotseat.HotseatMode;
 import app.lawnchair.preferences2.PreferenceManager2;
 import app.lawnchair.theme.color.tokens.ColorTokens;
@@ -167,7 +167,7 @@ public class TaskbarView extends FrameLayout implements FolderIcon.FolderIconPar
             int defStyleRes) {
         super(context, attrs, defStyleAttr, defStyleRes);
         PreferenceManager2 preferenceManager2 = PreferenceManager2.getInstance(context);
-        HotseatMode hotseatMode = PreferenceExtensionsKt.firstBlocking(preferenceManager2.getHotseatMode());
+        HotseatMode hotseatMode = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getHotseatMode(), preferenceManager2);
         mActivityContext = ActivityContext.lookupContext(context);
         mIconLayoutBounds = mActivityContext.getTransientTaskbarBounds();
         Resources resources = getResources();

--- a/quickstep/src/com/android/launcher3/taskbar/bubbles/BubbleView.java
+++ b/quickstep/src/com/android/launcher3/taskbar/bubbles/BubbleView.java
@@ -40,7 +40,7 @@ import com.android.wm.shell.shared.animation.Interpolators;
 import com.android.wm.shell.shared.bubbles.BubbleBarLocation;
 import com.android.wm.shell.shared.bubbles.BubbleInfo;
 
-import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 import app.lawnchair.preferences2.PreferenceManager2;
 import app.lawnchair.theme.color.ColorOption;
 
@@ -262,10 +262,10 @@ public class BubbleView extends ConstraintLayout {
             mAppIcon.setVisibility(GONE);
         }
         mDotColor = bubble.getDotColor();
-        ColorOption dotColorOption = PreferenceExtensionsKt.firstBlocking(preferenceManager2.getNotificationDotColor());
+        ColorOption dotColorOption = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getNotificationDotColor(), preferenceManager2);
         int dotColor = dotColorOption.getColorPreferenceEntry().getLightColor().invoke(getContext());
-        ColorOption counterColorOption = PreferenceExtensionsKt
-                .firstBlocking(preferenceManager2.getNotificationDotTextColor());
+        ColorOption counterColorOption = PreferenceCacheExtensionsKt
+                .firstCached(preferenceManager2.getNotificationDotTextColor(), preferenceManager2);
         int countColor = counterColorOption.getColorPreferenceEntry().getLightColor().invoke(getContext());
         mDotRenderer = new DotRenderer(mBubbleSize, bubble.getDotPath(), DEFAULT_PATH_SIZE, false, null, dotColor,
                 countColor);

--- a/quickstep/src/com/android/launcher3/taskbar/bubbles/BubbleView.java
+++ b/quickstep/src/com/android/launcher3/taskbar/bubbles/BubbleView.java
@@ -262,7 +262,7 @@ public class BubbleView extends ConstraintLayout {
             mAppIcon.setVisibility(GONE);
         }
         mDotColor = bubble.getDotColor();
-        ColorOption dotColorOption = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getNotificationDotColor(), preferenceManager2);
+        ColorOption dotColorOption = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getNotificationDotColor());
         int dotColor = dotColorOption.getColorPreferenceEntry().getLightColor().invoke(getContext());
         ColorOption counterColorOption = PreferenceCacheExtensionsKt
                 .firstCached(preferenceManager2.getNotificationDotTextColor(), preferenceManager2);

--- a/src/com/android/launcher3/AppWidgetResizeFrame.java
+++ b/src/com/android/launcher3/AppWidgetResizeFrame.java
@@ -54,7 +54,7 @@ import com.android.launcher3.widget.util.WidgetSizes;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 import app.lawnchair.preferences2.PreferenceManager2;
 import app.lawnchair.theme.color.tokens.ColorTokens;
 import app.lawnchair.theme.drawable.DrawableTokens;
@@ -220,8 +220,8 @@ public class AppWidgetResizeFrame extends AbstractFloatingView implements View.O
 
     public static void showForWidget(LauncherAppWidgetHostView widget, CellLayout cellLayout) {
         PreferenceManager2 pref2 = PreferenceManager2.getInstance(widget.getContext());
-        boolean force = PreferenceExtensionsKt.firstBlocking(pref2.getForceWidgetResize());
-        boolean unlimited = PreferenceExtensionsKt.firstBlocking(pref2.getWidgetUnlimitedSize());
+        boolean force = PreferenceCacheExtensionsKt.firstCached(pref2.getForceWidgetResize(), pref2);
+        boolean unlimited = PreferenceCacheExtensionsKt.firstCached(pref2.getWidgetUnlimitedSize(), pref2);
 
         // If widget is not added to view hierarchy, we cannot show resize frame at correct location
         if (widget.getParent() == null) {

--- a/src/com/android/launcher3/AppWidgetResizeFrame.java
+++ b/src/com/android/launcher3/AppWidgetResizeFrame.java
@@ -220,8 +220,8 @@ public class AppWidgetResizeFrame extends AbstractFloatingView implements View.O
 
     public static void showForWidget(LauncherAppWidgetHostView widget, CellLayout cellLayout) {
         PreferenceManager2 pref2 = PreferenceManager2.getInstance(widget.getContext());
-        boolean force = PreferenceCacheExtensionsKt.firstCached(pref2.getForceWidgetResize(), pref2);
-        boolean unlimited = PreferenceCacheExtensionsKt.firstCached(pref2.getWidgetUnlimitedSize(), pref2);
+        boolean force = PreferenceCacheExtensionsKt.firstCached(pref2.getForceWidgetResize());
+        boolean unlimited = PreferenceCacheExtensionsKt.firstCached(pref2.getWidgetUnlimitedSize());
 
         // If widget is not added to view hierarchy, we cannot show resize frame at correct location
         if (widget.getParent() == null) {

--- a/src/com/android/launcher3/BubbleTextView.java
+++ b/src/com/android/launcher3/BubbleTextView.java
@@ -110,7 +110,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Objects;
 
-import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 import app.lawnchair.LawnchairApp;
 import app.lawnchair.font.FontManager;
 import app.lawnchair.gestures.IconGestureListener;
@@ -1186,7 +1186,7 @@ public class BubbleTextView extends TextView implements ItemInfoUpdateReceiver,
         ItemInfo info = tag instanceof ItemInfo ? (ItemInfo) tag : null;
         return info == null || info.container != LauncherSettings.Favorites.CONTAINER_HOTSEAT
                 && info.container != LauncherSettings.Favorites.CONTAINER_HOTSEAT_PREDICTION
-                || PreferenceExtensionsKt.firstBlocking(pref2.getEnableLabelInDock());
+                || PreferenceCacheExtensionsKt.firstCached(pref2.getEnableLabelInDock(), pref2);
     }
 
     /**

--- a/src/com/android/launcher3/BubbleTextView.java
+++ b/src/com/android/launcher3/BubbleTextView.java
@@ -1186,7 +1186,7 @@ public class BubbleTextView extends TextView implements ItemInfoUpdateReceiver,
         ItemInfo info = tag instanceof ItemInfo ? (ItemInfo) tag : null;
         return info == null || info.container != LauncherSettings.Favorites.CONTAINER_HOTSEAT
                 && info.container != LauncherSettings.Favorites.CONTAINER_HOTSEAT_PREDICTION
-                || PreferenceCacheExtensionsKt.firstCached(pref2.getEnableLabelInDock(), pref2);
+                || PreferenceCacheExtensionsKt.firstCached(pref2.getEnableLabelInDock());
     }
 
     /**

--- a/src/com/android/launcher3/CellLayout.java
+++ b/src/com/android/launcher3/CellLayout.java
@@ -79,7 +79,7 @@ import com.android.launcher3.util.Themes;
 import com.android.launcher3.util.Thunk;
 import com.android.launcher3.views.ActivityContext;
 import com.android.launcher3.widget.LauncherAppWidgetHostView;
-import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 
 import com.google.android.msdl.data.model.MSDLToken;
 
@@ -774,7 +774,7 @@ public class CellLayout extends ViewGroup {
         // Hotseat icons - modified by lawnchair
         if (child instanceof BubbleTextView bubbleChild) {
             boolean enableLabel = mContainerType == HOTSEAT
-                    ? PreferenceExtensionsKt.firstBlocking(pref.getEnableLabelInDock())
+                    ? PreferenceCacheExtensionsKt.firstCached(pref.getEnableLabelInDock(), pref)
                     : true;
             bubbleChild.setTextVisibility(enableLabel);
         }
@@ -1926,7 +1926,7 @@ public class CellLayout extends ViewGroup {
 
     public boolean isOccupied(int x, int y) {
         if (x >= 0 && x < mCountX && y >= 0 && y < mCountY) {
-            return mOccupied.cells[x][y] && !PreferenceExtensionsKt.firstBlocking(pref.getAllowWidgetOverlap());
+            return mOccupied.cells[x][y] && !PreferenceCacheExtensionsKt.firstCached(pref.getAllowWidgetOverlap(), pref);
         }
         if (BuildConfigs.IS_STUDIO_BUILD) {
             throw new RuntimeException("Position exceeds the bound of this CellLayout");
@@ -2009,7 +2009,7 @@ public class CellLayout extends ViewGroup {
     }
 
     public boolean isRegionVacant(int x, int y, int spanX, int spanY) {
-        return mOccupied.isRegionVacant(x, y, spanX, spanY) || PreferenceExtensionsKt.firstBlocking(pref.getAllowWidgetOverlap());
+        return mOccupied.isRegionVacant(x, y, spanX, spanY) || PreferenceCacheExtensionsKt.firstCached(pref.getAllowWidgetOverlap(), pref);
     }
 
     public void setSpaceBetweenCellLayoutsPx(@Px int spaceBetweenCellLayoutsPx) {

--- a/src/com/android/launcher3/CellLayout.java
+++ b/src/com/android/launcher3/CellLayout.java
@@ -774,7 +774,7 @@ public class CellLayout extends ViewGroup {
         // Hotseat icons - modified by lawnchair
         if (child instanceof BubbleTextView bubbleChild) {
             boolean enableLabel = mContainerType == HOTSEAT
-                    ? PreferenceCacheExtensionsKt.firstCached(pref.getEnableLabelInDock(), pref)
+                    ? PreferenceCacheExtensionsKt.firstCached(pref.getEnableLabelInDock())
                     : true;
             bubbleChild.setTextVisibility(enableLabel);
         }
@@ -1926,7 +1926,7 @@ public class CellLayout extends ViewGroup {
 
     public boolean isOccupied(int x, int y) {
         if (x >= 0 && x < mCountX && y >= 0 && y < mCountY) {
-            return mOccupied.cells[x][y] && !PreferenceCacheExtensionsKt.firstCached(pref.getAllowWidgetOverlap(), pref);
+            return mOccupied.cells[x][y] && !PreferenceCacheExtensionsKt.firstCached(pref.getAllowWidgetOverlap());
         }
         if (BuildConfigs.IS_STUDIO_BUILD) {
             throw new RuntimeException("Position exceeds the bound of this CellLayout");
@@ -2009,7 +2009,7 @@ public class CellLayout extends ViewGroup {
     }
 
     public boolean isRegionVacant(int x, int y, int spanX, int spanY) {
-        return mOccupied.isRegionVacant(x, y, spanX, spanY) || PreferenceCacheExtensionsKt.firstCached(pref.getAllowWidgetOverlap(), pref);
+        return mOccupied.isRegionVacant(x, y, spanX, spanY) || PreferenceCacheExtensionsKt.firstCached(pref.getAllowWidgetOverlap());
     }
 
     public void setSpaceBetweenCellLayoutsPx(@Px int spaceBetweenCellLayoutsPx) {

--- a/src/com/android/launcher3/DeleteDropTarget.java
+++ b/src/com/android/launcher3/DeleteDropTarget.java
@@ -33,7 +33,7 @@ import com.android.launcher3.model.data.ItemInfo;
 import com.android.launcher3.model.data.LauncherAppWidgetInfo;
 import com.android.launcher3.model.data.WorkspaceItemInfo;
 import com.android.launcher3.util.Preconditions;
-import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 
 import app.lawnchair.preferences2.PreferenceManager2;
 
@@ -125,7 +125,7 @@ public class DeleteDropTarget extends ButtonDropTarget {
     }
 
     private boolean canRemove(ItemInfo item) {
-        boolean isDeckLayoutFirst = PreferenceExtensionsKt.firstBlocking(pref2.getDeckLayout());
+        boolean isDeckLayoutFirst = PreferenceCacheExtensionsKt.firstCached(pref2.getDeckLayout(), pref2);
         return isDeckLayoutFirst ? isCanDrop(item) : item.id != ItemInfo.NO_ID;
     }
 
@@ -169,7 +169,7 @@ public class DeleteDropTarget extends ButtonDropTarget {
         // because we already remove the drag view from the folder (if the drag originated from
         // a folder) in Folder.beginDrag()
         CharSequence announcement = getContext().getString(R.string.item_removed);
-        if (!PreferenceExtensionsKt.firstBlocking(pref2.getDeckLayout())) {
+        if (!PreferenceCacheExtensionsKt.firstCached(pref2.getDeckLayout(), pref2)) {
             mDropTargetHandler.onAccessibilityDelete(view, item, announcement);
         }
     }

--- a/src/com/android/launcher3/DeleteDropTarget.java
+++ b/src/com/android/launcher3/DeleteDropTarget.java
@@ -125,7 +125,7 @@ public class DeleteDropTarget extends ButtonDropTarget {
     }
 
     private boolean canRemove(ItemInfo item) {
-        boolean isDeckLayoutFirst = PreferenceCacheExtensionsKt.firstCached(pref2.getDeckLayout(), pref2);
+        boolean isDeckLayoutFirst = PreferenceCacheExtensionsKt.firstCached(pref2.getDeckLayout());
         return isDeckLayoutFirst ? isCanDrop(item) : item.id != ItemInfo.NO_ID;
     }
 
@@ -169,7 +169,7 @@ public class DeleteDropTarget extends ButtonDropTarget {
         // because we already remove the drag view from the folder (if the drag originated from
         // a folder) in Folder.beginDrag()
         CharSequence announcement = getContext().getString(R.string.item_removed);
-        if (!PreferenceCacheExtensionsKt.firstCached(pref2.getDeckLayout(), pref2)) {
+        if (!PreferenceCacheExtensionsKt.firstCached(pref2.getDeckLayout())) {
             mDropTargetHandler.onAccessibilityDelete(view, item, announcement);
         }
     }

--- a/src/com/android/launcher3/DeviceProfile.java
+++ b/src/com/android/launcher3/DeviceProfile.java
@@ -378,7 +378,7 @@ public class DeviceProfile {
         mIsScalableGrid = inv.isScalable && !isVerticalBarLayout() && !isMultiWindowMode;
         // Determine device posture.
         mInfo = info;
-        boolean isTaskBarEnabled = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getEnableTaskbarOnPhone(), preferenceManager2);
+        boolean isTaskBarEnabled = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getEnableTaskbarOnPhone());
         boolean taskbarOrBubbleBarOnPhones = enableTinyTaskbar()
                 || (enableBubbleBar() && enableBubbleBarOnPhones());
         isTaskbarPresent = isTaskBarEnabled && (mDeviceProperties.isTablet() || (taskbarOrBubbleBarOnPhones && isGestureMode))
@@ -493,7 +493,7 @@ public class DeviceProfile {
 
         workspaceCellPaddingXPx = res.getDimensionPixelSize(R.dimen.dynamic_grid_cell_padding_x);
 
-        HotseatMode hotseatMode = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getHotseatMode(), preferenceManager2);
+        HotseatMode hotseatMode = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getHotseatMode());
         boolean isQsbEnable = hotseatMode.getLayoutResourceId() != R.layout.empty_view;
 
         numShownHotseatIcons = displayOptionSpec.numShownHotseatIcons;
@@ -705,7 +705,7 @@ public class DeviceProfile {
         }
 
         // Load dot color
-        ColorOption dotColorOption = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getNotificationDotColor(), preferenceManager2);
+        ColorOption dotColorOption = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getNotificationDotColor());
         int dotColor = dotColorOption.getColorPreferenceEntry().getLightColor().invoke(context);
 
         // Load counter color
@@ -858,7 +858,7 @@ public class DeviceProfile {
     /** Updates hotseatCellHeightPx and hotseatBarSizePx */
     private void updateHotseatSizes(int hotseatIconSizePx) {
         int iconTextHeight = Utilities.calculateTextHeight(iconTextSizePx);
-        boolean isLabelInDock = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getEnableLabelInDock(), preferenceManager2);
+        boolean isLabelInDock = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getEnableLabelInDock());
         // Ensure there is enough space for folder icons, which have a slightly larger radius.
         hotseatCellHeightPx = getIconSizeWithOverlap(hotseatIconSizePx * 2) - hotseatIconSizePx / 2;
         hotseatCellHeightPx += isLabelInDock ? iconTextHeight : 0;
@@ -884,7 +884,7 @@ public class DeviceProfile {
                     + hotseatBarBottomSpacePx
                     + space;
         }
-        var isHotseatEnabled = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.isHotseatEnabled(), preferenceManager2);
+        var isHotseatEnabled = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.isHotseatEnabled());
         if (!isHotseatEnabled) {
             hotseatBarSizePx = 0;
         }

--- a/src/com/android/launcher3/DeviceProfile.java
+++ b/src/com/android/launcher3/DeviceProfile.java
@@ -88,7 +88,7 @@ import java.io.PrintWriter;
 import java.util.Locale;
 import java.util.function.Consumer;
 
-import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 import app.lawnchair.DeviceProfileOverrides;
 import app.lawnchair.LawnchairApp;
 import app.lawnchair.LawnchairAppKt;
@@ -351,8 +351,8 @@ public class DeviceProfile {
         mTextFactors = DeviceProfileOverrides.INSTANCE.get(context).getTextFactors();
 
         preferenceManager2 = PreferenceManager2.INSTANCE.get(context);
-        allAppsCellHeightMultiplier = PreferenceExtensionsKt
-                .firstBlocking(preferenceManager2.getDrawerCellHeightFactor());
+        allAppsCellHeightMultiplier = PreferenceCacheExtensionsKt
+                .firstCached(preferenceManager2.getDrawerCellHeightFactor(), preferenceManager2);
         this.inv = inv;
 
         mDeviceProperties = DeviceProperties.Factory.createDeviceProperties(
@@ -378,7 +378,7 @@ public class DeviceProfile {
         mIsScalableGrid = inv.isScalable && !isVerticalBarLayout() && !isMultiWindowMode;
         // Determine device posture.
         mInfo = info;
-        boolean isTaskBarEnabled = PreferenceExtensionsKt.firstBlocking(preferenceManager2.getEnableTaskbarOnPhone());
+        boolean isTaskBarEnabled = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getEnableTaskbarOnPhone(), preferenceManager2);
         boolean taskbarOrBubbleBarOnPhones = enableTinyTaskbar()
                 || (enableBubbleBar() && enableBubbleBarOnPhones());
         isTaskbarPresent = isTaskBarEnabled && (mDeviceProperties.isTablet() || (taskbarOrBubbleBarOnPhones && isGestureMode))
@@ -395,8 +395,8 @@ public class DeviceProfile {
 
         workspacePageIndicatorHeight = res.getDimensionPixelSize(
                 R.dimen.workspace_page_indicator_height);
-        workspacePageIndicatorHeight *= PreferenceExtensionsKt
-                .firstBlocking(preferenceManager2.getPageIndicatorHeightFactor());
+        workspacePageIndicatorHeight *= PreferenceCacheExtensionsKt
+                .firstCached(preferenceManager2.getPageIndicatorHeightFactor(), preferenceManager2);
         mWorkspacePageIndicatorOverlapWorkspace =
                 res.getDimensionPixelSize(R.dimen.workspace_page_indicator_overlap_workspace);
 
@@ -493,7 +493,7 @@ public class DeviceProfile {
 
         workspaceCellPaddingXPx = res.getDimensionPixelSize(R.dimen.dynamic_grid_cell_padding_x);
 
-        HotseatMode hotseatMode = PreferenceExtensionsKt.firstBlocking(preferenceManager2.getHotseatMode());
+        HotseatMode hotseatMode = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getHotseatMode(), preferenceManager2);
         boolean isQsbEnable = hotseatMode.getLayoutResourceId() != R.layout.empty_view;
 
         numShownHotseatIcons = displayOptionSpec.numShownHotseatIcons;
@@ -695,8 +695,8 @@ public class DeviceProfile {
         dimensionOverrideProvider.accept(this);
 
         // Check if notification dots should show the notification count
-        boolean showNotificationCount = PreferenceExtensionsKt
-                .firstBlocking(preferenceManager2.getShowNotificationCount());
+        boolean showNotificationCount = PreferenceCacheExtensionsKt
+                .firstCached(preferenceManager2.getShowNotificationCount(), preferenceManager2);
 
         // Load the default font to use on notification dots
         Typeface typeface = null;
@@ -705,12 +705,12 @@ public class DeviceProfile {
         }
 
         // Load dot color
-        ColorOption dotColorOption = PreferenceExtensionsKt.firstBlocking(preferenceManager2.getNotificationDotColor());
+        ColorOption dotColorOption = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getNotificationDotColor(), preferenceManager2);
         int dotColor = dotColorOption.getColorPreferenceEntry().getLightColor().invoke(context);
 
         // Load counter color
-        ColorOption counterColorOption = PreferenceExtensionsKt
-                .firstBlocking(preferenceManager2.getNotificationDotTextColor());
+        ColorOption counterColorOption = PreferenceCacheExtensionsKt
+                .firstCached(preferenceManager2.getNotificationDotTextColor(), preferenceManager2);
         int countColor = counterColorOption.getColorPreferenceEntry().getLightColor().invoke(context);
 
         // This is done last, after iconSizePx is calculated above.
@@ -858,7 +858,7 @@ public class DeviceProfile {
     /** Updates hotseatCellHeightPx and hotseatBarSizePx */
     private void updateHotseatSizes(int hotseatIconSizePx) {
         int iconTextHeight = Utilities.calculateTextHeight(iconTextSizePx);
-        boolean isLabelInDock = PreferenceExtensionsKt.firstBlocking(preferenceManager2.getEnableLabelInDock());
+        boolean isLabelInDock = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getEnableLabelInDock(), preferenceManager2);
         // Ensure there is enough space for folder icons, which have a slightly larger radius.
         hotseatCellHeightPx = getIconSizeWithOverlap(hotseatIconSizePx * 2) - hotseatIconSizePx / 2;
         hotseatCellHeightPx += isLabelInDock ? iconTextHeight : 0;
@@ -866,8 +866,8 @@ public class DeviceProfile {
         
         int space = Math.abs(hotseatCellHeightPx / 2) - 16;
 
-        hotseatBarBottomSpacePx *= PreferenceExtensionsKt
-            .firstBlocking(preferenceManager2.getHotseatBottomFactor());
+        hotseatBarBottomSpacePx *= PreferenceCacheExtensionsKt
+            .firstCached(preferenceManager2.getHotseatBottomFactor(), preferenceManager2);
 
         if (isVerticalBarLayout()) {
             hotseatBarSizePx = hotseatIconSizePx + getHotseatProfile().getBarEdgePaddingPx()
@@ -884,7 +884,7 @@ public class DeviceProfile {
                     + hotseatBarBottomSpacePx
                     + space;
         }
-        var isHotseatEnabled = PreferenceExtensionsKt.firstBlocking(preferenceManager2.isHotseatEnabled());
+        var isHotseatEnabled = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.isHotseatEnabled(), preferenceManager2);
         if (!isHotseatEnabled) {
             hotseatBarSizePx = 0;
         }
@@ -1386,8 +1386,8 @@ public class DeviceProfile {
                     Math.max(0, desiredWorkspaceHorizontalMarginPx + cellLayoutHorizontalPadding
                             - (getAllAppsProfile().getBorderSpacePx().x / 2));
         }
-        var allAppLeftRightMarginMultiplier = PreferenceExtensionsKt
-                .firstBlocking(preferenceManager2.getDrawerLeftRightMarginFactor());
+        var allAppLeftRightMarginMultiplier = PreferenceCacheExtensionsKt
+                .firstCached(preferenceManager2.getDrawerLeftRightMarginFactor(), preferenceManager2);
         var marginMultiplier = allAppLeftRightMarginMultiplier * (!getDeviceProperties().isTablet() ? 100 : 2);
         allAppsLeftRightMargin = (int) (allAppsLeftRightMargin * marginMultiplier);
 

--- a/src/com/android/launcher3/FastScrollRecyclerView.java
+++ b/src/com/android/launcher3/FastScrollRecyclerView.java
@@ -99,7 +99,7 @@ public abstract class FastScrollRecyclerView extends RecyclerView  {
      * Saved the scroll position
      */
     public void saveScrollPosition() {
-        savedScrollPosition = PreferenceCacheExtensionsKt.firstCached(pref2.getRememberPosition(), pref2)
+        savedScrollPosition = PreferenceCacheExtensionsKt.firstCached(pref2.getRememberPosition())
                 ? computeVerticalScrollOffset()
                 : 0;
     }

--- a/src/com/android/launcher3/FastScrollRecyclerView.java
+++ b/src/com/android/launcher3/FastScrollRecyclerView.java
@@ -31,7 +31,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.android.launcher3.compat.AccessibilityManagerCompat;
 import com.android.launcher3.views.RecyclerViewFastScroller;
 
-import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 import app.lawnchair.preferences2.PreferenceManager2;
 
 /**
@@ -99,7 +99,7 @@ public abstract class FastScrollRecyclerView extends RecyclerView  {
      * Saved the scroll position
      */
     public void saveScrollPosition() {
-        savedScrollPosition = PreferenceExtensionsKt.firstBlocking(pref2.getRememberPosition())
+        savedScrollPosition = PreferenceCacheExtensionsKt.firstCached(pref2.getRememberPosition(), pref2)
                 ? computeVerticalScrollOffset()
                 : 0;
     }

--- a/src/com/android/launcher3/Hotseat.java
+++ b/src/com/android/launcher3/Hotseat.java
@@ -62,7 +62,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 import com.hoko.blur.HokoBlur;
-import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 import app.lawnchair.hotseat.DisabledHotseat;
 import app.lawnchair.hotseat.HotseatMode;
 import app.lawnchair.hotseat.LawnchairHotseat;
@@ -128,8 +128,8 @@ public class Hotseat extends CellLayout implements Insettable {
 
         preferenceManager2 = PreferenceManager2.getInstance(context);
         preferenceManager = PreferenceManager.getInstance(context);
-        HotseatMode hotseatMode = PreferenceExtensionsKt.firstBlocking(preferenceManager2.getHotseatMode());
-        var hotseatEnabled = PreferenceExtensionsKt.firstBlocking(preferenceManager2.isHotseatEnabled());
+        HotseatMode hotseatMode = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getHotseatMode(), preferenceManager2);
+        var hotseatEnabled = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.isHotseatEnabled(), preferenceManager2);
 
         if (!hotseatEnabled) {
             hotseatMode = DisabledHotseat.INSTANCE;
@@ -139,7 +139,7 @@ public class Hotseat extends CellLayout implements Insettable {
             // The current hotseat mode is not available,
             // setting the hotseat mode to one that is always available
             hotseatMode = LawnchairHotseat.INSTANCE;
-            PreferenceExtensionsKt.setBlocking(preferenceManager2.getHotseatMode(), hotseatMode);
+            com.patrykmichalik.opto.core.PreferenceExtensionsKt.setBlocking(preferenceManager2.getHotseatMode(), hotseatMode);
         }
         int layoutId = hotseatMode.getLayoutResourceId();
 
@@ -170,7 +170,7 @@ public class Hotseat extends CellLayout implements Insettable {
     private void setUpBackground() {
         if(!preferenceManager.getHotseatBG().get()) return;
 
-        var bgColor = PreferenceExtensionsKt.firstBlocking(preferenceManager2.getHotseatBackgroundColor());
+        var bgColor = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getHotseatBackgroundColor(), preferenceManager2);
         var transparency = preferenceManager.getHotseatBGAlpha().get();
         var alphaValue = (transparency * 255) / 100;
         var baseColor = bgColor.getColorPreferenceEntry().getLightColor().invoke(getContext());

--- a/src/com/android/launcher3/Hotseat.java
+++ b/src/com/android/launcher3/Hotseat.java
@@ -128,8 +128,8 @@ public class Hotseat extends CellLayout implements Insettable {
 
         preferenceManager2 = PreferenceManager2.getInstance(context);
         preferenceManager = PreferenceManager.getInstance(context);
-        HotseatMode hotseatMode = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getHotseatMode(), preferenceManager2);
-        var hotseatEnabled = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.isHotseatEnabled(), preferenceManager2);
+        HotseatMode hotseatMode = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getHotseatMode());
+        var hotseatEnabled = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.isHotseatEnabled());
 
         if (!hotseatEnabled) {
             hotseatMode = DisabledHotseat.INSTANCE;
@@ -170,7 +170,7 @@ public class Hotseat extends CellLayout implements Insettable {
     private void setUpBackground() {
         if(!preferenceManager.getHotseatBG().get()) return;
 
-        var bgColor = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getHotseatBackgroundColor(), preferenceManager2);
+        var bgColor = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getHotseatBackgroundColor());
         var transparency = preferenceManager.getHotseatBGAlpha().get();
         var alphaValue = (transparency * 255) / 100;
         var baseColor = bgColor.getColorPreferenceEntry().getLightColor().invoke(getContext());

--- a/src/com/android/launcher3/LauncherRootView.java
+++ b/src/com/android/launcher3/LauncherRootView.java
@@ -61,7 +61,7 @@ public class LauncherRootView extends InsettableFrameLayout {
         pref = PreferenceManager.getInstance(context);
         PreferenceManager2 prefs2 = PreferenceManager2.getInstance(context);
         
-        mEnableTaskbarOnPhone = PreferenceCacheExtensionsKt.firstCached(prefs2.getEnableTaskbarOnPhone(), prefs2);
+        mEnableTaskbarOnPhone = PreferenceCacheExtensionsKt.firstCached(prefs2.getEnableTaskbarOnPhone());
 
         FileAccessManager fileAccessManager = FileAccessManager.getInstance(context);
         FileAccessState wallpaperAccessState = fileAccessManager.getWallpaperAccessState().getValue();

--- a/src/com/android/launcher3/LauncherRootView.java
+++ b/src/com/android/launcher3/LauncherRootView.java
@@ -26,7 +26,7 @@ import java.util.Collections;
 import java.util.List;
 
 import com.hoko.blur.HokoBlur;
-import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 import app.lawnchair.preferences.PreferenceManager;
 import app.lawnchair.preferences2.PreferenceManager2;
 import app.lawnchair.util.FileAccessManager;
@@ -61,7 +61,7 @@ public class LauncherRootView extends InsettableFrameLayout {
         pref = PreferenceManager.getInstance(context);
         PreferenceManager2 prefs2 = PreferenceManager2.getInstance(context);
         
-        mEnableTaskbarOnPhone = PreferenceExtensionsKt.firstBlocking(prefs2.getEnableTaskbarOnPhone());
+        mEnableTaskbarOnPhone = PreferenceCacheExtensionsKt.firstCached(prefs2.getEnableTaskbarOnPhone(), prefs2);
 
         FileAccessManager fileAccessManager = FileAccessManager.getInstance(context);
         FileAccessState wallpaperAccessState = fileAccessManager.getWallpaperAccessState().getValue();

--- a/src/com/android/launcher3/PagedView.java
+++ b/src/com/android/launcher3/PagedView.java
@@ -63,7 +63,7 @@ import com.android.launcher3.util.IntSet;
 import com.android.launcher3.util.Thunk;
 import com.android.launcher3.views.ActivityContext;
 
-import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 import java.util.ArrayList;
 import java.util.function.Consumer;
 
@@ -1423,7 +1423,7 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
                     // move to the left and fling to the right will register as a fling to the right.
 
                     boolean infiniteScroll = prefs.getInfiniteScrolling().get();
-                    boolean enableFeed = PreferenceExtensionsKt.firstBlocking(prefs2.getEnableFeed());
+                    boolean enableFeed = PreferenceCacheExtensionsKt.firstCached(prefs2.getEnableFeed(), prefs2);
 
                     if (((isSignificantMove && !isDeltaLeft && !isFling) ||
                             (isFling && !isVelocityLeft)) && mCurrentPage > 0) {

--- a/src/com/android/launcher3/PagedView.java
+++ b/src/com/android/launcher3/PagedView.java
@@ -1423,7 +1423,7 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
                     // move to the left and fling to the right will register as a fling to the right.
 
                     boolean infiniteScroll = prefs.getInfiniteScrolling().get();
-                    boolean enableFeed = PreferenceCacheExtensionsKt.firstCached(prefs2.getEnableFeed(), prefs2);
+                    boolean enableFeed = PreferenceCacheExtensionsKt.firstCached(prefs2.getEnableFeed());
 
                     if (((isSignificantMove && !isDeltaLeft && !isFling) ||
                             (isFling && !isVelocityLeft)) && mCurrentPage > 0) {

--- a/src/com/android/launcher3/SessionCommitReceiver.java
+++ b/src/com/android/launcher3/SessionCommitReceiver.java
@@ -113,7 +113,7 @@ public class SessionCommitReceiver extends BroadcastReceiver {
         if (Flags.privateSpaceRestrictItemDrag() 
             && user != null) {
             PreferenceManager2 prefs2 = PreferenceManager2.getInstance(context);
-            if (PreferenceCacheExtensionsKt.firstCached(prefs2.getLockHomeScreen(), prefs2)
+            if (PreferenceCacheExtensionsKt.firstCached(prefs2.getLockHomeScreen())
                 && UserCache.getInstance(context).getUserInfo(user).isPrivate()) {
                 return false;
             }

--- a/src/com/android/launcher3/SessionCommitReceiver.java
+++ b/src/com/android/launcher3/SessionCommitReceiver.java
@@ -32,8 +32,7 @@ import com.android.launcher3.model.ItemInstallQueue;
 import com.android.launcher3.pm.InstallSessionHelper;
 import com.android.launcher3.pm.UserCache;
 import com.android.launcher3.util.Executors;
-import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
-
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 import app.lawnchair.preferences2.PreferenceManager2;
 
 import java.util.Locale;
@@ -112,10 +111,12 @@ public class SessionCommitReceiver extends BroadcastReceiver {
      */
     public static boolean isEnabled(Context context, UserHandle user) {
         if (Flags.privateSpaceRestrictItemDrag() 
-            && PreferenceExtensionsKt.firstBlocking(PreferenceManager2.getInstance(context).getLockHomeScreen())
-            && user != null
-            && UserCache.getInstance(context).getUserInfo(user).isPrivate()) {
-            return false;
+            && user != null) {
+            PreferenceManager2 prefs2 = PreferenceManager2.getInstance(context);
+            if (PreferenceCacheExtensionsKt.firstCached(prefs2.getLockHomeScreen(), prefs2)
+                && UserCache.getInstance(context).getUserInfo(user).isPrivate()) {
+                return false;
+            }
         }
         return LauncherPrefs.getPrefs(context).getBoolean(ADD_ICON_PREFERENCE_KEY, true);
     }

--- a/src/com/android/launcher3/ShortcutAndWidgetContainer.java
+++ b/src/com/android/launcher3/ShortcutAndWidgetContainer.java
@@ -87,7 +87,7 @@ public class ShortcutAndWidgetContainer extends ViewGroup implements FolderIcon.
     @Override
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
-        boolean mAllowWidgetOverlap = PreferenceCacheExtensionsKt.firstCached(mPreferenceManager2.getAllowWidgetOverlap(), mPreferenceManager2);
+        boolean mAllowWidgetOverlap = PreferenceCacheExtensionsKt.firstCached(mPreferenceManager2.getAllowWidgetOverlap());
         setClipChildren(!mAllowWidgetOverlap);
         setClipToPadding(!mAllowWidgetOverlap);
         setClipToOutline(!mAllowWidgetOverlap);

--- a/src/com/android/launcher3/ShortcutAndWidgetContainer.java
+++ b/src/com/android/launcher3/ShortcutAndWidgetContainer.java
@@ -43,7 +43,7 @@ import com.android.launcher3.model.data.ItemInfo;
 import com.android.launcher3.views.ActivityContext;
 import com.android.launcher3.widget.LauncherAppWidgetHostView;
 import com.android.launcher3.widget.NavigableAppWidgetHostView;
-import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 
 import app.lawnchair.preferences2.PreferenceManager2;
 
@@ -87,7 +87,7 @@ public class ShortcutAndWidgetContainer extends ViewGroup implements FolderIcon.
     @Override
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
-        boolean mAllowWidgetOverlap = PreferenceExtensionsKt.firstBlocking(mPreferenceManager2.getAllowWidgetOverlap());
+        boolean mAllowWidgetOverlap = PreferenceCacheExtensionsKt.firstCached(mPreferenceManager2.getAllowWidgetOverlap(), mPreferenceManager2);
         setClipChildren(!mAllowWidgetOverlap);
         setClipToPadding(!mAllowWidgetOverlap);
         setClipToOutline(!mAllowWidgetOverlap);

--- a/src/com/android/launcher3/Workspace.java
+++ b/src/com/android/launcher3/Workspace.java
@@ -145,7 +145,7 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 import static app.lawnchair.util.LawnchairUtilsKt.toBitmap;
 import app.lawnchair.LawnchairApp;
 import app.lawnchair.LawnchairAppKt;
@@ -612,7 +612,7 @@ public class Workspace<T extends View & PageIndicator> extends PagedView<T>
     }
 
     public void updateStatusbarClock() {
-        if (mCurrentPage == 0 && PreferenceExtensionsKt.firstBlocking(mPreferenceManager2.getStatusBarClock())) {
+        if (mCurrentPage == 0 && PreferenceCacheExtensionsKt.firstCached(mPreferenceManager2.getStatusBarClock(), mPreferenceManager2)) {
             LawnchairAppKt.getLawnchairApp(mLauncher).hideClockInStatusBar();
         } else {
             LawnchairAppKt.getLawnchairApp(mLauncher).restoreClockInStatusBar();
@@ -662,18 +662,18 @@ public class Workspace<T extends View & PageIndicator> extends PagedView<T>
     public void bindAndInitFirstWorkspaceScreen() {
         // Add the first page
         CellLayout firstPage = insertNewWorkspaceScreen(Workspace.FIRST_SCREEN_ID, getChildCount());
-        if (!PreferenceExtensionsKt.firstBlocking(mPreferenceManager2.getEnableSmartspace())) {
+        if (!PreferenceCacheExtensionsKt.firstCached(mPreferenceManager2.getEnableSmartspace(), mPreferenceManager2)) {
             mFirstPagePinnedItem = null;
             return;
         }
         if (mFirstPagePinnedItem == null) {
-            SmartspaceMode smartspaceMode = PreferenceExtensionsKt
-                .firstBlocking(mPreferenceManager2.getSmartspaceMode());
+            SmartspaceMode smartspaceMode = PreferenceCacheExtensionsKt
+                .firstCached(mPreferenceManager2.getSmartspaceMode(), mPreferenceManager2);
             if (!smartspaceMode.isAvailable(this.mLauncher)) {
                 // The current smartspace mode is not available,
                 // setting the smartspace mode to one that is always available
                 smartspaceMode = LawnchairSmartspace.INSTANCE;
-                PreferenceExtensionsKt.setBlocking(mPreferenceManager2.getSmartspaceMode(), smartspaceMode);
+                com.patrykmichalik.opto.core.PreferenceExtensionsKt.setBlocking(mPreferenceManager2.getSmartspaceMode(), smartspaceMode);
             }
             // In transposed layout, we add the first page pinned widget in the Grid.
             // As workspace does not touch the edges, we do not need a full
@@ -1113,7 +1113,7 @@ public class Workspace<T extends View & PageIndicator> extends PagedView<T>
                     id, persistedScreenIds, isExtraEmptyScreen(id))) {
                 continue;
             }
-            if ((!PreferenceExtensionsKt.firstBlocking(PreferenceManager2.INSTANCE.get(getContext()).getEnableSmartspace()) || id > FIRST_SCREEN_ID)
+            if ((!PreferenceCacheExtensionsKt.firstCached(PreferenceManager2.INSTANCE.get(getContext()).getEnableSmartspace(), PreferenceManager2.INSTANCE.get(getContext())) || id > FIRST_SCREEN_ID)
                     && cl.getShortcutsAndWidgets().getChildCount() == 0) {
                 removeScreens.add(id);
             }
@@ -1174,7 +1174,7 @@ public class Workspace<T extends View & PageIndicator> extends PagedView<T>
         updateAccessibilityViewPageDescription();
 
         // Reset default home page if it's now out of range after page removal
-        int storedDefault = PreferenceExtensionsKt.firstBlocking(mPreferenceManager2.getDefaultHomePage());
+        int storedDefault = PreferenceCacheExtensionsKt.firstCached(mPreferenceManager2.getDefaultHomePage(), mPreferenceManager2);
         if (storedDefault >= getChildCount()) {
             setDefaultPage(DEFAULT_PAGE);
         }
@@ -1494,7 +1494,7 @@ public class Workspace<T extends View & PageIndicator> extends PagedView<T>
     public void showPageIndicatorAtCurrentScroll() {
         if (mPageIndicator != null) {
             mPageIndicator.setScroll(getScrollX(), computeMaxScroll());
-            var isHotseatEnabled = PreferenceExtensionsKt.firstBlocking(mPreferenceManager2.isHotseatEnabled());
+            var isHotseatEnabled = PreferenceCacheExtensionsKt.firstCached(mPreferenceManager2.isHotseatEnabled(), mPreferenceManager2);
             mPageIndicator.setVisibility(isHotseatEnabled ? VISIBLE : INVISIBLE);
         }
     }
@@ -1940,7 +1940,7 @@ public class Workspace<T extends View & PageIndicator> extends PagedView<T>
             }
         }
 
-        boolean lockHomeScreen = PreferenceExtensionsKt.firstBlocking(mPreferenceManager2.getLockHomeScreen());
+        boolean lockHomeScreen = PreferenceCacheExtensionsKt.firstCached(mPreferenceManager2.getLockHomeScreen(), mPreferenceManager2);
         if (lockHomeScreen) {
             child.setVisibility(View.VISIBLE);
 
@@ -2226,7 +2226,7 @@ public class Workspace<T extends View & PageIndicator> extends PagedView<T>
         boolean snappedToNewPage = false;
         boolean resizeOnDrop = false;
         Runnable onCompleteRunnable = null;
-        boolean forceWidgetResize = PreferenceExtensionsKt.firstBlocking(mPreferenceManager2.getForceWidgetResize());
+        boolean forceWidgetResize = PreferenceCacheExtensionsKt.firstCached(mPreferenceManager2.getForceWidgetResize(), mPreferenceManager2);
         if (d.dragSource != this || mDragInfo == null) {
             final int[] touchXY = new int[]{(int) mDragViewVisualCenter[0],
                     (int) mDragViewVisualCenter[1]};
@@ -3862,7 +3862,7 @@ public class Workspace<T extends View & PageIndicator> extends PagedView<T>
      * Falls back to {@link #DEFAULT_PAGE} if the stored page is out of range.
      */
     public int getDefaultPage() {
-        int storedPage = PreferenceExtensionsKt.firstBlocking(mPreferenceManager2.getDefaultHomePage());
+        int storedPage = PreferenceCacheExtensionsKt.firstCached(mPreferenceManager2.getDefaultHomePage(), mPreferenceManager2);
         int pageCount = getChildCount();
         if (storedPage >= 0 && storedPage < pageCount) {
             return storedPage;
@@ -3874,7 +3874,7 @@ public class Workspace<T extends View & PageIndicator> extends PagedView<T>
      * Sets the given page index as the default home page.
      */
     public void setDefaultPage(int pageIndex) {
-        PreferenceExtensionsKt.setBlocking(mPreferenceManager2.getDefaultHomePage(), pageIndex);
+        com.patrykmichalik.opto.core.PreferenceExtensionsKt.setBlocking(mPreferenceManager2.getDefaultHomePage(), pageIndex);
     }
 
     /**

--- a/src/com/android/launcher3/Workspace.java
+++ b/src/com/android/launcher3/Workspace.java
@@ -612,7 +612,7 @@ public class Workspace<T extends View & PageIndicator> extends PagedView<T>
     }
 
     public void updateStatusbarClock() {
-        if (mCurrentPage == 0 && PreferenceCacheExtensionsKt.firstCached(mPreferenceManager2.getStatusBarClock(), mPreferenceManager2)) {
+        if (mCurrentPage == 0 && PreferenceCacheExtensionsKt.firstCached(mPreferenceManager2.getStatusBarClock())) {
             LawnchairAppKt.getLawnchairApp(mLauncher).hideClockInStatusBar();
         } else {
             LawnchairAppKt.getLawnchairApp(mLauncher).restoreClockInStatusBar();
@@ -662,7 +662,7 @@ public class Workspace<T extends View & PageIndicator> extends PagedView<T>
     public void bindAndInitFirstWorkspaceScreen() {
         // Add the first page
         CellLayout firstPage = insertNewWorkspaceScreen(Workspace.FIRST_SCREEN_ID, getChildCount());
-        if (!PreferenceCacheExtensionsKt.firstCached(mPreferenceManager2.getEnableSmartspace(), mPreferenceManager2)) {
+        if (!PreferenceCacheExtensionsKt.firstCached(mPreferenceManager2.getEnableSmartspace())) {
             mFirstPagePinnedItem = null;
             return;
         }
@@ -1174,7 +1174,7 @@ public class Workspace<T extends View & PageIndicator> extends PagedView<T>
         updateAccessibilityViewPageDescription();
 
         // Reset default home page if it's now out of range after page removal
-        int storedDefault = PreferenceCacheExtensionsKt.firstCached(mPreferenceManager2.getDefaultHomePage(), mPreferenceManager2);
+        int storedDefault = PreferenceCacheExtensionsKt.firstCached(mPreferenceManager2.getDefaultHomePage());
         if (storedDefault >= getChildCount()) {
             setDefaultPage(DEFAULT_PAGE);
         }
@@ -1494,7 +1494,7 @@ public class Workspace<T extends View & PageIndicator> extends PagedView<T>
     public void showPageIndicatorAtCurrentScroll() {
         if (mPageIndicator != null) {
             mPageIndicator.setScroll(getScrollX(), computeMaxScroll());
-            var isHotseatEnabled = PreferenceCacheExtensionsKt.firstCached(mPreferenceManager2.isHotseatEnabled(), mPreferenceManager2);
+            var isHotseatEnabled = PreferenceCacheExtensionsKt.firstCached(mPreferenceManager2.isHotseatEnabled());
             mPageIndicator.setVisibility(isHotseatEnabled ? VISIBLE : INVISIBLE);
         }
     }
@@ -1940,7 +1940,7 @@ public class Workspace<T extends View & PageIndicator> extends PagedView<T>
             }
         }
 
-        boolean lockHomeScreen = PreferenceCacheExtensionsKt.firstCached(mPreferenceManager2.getLockHomeScreen(), mPreferenceManager2);
+        boolean lockHomeScreen = PreferenceCacheExtensionsKt.firstCached(mPreferenceManager2.getLockHomeScreen());
         if (lockHomeScreen) {
             child.setVisibility(View.VISIBLE);
 
@@ -2226,7 +2226,7 @@ public class Workspace<T extends View & PageIndicator> extends PagedView<T>
         boolean snappedToNewPage = false;
         boolean resizeOnDrop = false;
         Runnable onCompleteRunnable = null;
-        boolean forceWidgetResize = PreferenceCacheExtensionsKt.firstCached(mPreferenceManager2.getForceWidgetResize(), mPreferenceManager2);
+        boolean forceWidgetResize = PreferenceCacheExtensionsKt.firstCached(mPreferenceManager2.getForceWidgetResize());
         if (d.dragSource != this || mDragInfo == null) {
             final int[] touchXY = new int[]{(int) mDragViewVisualCenter[0],
                     (int) mDragViewVisualCenter[1]};
@@ -3862,7 +3862,7 @@ public class Workspace<T extends View & PageIndicator> extends PagedView<T>
      * Falls back to {@link #DEFAULT_PAGE} if the stored page is out of range.
      */
     public int getDefaultPage() {
-        int storedPage = PreferenceCacheExtensionsKt.firstCached(mPreferenceManager2.getDefaultHomePage(), mPreferenceManager2);
+        int storedPage = PreferenceCacheExtensionsKt.firstCached(mPreferenceManager2.getDefaultHomePage());
         int pageCount = getChildCount();
         if (storedPage >= 0 && storedPage < pageCount) {
             return storedPage;

--- a/src/com/android/launcher3/WorkspaceLayoutManager.java
+++ b/src/com/android/launcher3/WorkspaceLayoutManager.java
@@ -28,7 +28,7 @@ import com.android.launcher3.model.data.ItemInfo;
 import com.android.launcher3.touch.ItemLongClickListener;
 
 import app.lawnchair.preferences2.PreferenceManager2;
-import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 import com.android.launcher3.util.IntSet;
 
 public interface WorkspaceLayoutManager {
@@ -110,10 +110,10 @@ public interface WorkspaceLayoutManager {
 
             // Hide folder title in the hotseat
             if (child instanceof FolderIcon) {
+                PreferenceManager2 prefs = PreferenceManager2.getInstance(child.getContext());
                 ((FolderIcon) child).setTextVisible(
-                        PreferenceExtensionsKt.firstBlocking(
-                                PreferenceManager2.getInstance(child.getContext())
-                                        .getEnableLabelInDock())); // LC-Note: Show/hide folder title based on dock label preference
+                        PreferenceCacheExtensionsKt.firstCached(
+                                prefs.getEnableLabelInDock(), prefs));
             }
         } else {
             // Show folder title if not in the hotseat

--- a/src/com/android/launcher3/allapps/ActivityAllAppsContainerView.java
+++ b/src/com/android/launcher3/allapps/ActivityAllAppsContainerView.java
@@ -111,7 +111,7 @@ import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 import static com.topjohnwu.superuser.internal.Utils.context;
 import app.lawnchair.allapps.LawnchairAlphabeticalAppsList;
 import app.lawnchair.font.FontManager;
@@ -283,7 +283,7 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
      *   onFinishInflate -> onPostCreate
      */
     protected void initContent() {
-        showFastScroller = PreferenceExtensionsKt.firstBlocking(pref2.getShowScrollbar());
+        showFastScroller = PreferenceCacheExtensionsKt.firstCached(pref2.getShowScrollbar(), pref2);
 
         mMainAdapterProvider = mSearchUiDelegate.createMainAdapterProvider();
 
@@ -543,7 +543,7 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
      */
     public void reset(boolean animate, boolean exitSearch) {
         // Scroll Main and Work RV to top. Search RV is done in `resetSearch`.
-        if (!PreferenceExtensionsKt.firstBlocking(pref2.getRememberPosition())) {
+        if (!PreferenceCacheExtensionsKt.firstCached(pref2.getRememberPosition(), pref2)) {
             for (int i = 0; i < mAH.size(); i++) {
                 if (i != SEARCH && mAH.get(i).mRecyclerView != null) {
                     mAH.get(i).mRecyclerView.scrollToTop();
@@ -817,7 +817,7 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
     void setupHeader() {
         mAdditionalHeaderRows.forEach(row -> mHeader.onPluginDisconnected(row));
 
-        var hideHeader = PreferenceExtensionsKt.firstBlocking(pref2.getHideAppDrawerSearchBar());
+        var hideHeader = PreferenceCacheExtensionsKt.firstCached(pref2.getHideAppDrawerSearchBar(), pref2);
         mHeader.setVisibility(hideHeader ? View.GONE : View.VISIBLE);
         boolean tabsHidden = !mUsingTabs;
         mHeader.setup(
@@ -870,12 +870,12 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
     }
 
     protected void updateHeaderScroll(int scrolledOffset) {
-        if (PreferenceExtensionsKt.firstBlocking(pref2.getHideAppDrawerSearchBar()))
+        if (PreferenceCacheExtensionsKt.firstCached(pref2.getHideAppDrawerSearchBar(), pref2))
             return;
         
         // Check if tab container background should be shown
-        boolean showTabContainerBackground = PreferenceExtensionsKt.firstBlocking(
-                pref2.getWorkProfileTabContainerBackground());
+        boolean showTabContainerBackground = PreferenceCacheExtensionsKt.firstCached(
+                pref2.getWorkProfileTabContainerBackground(), pref2);
         
         float prog = Utilities.boundToRange((float) scrolledOffset / mHeaderThreshold, 0f, 1f);
         int headerColor = getHeaderColor(prog);
@@ -904,8 +904,8 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
     protected int getHeaderColor(float blendRatio) {
         if (!mActivityContext.getDeviceProfile().shouldShowAllAppsOnSheet()) {
             float opacity = mSearchContainer.getAlpha();
-            var showHeaderBackground = PreferenceExtensionsKt.firstBlocking(
-                pref2.getAppDrawerSearchBarBackground());
+            var showHeaderBackground = PreferenceCacheExtensionsKt.firstCached(
+                pref2.getAppDrawerSearchBarBackground(), pref2);
             if (showHeaderBackground) {
                 opacity = pref.getDrawerOpacity().get();
             }
@@ -1034,7 +1034,7 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
 
     private void alignParentTop(View v, boolean includeTabsMargin) {
         if (!(v.getLayoutParams() instanceof RelativeLayout.LayoutParams)
-                || PreferenceExtensionsKt.firstBlocking(pref2.getHideAppDrawerSearchBar())) {
+                || PreferenceCacheExtensionsKt.firstCached(pref2.getHideAppDrawerSearchBar(), pref2)) {
             return;
         }
 
@@ -1049,7 +1049,7 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
 
     private void removeCustomRules(View v) {
         if (!(v.getLayoutParams() instanceof RelativeLayout.LayoutParams)
-                || PreferenceExtensionsKt.firstBlocking(pref2.getHideAppDrawerSearchBar())) {
+                || PreferenceCacheExtensionsKt.firstCached(pref2.getHideAppDrawerSearchBar(), pref2)) {
             return;
         }
 

--- a/src/com/android/launcher3/allapps/ActivityAllAppsContainerView.java
+++ b/src/com/android/launcher3/allapps/ActivityAllAppsContainerView.java
@@ -283,7 +283,7 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
      *   onFinishInflate -> onPostCreate
      */
     protected void initContent() {
-        showFastScroller = PreferenceCacheExtensionsKt.firstCached(pref2.getShowScrollbar(), pref2);
+        showFastScroller = PreferenceCacheExtensionsKt.firstCached(pref2.getShowScrollbar());
 
         mMainAdapterProvider = mSearchUiDelegate.createMainAdapterProvider();
 
@@ -543,7 +543,7 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
      */
     public void reset(boolean animate, boolean exitSearch) {
         // Scroll Main and Work RV to top. Search RV is done in `resetSearch`.
-        if (!PreferenceCacheExtensionsKt.firstCached(pref2.getRememberPosition(), pref2)) {
+        if (!PreferenceCacheExtensionsKt.firstCached(pref2.getRememberPosition())) {
             for (int i = 0; i < mAH.size(); i++) {
                 if (i != SEARCH && mAH.get(i).mRecyclerView != null) {
                     mAH.get(i).mRecyclerView.scrollToTop();
@@ -817,7 +817,7 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
     void setupHeader() {
         mAdditionalHeaderRows.forEach(row -> mHeader.onPluginDisconnected(row));
 
-        var hideHeader = PreferenceCacheExtensionsKt.firstCached(pref2.getHideAppDrawerSearchBar(), pref2);
+        var hideHeader = PreferenceCacheExtensionsKt.firstCached(pref2.getHideAppDrawerSearchBar());
         mHeader.setVisibility(hideHeader ? View.GONE : View.VISIBLE);
         boolean tabsHidden = !mUsingTabs;
         mHeader.setup(
@@ -870,7 +870,7 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
     }
 
     protected void updateHeaderScroll(int scrolledOffset) {
-        if (PreferenceCacheExtensionsKt.firstCached(pref2.getHideAppDrawerSearchBar(), pref2))
+        if (PreferenceCacheExtensionsKt.firstCached(pref2.getHideAppDrawerSearchBar()))
             return;
         
         // Check if tab container background should be shown
@@ -1034,7 +1034,7 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
 
     private void alignParentTop(View v, boolean includeTabsMargin) {
         if (!(v.getLayoutParams() instanceof RelativeLayout.LayoutParams)
-                || PreferenceCacheExtensionsKt.firstCached(pref2.getHideAppDrawerSearchBar(), pref2)) {
+                || PreferenceCacheExtensionsKt.firstCached(pref2.getHideAppDrawerSearchBar())) {
             return;
         }
 
@@ -1049,7 +1049,7 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
 
     private void removeCustomRules(View v) {
         if (!(v.getLayoutParams() instanceof RelativeLayout.LayoutParams)
-                || PreferenceCacheExtensionsKt.firstCached(pref2.getHideAppDrawerSearchBar(), pref2)) {
+                || PreferenceCacheExtensionsKt.firstCached(pref2.getHideAppDrawerSearchBar())) {
             return;
         }
 

--- a/src/com/android/launcher3/allapps/AllAppsTransitionController.java
+++ b/src/com/android/launcher3/allapps/AllAppsTransitionController.java
@@ -67,7 +67,7 @@ import com.android.launcher3.views.ScrimView;
 import com.google.android.msdl.data.model.MSDLToken;
 
 import app.lawnchair.preferences2.PreferenceManager2;
-import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 
 /**
  * Handles AllApps view transition.
@@ -404,8 +404,9 @@ public class AllAppsTransitionController
         setAlphas(toState, config, builder);
         // This controls both haptics for tapping on QSB and going to all apps.
         if (ALL_APPS.equals(toState) && mLauncher.isInState(NORMAL)) {
-            boolean hapticEnabled = PreferenceExtensionsKt.firstBlocking(
-                    PreferenceManager2.getInstance(mLauncher).getAppDrawerHapticFeedback());
+            PreferenceManager2 prefs = PreferenceManager2.getInstance(mLauncher);
+            boolean hapticEnabled = PreferenceCacheExtensionsKt.firstCached(
+                    prefs.getAppDrawerHapticFeedback(), prefs);
 
             if (hapticEnabled) {
                 if (Flags.msdlFeedback()) {

--- a/src/com/android/launcher3/allapps/FloatingHeaderView.java
+++ b/src/com/android/launcher3/allapps/FloatingHeaderView.java
@@ -42,7 +42,7 @@ import com.android.launcher3.workprofile.PersonalWorkSlidingTabStrip;
 import com.android.systemui.plugins.AllAppsRow;
 import com.android.systemui.plugins.AllAppsRow.OnHeightUpdatedListener;
 import com.android.systemui.plugins.PluginListener;
-import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -405,7 +405,7 @@ public class FloatingHeaderView extends LinearLayout implements
         }
         mHeaderCollapsed = false;
         mSnappedScrolledY = -mMaxTranslation;
-        if (!PreferenceExtensionsKt.firstBlocking (pref2.getRememberPosition ())) {
+        if (!PreferenceCacheExtensionsKt.firstCached(pref2.getRememberPosition(), pref2)) {
             mCurrentRV.scrollToTop();
         }
     }

--- a/src/com/android/launcher3/allapps/FloatingHeaderView.java
+++ b/src/com/android/launcher3/allapps/FloatingHeaderView.java
@@ -405,7 +405,7 @@ public class FloatingHeaderView extends LinearLayout implements
         }
         mHeaderCollapsed = false;
         mSnappedScrolledY = -mMaxTranslation;
-        if (!PreferenceCacheExtensionsKt.firstCached(pref2.getRememberPosition(), pref2)) {
+        if (!PreferenceCacheExtensionsKt.firstCached(pref2.getRememberPosition())) {
             mCurrentRV.scrollToTop();
         }
     }

--- a/src/com/android/launcher3/celllayout/ReorderAlgorithm.java
+++ b/src/com/android/launcher3/celllayout/ReorderAlgorithm.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
-import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 
 /**
  * Contains the logic of a reorder.
@@ -134,7 +134,7 @@ public class ReorderAlgorithm {
         Rect occupiedRect = new Rect(cellX, cellY, cellX + spanX, cellY + spanY);
 
         // Lawnchair: Widget overlap
-        if (PreferenceExtensionsKt.firstBlocking(mCellLayout.pref.getAllowWidgetOverlap())) {
+        if (PreferenceCacheExtensionsKt.firstCached(mCellLayout.pref.getAllowWidgetOverlap(), mCellLayout.pref)) {
             solution.intersectingViews = new ArrayList<>(intersectingViews);
             return true;
         }

--- a/src/com/android/launcher3/dragndrop/DragController.java
+++ b/src/com/android/launcher3/dragndrop/DragController.java
@@ -44,7 +44,7 @@ import com.android.launcher3.model.data.ItemInfoWithIcon;
 import com.android.launcher3.model.data.WorkspaceItemInfo;
 import com.android.launcher3.util.TouchController;
 import com.android.launcher3.views.ActivityContext;
-import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 
 import java.util.ArrayList;
 import java.util.Optional;
@@ -558,7 +558,7 @@ public abstract class DragController<T extends ActivityContext>
                     dropTarget.onDrop(mDragObject, mOptions);
                 }
                 accepted = true;
-                if (PreferenceExtensionsKt.firstBlocking(pref2.getDeckLayout()) && dropTarget instanceof DeleteDropTarget &&
+                if (PreferenceCacheExtensionsKt.firstCached(pref2.getDeckLayout(), pref2) && dropTarget instanceof DeleteDropTarget &&
                         isNeedCancelDrag(mDragObject.dragInfo)) {
                     cancelDrag();
                 }

--- a/src/com/android/launcher3/dragndrop/DragController.java
+++ b/src/com/android/launcher3/dragndrop/DragController.java
@@ -558,7 +558,7 @@ public abstract class DragController<T extends ActivityContext>
                     dropTarget.onDrop(mDragObject, mOptions);
                 }
                 accepted = true;
-                if (PreferenceCacheExtensionsKt.firstCached(pref2.getDeckLayout(), pref2) && dropTarget instanceof DeleteDropTarget &&
+                if (PreferenceCacheExtensionsKt.firstCached(pref2.getDeckLayout()) && dropTarget instanceof DeleteDropTarget &&
                         isNeedCancelDrag(mDragObject.dragInfo)) {
                     cancelDrag();
                 }

--- a/src/com/android/launcher3/folder/FolderAnimationManager.java
+++ b/src/com/android/launcher3/folder/FolderAnimationManager.java
@@ -53,7 +53,7 @@ import com.android.launcher3.graphics.ThemeManager;
 import com.android.launcher3.util.Themes;
 import com.android.launcher3.views.BaseDragLayer;
 import com.androidinternal.graphics.ColorUtils;
-import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 
 import java.util.List;
 
@@ -197,7 +197,7 @@ public class FolderAnimationManager implements FolderAnimationCreator {
         int initialColor = ColorUtils.setAlphaComponent(previewColor, LawnchairUtilsKt.getFolderPreviewAlpha(mContext));
         int finalColor = ColorTokens.FolderBackgroundColor.resolveColor(mContext);
 
-        ColorOption colorOption = PreferenceExtensionsKt.firstBlocking(mFolder.preferenceManager2.getFolderColor());
+        ColorOption colorOption = PreferenceCacheExtensionsKt.firstCached(mFolder.preferenceManager2.getFolderColor(), mFolder.preferenceManager2);
         int folderColor = colorOption.getColorPreferenceEntry().getLightColor().invoke(mContext);
 
         if (folderColor != 0) {

--- a/src/com/android/launcher3/folder/FolderNameEditText.java
+++ b/src/com/android/launcher3/folder/FolderNameEditText.java
@@ -139,7 +139,7 @@ public class FolderNameEditText extends ExtendedEditText {
 
     @Override
     public boolean onTouchEvent(MotionEvent event) {
-        if (PreferenceCacheExtensionsKt.firstCached(mPreferenceManager2.getLockHomeScreen(), mPreferenceManager2)) return true;
+        if (PreferenceCacheExtensionsKt.firstCached(mPreferenceManager2.getLockHomeScreen())) return true;
         return super.onTouchEvent(event);
     }
 }

--- a/src/com/android/launcher3/folder/FolderNameEditText.java
+++ b/src/com/android/launcher3/folder/FolderNameEditText.java
@@ -27,7 +27,7 @@ import android.view.inputmethod.InputConnectionWrapper;
 import android.view.inputmethod.InputMethodManager;
 
 import com.android.launcher3.ExtendedEditText;
-import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 
 import java.util.List;
 
@@ -139,7 +139,7 @@ public class FolderNameEditText extends ExtendedEditText {
 
     @Override
     public boolean onTouchEvent(MotionEvent event) {
-        if (PreferenceExtensionsKt.firstBlocking(mPreferenceManager2.getLockHomeScreen())) return true;
+        if (PreferenceCacheExtensionsKt.firstCached(mPreferenceManager2.getLockHomeScreen(), mPreferenceManager2)) return true;
         return super.onTouchEvent(event);
     }
 }

--- a/src/com/android/launcher3/folder/PreviewBackground.java
+++ b/src/com/android/launcher3/folder/PreviewBackground.java
@@ -192,11 +192,11 @@ public class PreviewBackground extends DelegatedCellDrawing {
         PreferenceManager2 preferenceManager2 = PreferenceManager2.INSTANCE.get(context);
 
         // Load folder color
-        ColorOption colorOption = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getFolderColor(), preferenceManager2);
+        ColorOption colorOption = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getFolderColor());
         int folderColor = colorOption.getColorPreferenceEntry().getLightColor().invoke(context);
 
         TypedArray ta = context.getTheme().obtainStyledAttributes(R.styleable.FolderIconPreview);
-        ColorOption dotColorOption = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getNotificationDotColor(), preferenceManager2);
+        ColorOption dotColorOption = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getNotificationDotColor());
         mDotColor = dotColorOption.getColorPreferenceEntry().getLightColor().invoke(context);
         mStrokeColor = ColorTokens.FolderIconBorderColor.resolveColor(context);
         if (folderColor != 0) {

--- a/src/com/android/launcher3/folder/PreviewBackground.java
+++ b/src/com/android/launcher3/folder/PreviewBackground.java
@@ -56,7 +56,7 @@ import com.android.launcher3.graphics.ShapeDelegate;
 import com.android.launcher3.graphics.ThemeManager;
 import com.android.launcher3.util.Themes;
 import com.android.launcher3.views.ActivityContext;
-import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 
 import app.lawnchair.preferences2.PreferenceManager2;
 import app.lawnchair.theme.color.ColorOption;
@@ -192,11 +192,11 @@ public class PreviewBackground extends DelegatedCellDrawing {
         PreferenceManager2 preferenceManager2 = PreferenceManager2.INSTANCE.get(context);
 
         // Load folder color
-        ColorOption colorOption = PreferenceExtensionsKt.firstBlocking(preferenceManager2.getFolderColor());
+        ColorOption colorOption = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getFolderColor(), preferenceManager2);
         int folderColor = colorOption.getColorPreferenceEntry().getLightColor().invoke(context);
 
         TypedArray ta = context.getTheme().obtainStyledAttributes(R.styleable.FolderIconPreview);
-        ColorOption dotColorOption = PreferenceExtensionsKt.firstBlocking(preferenceManager2.getNotificationDotColor());
+        ColorOption dotColorOption = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getNotificationDotColor(), preferenceManager2);
         mDotColor = dotColorOption.getColorPreferenceEntry().getLightColor().invoke(context);
         mStrokeColor = ColorTokens.FolderIconBorderColor.resolveColor(context);
         if (folderColor != 0) {

--- a/src/com/android/launcher3/model/DatabaseHelper.java
+++ b/src/com/android/launcher3/model/DatabaseHelper.java
@@ -53,7 +53,8 @@ import com.android.launcher3.util.PackageManagerHelper;
 import com.android.launcher3.util.Thunk;
 import com.android.launcher3.widget.LauncherWidgetHolder;
 
-import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
+import app.lawnchair.preferences2.PreferenceManager2;
 import java.io.File;
 import java.net.URISyntaxException;
 import java.util.Arrays;
@@ -259,7 +260,8 @@ public class DatabaseHelper extends NoLocaleSQLiteHelper implements
                         Favorites.SCREEN, IntArray.wrap(-777, -778)), null);
             }
             case 30: {
-                if (PreferenceExtensionsKt.firstBlocking(PreferenceManager2.INSTANCE.get(mContext).getEnableSmartspace())) {
+                PreferenceManager2 prefs = PreferenceManager2.INSTANCE.get(mContext);
+                if (PreferenceCacheExtensionsKt.firstCached(prefs.getEnableSmartspace(), prefs)) {
                     // Clean up first row in screen 0 as it might contain junk data.
                     Log.d(TAG, "Cleaning up first row");
                     db.delete(Favorites.TABLE_NAME,

--- a/src/com/android/launcher3/model/DatabaseHelper.java
+++ b/src/com/android/launcher3/model/DatabaseHelper.java
@@ -261,7 +261,7 @@ public class DatabaseHelper extends NoLocaleSQLiteHelper implements
             }
             case 30: {
                 PreferenceManager2 prefs = PreferenceManager2.INSTANCE.get(mContext);
-                if (PreferenceCacheExtensionsKt.firstCached(prefs.getEnableSmartspace(), prefs)) {
+                if (PreferenceCacheExtensionsKt.firstCached(prefs.getEnableSmartspace())) {
                     // Clean up first row in screen 0 as it might contain junk data.
                     Log.d(TAG, "Cleaning up first row");
                     db.delete(Favorites.TABLE_NAME,

--- a/src/com/android/launcher3/model/GridSizeMigrationDBController.java
+++ b/src/com/android/launcher3/model/GridSizeMigrationDBController.java
@@ -55,7 +55,7 @@ import com.android.launcher3.util.IntArray;
 import com.android.launcher3.widget.LauncherAppWidgetProviderInfo;
 import com.android.launcher3.widget.WidgetManagerHelper;
 
-import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -400,7 +400,7 @@ public class GridSizeMigrationDBController {
             @NonNull final List<DbEntry> sortedItemsToPlace, List<Integer> idsInUse, Context context) {
         PreferenceManager2 prefs2 = PreferenceManager2.INSTANCE.get(context);
         
-        boolean smartspaceEnabled = PreferenceExtensionsKt.firstBlocking(prefs2.getEnableSmartspace());
+        boolean smartspaceEnabled = PreferenceCacheExtensionsKt.firstCached(prefs2.getEnableSmartspace(), prefs2);
         
         final GridOccupancy occupied = new GridOccupancy(trgX, trgY);
         final Point trg = new Point(trgX, trgY);

--- a/src/com/android/launcher3/model/GridSizeMigrationDBController.java
+++ b/src/com/android/launcher3/model/GridSizeMigrationDBController.java
@@ -400,7 +400,7 @@ public class GridSizeMigrationDBController {
             @NonNull final List<DbEntry> sortedItemsToPlace, List<Integer> idsInUse, Context context) {
         PreferenceManager2 prefs2 = PreferenceManager2.INSTANCE.get(context);
         
-        boolean smartspaceEnabled = PreferenceCacheExtensionsKt.firstCached(prefs2.getEnableSmartspace(), prefs2);
+        boolean smartspaceEnabled = PreferenceCacheExtensionsKt.firstCached(prefs2.getEnableSmartspace());
         
         final GridOccupancy occupied = new GridOccupancy(trgX, trgY);
         final Point trg = new Point(trgX, trgY);

--- a/src/com/android/launcher3/model/GridSizeMigrationLogic.kt
+++ b/src/com/android/launcher3/model/GridSizeMigrationLogic.kt
@@ -44,7 +44,7 @@ import com.android.launcher3.provider.LauncherDbUtils.shiftWorkspaceByXCells
 import com.android.launcher3.util.CellAndSpan
 import com.android.launcher3.util.GridOccupancy
 import com.android.launcher3.util.IntArray
-import com.patrykmichalik.opto.core.firstBlocking
+import app.lawnchair.preferences2.firstCached
 
 class GridSizeMigrationLogic {
     /**
@@ -507,7 +507,7 @@ class GridSizeMigrationLogic {
         val prefs2 = PreferenceManager2.INSTANCE.get(context)
 
         val next: Point =
-            if (screenId == 0 && prefs2.enableSmartspace.firstBlocking()) {
+            if (screenId == 0 && prefs2.enableSmartspace.firstCached(prefs2)) {
                 Point(0, 1 /* smartspace */)
             } else {
                 Point(0, 0)

--- a/src/com/android/launcher3/model/GridSizeMigrationLogic.kt
+++ b/src/com/android/launcher3/model/GridSizeMigrationLogic.kt
@@ -507,7 +507,7 @@ class GridSizeMigrationLogic {
         val prefs2 = PreferenceManager2.INSTANCE.get(context)
 
         val next: Point =
-            if (screenId == 0 && prefs2.enableSmartspace.firstCached(prefs2)) {
+            if (screenId == 0 && prefs2.enableSmartspace.firstCached()) {
                 Point(0, 1 /* smartspace */)
             } else {
                 Point(0, 0)

--- a/src/com/android/launcher3/model/LoaderCursor.java
+++ b/src/com/android/launcher3/model/LoaderCursor.java
@@ -80,7 +80,7 @@ import dagger.assisted.AssistedInject;
 import java.net.URISyntaxException;
 import java.security.InvalidParameterException;
 
-import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 import app.lawnchair.LawnchairApp;
 import app.lawnchair.preferences2.PreferenceManager2;
 
@@ -646,7 +646,7 @@ public class LoaderCursor extends CursorWrapper {
 
         if (!mOccupied.containsKey(item.screenId)) {
             GridOccupancy screen = new GridOccupancy(countX + 1, countY + 1);
-            if (item.screenId == Workspace.FIRST_SCREEN_ID && PreferenceExtensionsKt.firstBlocking(preferenceManager2.getEnableSmartspace())) {
+            if (item.screenId == Workspace.FIRST_SCREEN_ID && PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getEnableSmartspace(), preferenceManager2)) {
                 // Mark the first X columns (X is width of the search container) in the first row as
                 // occupied (if the feature is enabled) in order to account for the search
                 // container.
@@ -667,7 +667,7 @@ public class LoaderCursor extends CursorWrapper {
                     + " into cell (" + containerIndex + "-" + item.screenId + ":"
                     + item.cellX + "," + item.cellX + "," + item.spanX + "," + item.spanY
                     + ") already occupied");
-            return PreferenceExtensionsKt.firstBlocking(preferenceManager2.getAllowWidgetOverlap());
+            return PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getAllowWidgetOverlap(), preferenceManager2);
         }
     }
 

--- a/src/com/android/launcher3/model/LoaderCursor.java
+++ b/src/com/android/launcher3/model/LoaderCursor.java
@@ -646,7 +646,7 @@ public class LoaderCursor extends CursorWrapper {
 
         if (!mOccupied.containsKey(item.screenId)) {
             GridOccupancy screen = new GridOccupancy(countX + 1, countY + 1);
-            if (item.screenId == Workspace.FIRST_SCREEN_ID && PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getEnableSmartspace(), preferenceManager2)) {
+            if (item.screenId == Workspace.FIRST_SCREEN_ID && PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getEnableSmartspace())) {
                 // Mark the first X columns (X is width of the search container) in the first row as
                 // occupied (if the feature is enabled) in order to account for the search
                 // container.
@@ -667,7 +667,7 @@ public class LoaderCursor extends CursorWrapper {
                     + " into cell (" + containerIndex + "-" + item.screenId + ":"
                     + item.cellX + "," + item.cellX + "," + item.spanX + "," + item.spanY
                     + ") already occupied");
-            return PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getAllowWidgetOverlap(), preferenceManager2);
+            return PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getAllowWidgetOverlap());
         }
     }
 

--- a/src/com/android/launcher3/model/PackageUpdatedTask.java
+++ b/src/com/android/launcher3/model/PackageUpdatedTask.java
@@ -72,7 +72,7 @@ import java.util.stream.Collectors;
 import app.lawnchair.deck.LawndeckManager;
 import app.lawnchair.preferences.PreferenceManager;
 import app.lawnchair.preferences2.PreferenceManager2;
-import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 
 /**
  * Handles updates due to changes in package manager (app installed/updated/removed)
@@ -465,7 +465,7 @@ public class PackageUpdatedTask implements ModelUpdateTask {
             
             // If deck layout is enabled, add newly installed apps to workspace with categorization
             PreferenceManager2 pref2 = PreferenceManager2.INSTANCE.get(context);
-            if (PreferenceExtensionsKt.firstBlocking(pref2.getDeckLayout())) {
+            if (PreferenceCacheExtensionsKt.firstCached(pref2.getDeckLayout(), pref2)) {
                 LawndeckManager deckManager = new LawndeckManager(context);
                 ModelWriter modelWriter = taskController.getModelWriter();
                 for (int i = 0; i < packageCount; i++) {

--- a/src/com/android/launcher3/model/PackageUpdatedTask.java
+++ b/src/com/android/launcher3/model/PackageUpdatedTask.java
@@ -465,7 +465,7 @@ public class PackageUpdatedTask implements ModelUpdateTask {
             
             // If deck layout is enabled, add newly installed apps to workspace with categorization
             PreferenceManager2 pref2 = PreferenceManager2.INSTANCE.get(context);
-            if (PreferenceCacheExtensionsKt.firstCached(pref2.getDeckLayout(), pref2)) {
+            if (PreferenceCacheExtensionsKt.firstCached(pref2.getDeckLayout())) {
                 LawndeckManager deckManager = new LawndeckManager(context);
                 ModelWriter modelWriter = taskController.getModelWriter();
                 for (int i = 0; i < packageCount; i++) {

--- a/src/com/android/launcher3/model/WorkspaceItemSpaceFinder.java
+++ b/src/com/android/launcher3/model/WorkspaceItemSpaceFinder.java
@@ -31,7 +31,8 @@ import com.android.launcher3.util.GridOccupancy;
 import com.android.launcher3.util.IntArray;
 import com.android.launcher3.util.IntSet;
 
-import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
+import app.lawnchair.preferences2.PreferenceManager2;
 import java.util.ArrayList;
 
 import javax.inject.Inject;
@@ -97,7 +98,8 @@ public class WorkspaceItemSpaceFinder {
         // First check the preferred screen.
         IntSet screensToExclude = new IntSet();
         
-        boolean smartspaceEnabled = PreferenceExtensionsKt.firstBlocking(PreferenceManager2.INSTANCE.get(context).getEnableSmartspace());
+        PreferenceManager2 prefs = PreferenceManager2.INSTANCE.get(context);
+        boolean smartspaceEnabled = PreferenceCacheExtensionsKt.firstCached(prefs.getEnableSmartspace(), prefs);
         if (smartspaceEnabled) {
             screensToExclude.add(FIRST_SCREEN_ID);
         }

--- a/src/com/android/launcher3/model/WorkspaceItemSpaceFinder.java
+++ b/src/com/android/launcher3/model/WorkspaceItemSpaceFinder.java
@@ -99,7 +99,7 @@ public class WorkspaceItemSpaceFinder {
         IntSet screensToExclude = new IntSet();
         
         PreferenceManager2 prefs = PreferenceManager2.INSTANCE.get(context);
-        boolean smartspaceEnabled = PreferenceCacheExtensionsKt.firstCached(prefs.getEnableSmartspace(), prefs);
+        boolean smartspaceEnabled = PreferenceCacheExtensionsKt.firstCached(prefs.getEnableSmartspace());
         if (smartspaceEnabled) {
             screensToExclude.add(FIRST_SCREEN_ID);
         }

--- a/src/com/android/launcher3/model/data/WorkspaceData.kt
+++ b/src/com/android/launcher3/model/data/WorkspaceData.kt
@@ -33,7 +33,7 @@ import com.android.launcher3.model.data.WorkspaceChangeEvent.UpdateEvent
 import com.android.launcher3.util.IntArray
 import com.android.launcher3.util.IntSet
 import com.android.launcher3.util.ItemInfoMatcher
-import com.patrykmichalik.opto.core.firstBlocking
+import app.lawnchair.preferences2.firstCached
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.stream.Stream
 import java.util.stream.StreamSupport
@@ -48,7 +48,7 @@ sealed class WorkspaceData : Iterable<ItemInfo> {
     // LC-Note: Add context to replace QSB_ON_FIRST_SCREEN config
     fun collectWorkspaceScreens(context: Context): IntArray {
         val prefs2 = PreferenceManager2.INSTANCE.get(context)
-        val smartspaceEnabled = prefs2.enableSmartspace.firstBlocking()
+        val smartspaceEnabled = prefs2.enableSmartspace.firstCached(prefs2)
 
         val screenSet = IntSet()
         forEach { if (it.container == CONTAINER_DESKTOP) screenSet.add(it.screenId) }

--- a/src/com/android/launcher3/model/data/WorkspaceData.kt
+++ b/src/com/android/launcher3/model/data/WorkspaceData.kt
@@ -48,7 +48,7 @@ sealed class WorkspaceData : Iterable<ItemInfo> {
     // LC-Note: Add context to replace QSB_ON_FIRST_SCREEN config
     fun collectWorkspaceScreens(context: Context): IntArray {
         val prefs2 = PreferenceManager2.INSTANCE.get(context)
-        val smartspaceEnabled = prefs2.enableSmartspace.firstCached(prefs2)
+        val smartspaceEnabled = prefs2.enableSmartspace.firstCached()
 
         val screenSet = IntSet()
         forEach { if (it.container == CONTAINER_DESKTOP) screenSet.add(it.screenId) }

--- a/src/com/android/launcher3/popup/SystemShortcut.java
+++ b/src/com/android/launcher3/popup/SystemShortcut.java
@@ -136,7 +136,7 @@ public abstract class SystemShortcut<T extends ActivityContext> extends ItemInfo
 
     private static boolean isHomeLocked(ActivityContext context) {
         PreferenceManager2 prefs = PreferenceManager2.getInstance(context.asContext());
-        return PreferenceCacheExtensionsKt.firstCached(prefs.getLockHomeScreen(), prefs);
+        return PreferenceCacheExtensionsKt.firstCached(prefs.getLockHomeScreen());
     }
 
     public static final Factory<ActivityContext> WIDGETS = (context, itemInfo, originalView) -> {

--- a/src/com/android/launcher3/popup/SystemShortcut.java
+++ b/src/com/android/launcher3/popup/SystemShortcut.java
@@ -52,7 +52,7 @@ import com.android.launcher3.widget.picker.model.data.WidgetPickerData;
 import java.net.URISyntaxException;
 import java.util.Arrays;
 
-import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 import app.lawnchair.preferences2.PreferenceManager2;
 
 /**
@@ -136,7 +136,7 @@ public abstract class SystemShortcut<T extends ActivityContext> extends ItemInfo
 
     private static boolean isHomeLocked(ActivityContext context) {
         PreferenceManager2 prefs = PreferenceManager2.getInstance(context.asContext());
-        return PreferenceExtensionsKt.firstBlocking(prefs.getLockHomeScreen());
+        return PreferenceCacheExtensionsKt.firstCached(prefs.getLockHomeScreen(), prefs);
     }
 
     public static final Factory<ActivityContext> WIDGETS = (context, itemInfo, originalView) -> {

--- a/src/com/android/launcher3/preview/LauncherPreviewRenderer.java
+++ b/src/com/android/launcher3/preview/LauncherPreviewRenderer.java
@@ -345,7 +345,7 @@ public class LauncherPreviewRenderer extends BaseContext
         populateHotseatPredictions(itemIdMap);
 
         // Add first page QSB
-        if (PreferenceCacheExtensionsKt.firstCached(mPreferenceManager2.getEnableSmartspace(), mPreferenceManager2)) {
+        if (PreferenceCacheExtensionsKt.firstCached(mPreferenceManager2.getEnableSmartspace())) {
             CellLayout firstScreen = mWorkspaceScreens.get(FIRST_SCREEN_ID);
             if (firstScreen != null) {
                 View qsb = mHomeElementInflater.inflate(mWorkspaceSearchContainer, firstScreen, false);

--- a/src/com/android/launcher3/preview/LauncherPreviewRenderer.java
+++ b/src/com/android/launcher3/preview/LauncherPreviewRenderer.java
@@ -79,7 +79,7 @@ import com.android.launcher3.util.window.WindowManagerProxy;
 import com.android.launcher3.views.BaseDragLayer;
 import com.android.launcher3.widget.LauncherWidgetHolder;
 
-import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -345,7 +345,7 @@ public class LauncherPreviewRenderer extends BaseContext
         populateHotseatPredictions(itemIdMap);
 
         // Add first page QSB
-        if (PreferenceExtensionsKt.firstBlocking(mPreferenceManager2.getEnableSmartspace())) {
+        if (PreferenceCacheExtensionsKt.firstCached(mPreferenceManager2.getEnableSmartspace(), mPreferenceManager2)) {
             CellLayout firstScreen = mWorkspaceScreens.get(FIRST_SCREEN_ID);
             if (firstScreen != null) {
                 View qsb = mHomeElementInflater.inflate(mWorkspaceSearchContainer, firstScreen, false);

--- a/src/com/android/launcher3/util/Themes.java
+++ b/src/com/android/launcher3/util/Themes.java
@@ -36,7 +36,7 @@ import com.android.launcher3.Utilities;
 import com.android.launcher3.icons.GraphicsUtils;
 import com.android.launcher3.views.ActivityContext;
 
-import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 import app.lawnchair.preferences.PreferenceManager;
 import app.lawnchair.preferences2.PreferenceManager2;
 import app.lawnchair.theme.color.ColorMode;
@@ -68,7 +68,7 @@ public class Themes {
 
     public static int getActivityThemeRes(Context context, int wallpaperColorHints) {
         PreferenceManager2 prefs2 = PreferenceManager2.getInstance(context);
-        ColorMode colorMode = PreferenceExtensionsKt.firstBlocking(prefs2.getWorkspaceTextColor());
+        ColorMode colorMode = PreferenceCacheExtensionsKt.firstCached(prefs2.getWorkspaceTextColor(), prefs2);
         boolean supportsDarkText = (wallpaperColorHints & HINT_SUPPORTS_DARK_TEXT) != 0;
         boolean isMainColorDark = (wallpaperColorHints & HINT_SUPPORTS_DARK_THEME) != 0;
 

--- a/src/com/android/launcher3/util/Themes.java
+++ b/src/com/android/launcher3/util/Themes.java
@@ -68,7 +68,7 @@ public class Themes {
 
     public static int getActivityThemeRes(Context context, int wallpaperColorHints) {
         PreferenceManager2 prefs2 = PreferenceManager2.getInstance(context);
-        ColorMode colorMode = PreferenceCacheExtensionsKt.firstCached(prefs2.getWorkspaceTextColor(), prefs2);
+        ColorMode colorMode = PreferenceCacheExtensionsKt.firstCached(prefs2.getWorkspaceTextColor());
         boolean supportsDarkText = (wallpaperColorHints & HINT_SUPPORTS_DARK_TEXT) != 0;
         boolean isMainColorDark = (wallpaperColorHints & HINT_SUPPORTS_DARK_THEME) != 0;
 

--- a/src/com/android/launcher3/views/OptionsPopupView.java
+++ b/src/com/android/launcher3/views/OptionsPopupView.java
@@ -274,7 +274,7 @@ public class OptionsPopupView<T extends Context & ActivityContext> extends Arrow
     private static boolean toggleHomeScreenLock(View v) {
         Context context = v.getContext();
         PreferenceManager2 preferenceManager2 = PreferenceManager2.getInstance(context);
-        boolean oldValue = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getLockHomeScreen(), preferenceManager2);
+        boolean oldValue = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getLockHomeScreen());
         com.patrykmichalik.opto.core.PreferenceExtensionsKt.setBlocking(preferenceManager2.getLockHomeScreen(), !oldValue);
         return true;
     }

--- a/src/com/android/launcher3/views/OptionsPopupView.java
+++ b/src/com/android/launcher3/views/OptionsPopupView.java
@@ -57,7 +57,7 @@ import com.android.launcher3.testing.shared.TestProtocol;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 import app.lawnchair.preferences2.PreferenceManager2;
 import app.lawnchair.ui.popup.LauncherOptionsPopup;
 
@@ -274,8 +274,8 @@ public class OptionsPopupView<T extends Context & ActivityContext> extends Arrow
     private static boolean toggleHomeScreenLock(View v) {
         Context context = v.getContext();
         PreferenceManager2 preferenceManager2 = PreferenceManager2.getInstance(context);
-        boolean oldValue = PreferenceExtensionsKt.firstBlocking(preferenceManager2.getLockHomeScreen());
-        PreferenceExtensionsKt.setBlocking(preferenceManager2.getLockHomeScreen(), !oldValue);
+        boolean oldValue = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getLockHomeScreen(), preferenceManager2);
+        com.patrykmichalik.opto.core.PreferenceExtensionsKt.setBlocking(preferenceManager2.getLockHomeScreen(), !oldValue);
         return true;
     }
 


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Fixes #6878 

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->

Cache instead of run blocking every time prefs are accessed, changes applied to preference will be immediately synced everywhere.

For compatibility reason, this will not remove `.firstBlocking()` but instead deprecate it so that it won't be a breaking changes for existing PR, and allows more time for other user to adapt to the new `.firstCached(prefs2)`.

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Prefs test

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Performance** (A code change that improves performance)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved responsiveness by switching many in-app preference reads to cached, non-blocking values across launcher UI, search, theming, gestures, and workspace/taskbar behaviors.
  * Added an in-memory preference cache to keep interactive updates feeling immediate.
* **Stability**
  * More consistent feature gating and rendering (including Smartspace and search) by relying on continuously refreshed cached preferences.
  * Properly stops background preference caching work when closing.
* **Developer Experience**
  * Added cached preference utilities (including lifecycle-aware Compose support) and discouraged blocking preference reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->