### PR TITLE
build: Use single build tools version

### DIFF
--- a/compatLib/build.gradle
+++ b/compatLib/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 android {
-    buildToolsVersion "36.1.0"
+    buildToolsVersion "37.0.0"
     namespace "app.lawnchair.compatlib"
 
     buildFeatures {

--- a/systemUI/animation/build.gradle
+++ b/systemUI/animation/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 // TODO: Pull out surfaceeffects outside of src and have separate build files there.
 android {
-    buildToolsVersion "36.1.0"
+    buildToolsVersion "37.0.0"
     namespace "com.android.systemui.animation"
     buildFeatures {
         aidl true

--- a/systemUI/common/build.gradle
+++ b/systemUI/common/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 android {
-    buildToolsVersion "36.1.0"
+    buildToolsVersion "37.0.0"
     namespace "com.android.systemui.common"
 
     sourceSets {

--- a/systemUI/log/build.gradle
+++ b/systemUI/log/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 android {
-    buildToolsVersion "36.1.0"
+    buildToolsVersion "37.0.0"
     namespace "com.android.systemui.log"
     buildFeatures {
         aidl true

--- a/systemUI/plugin/build.gradle
+++ b/systemUI/plugin/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 android {
-    buildToolsVersion "36.1.0"
+    buildToolsVersion "37.0.0"
     namespace "com.android.systemui.plugins"
     buildFeatures {
         aidl true

--- a/systemUI/plugin_core/build.gradle
+++ b/systemUI/plugin_core/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 android {
-    buildToolsVersion "36.1.0"
+    buildToolsVersion "37.0.0"
     namespace "com.android.systemui.plugin_core"
     buildFeatures {
         aidl true

--- a/systemUI/shared/build.gradle
+++ b/systemUI/shared/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 android {
-    buildToolsVersion "36.1.0"
+    buildToolsVersion "37.0.0"
     namespace "com.android.systemui.shared"
     buildFeatures {
         aidl true

--- a/systemUI/unfold/build.gradle
+++ b/systemUI/unfold/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 android {
-    buildToolsVersion "36.1.0"
+    buildToolsVersion "37.0.0"
     namespace "com.android.systemui.unfold"
     buildFeatures {
         aidl true

--- a/systemUI/utils/build.gradle
+++ b/systemUI/utils/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 android {
-    buildToolsVersion "36.1.0"
+    buildToolsVersion "37.0.0"
     namespace "com.android.systemui.utils"
     sourceSets {
         main {

--- a/wmshell/build.gradle
+++ b/wmshell/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 android {
-    buildToolsVersion "36.1.0"
+    buildToolsVersion "37.0.0"
     namespace "com.android.wm.shell"
     buildFeatures {
         aidl true


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Use `37.0.0` over `36.1.0` to be consistent with root configuration, and avoid downloading build tools 37 and 36.1 to compile Lawnchair.

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Project build

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Chore** (Changes to the build process or other tooling)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android build tools to version 37.0.0 across multiple modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->