### PR TITLE
feat: Use custom background colour for search result icon

### DIFF
--- a/lawnchair/src/app/lawnchair/search/adapter/SearchTargetFactory.kt
+++ b/lawnchair/src/app/lawnchair/search/adapter/SearchTargetFactory.kt
@@ -31,6 +31,8 @@ import app.lawnchair.search.algorithms.data.SettingInfo
 import app.lawnchair.search.algorithms.engine.provider.web.WebSearchProvider
 import app.lawnchair.theme.color.tokens.ColorTokens
 import app.lawnchair.util.calculateInSampleSize
+import app.lawnchair.util.createFilePreviewFallbackBitmap
+import app.lawnchair.util.createSmallSearchResultBitmap
 import app.lawnchair.util.createTextBitmap
 import app.lawnchair.util.file2Uri
 import app.lawnchair.util.mimeCompat
@@ -81,11 +83,9 @@ class SearchTargetFactory(
         val url = webSearchProvider.getSearchUrl(suggestion)
         val browserIntent = Intent(Intent.ACTION_VIEW, url.toUri())
         val id = suggestion + url
+        val bitmap = createSmallSearchResultBitmap(context, R.drawable.ic_allapps_search)
         val action = SearchActionCompat.Builder(id, suggestion).apply {
-            setIcon(
-                Icon.createWithResource(context, R.drawable.ic_allapps_search)
-                    .setTint(ColorTokens.TextColorSecondary.resolveColor(context)),
-            )
+            setIcon(Icon.createWithAdaptiveBitmap(bitmap))
             setIntent(browserIntent)
         }.build()
         return createSearchTarget(
@@ -104,11 +104,9 @@ class SearchTargetFactory(
         val equation = calculation.equation
         val uuid = UUID.randomUUID().toString()
         val id = "calculator:$uuid"
+        val bitmap = createSmallSearchResultBitmap(context, R.drawable.calculator)
         val action = SearchActionCompat.Builder(id, result)
-            .setIcon(
-                Icon.createWithResource(context, R.drawable.calculator)
-                    .setTint(ColorTokens.TextColorSecondary.resolveColor(context)),
-            )
+            .setIcon(Icon.createWithAdaptiveBitmap(bitmap))
             .setSubtitle(equation)
             .setIntent(Intent())
             .build()
@@ -149,11 +147,9 @@ class SearchTargetFactory(
         val value = recentKeyword.getValueByKey("display1") ?: ""
         val browserIntent = Intent(Intent.ACTION_VIEW, searchUrl(value).toUri())
         val id = recentKeyword.data.toString() + searchUrl(value)
+        val bitmap = createSmallSearchResultBitmap(context, R.drawable.ic_recent)
         val action = SearchActionCompat.Builder(id, value)
-            .setIcon(
-                Icon.createWithResource(context, R.drawable.ic_recent)
-                    .setTint(ColorTokens.TextColorSecondary.resolveColor(context)),
-            )
+            .setIcon(Icon.createWithAdaptiveBitmap(bitmap))
             .setIntent(browserIntent)
             .build()
         return createSearchTarget(
@@ -183,11 +179,9 @@ class SearchTargetFactory(
             return null
         }
 
+        val bitmap = createSmallSearchResultBitmap(context, R.drawable.ic_setting)
         val actionBuilder = SearchActionCompat.Builder(id, SettingsTarget.formatSettingTitle(info.name))
-            .setIcon(
-                Icon.createWithResource(context, R.drawable.ic_setting)
-                    .setTint(ColorTokens.Accent1_600.resolveColor(context)),
-            )
+            .setIcon(Icon.createWithAdaptiveBitmap(bitmap))
             .setIntent(intent)
             .build()
 
@@ -420,10 +414,14 @@ object FilesTarget {
     ): Icon {
         val fileInfo = info as? FileInfo
         return if (fileInfo?.isImageType == true) {
-            decodeThumbnailIcon(fileInfo.path)
-                ?: Icon.createWithResource(context, fileInfo.iconRes)
+            val bitmap = createFilePreviewFallbackBitmap(context, fileInfo.iconRes)
+            decodeThumbnailIcon(fileInfo.path) ?: Icon.createWithBitmap(bitmap)
         } else {
-            Icon.createWithResource(context, fileInfo?.iconRes ?: R.drawable.ic_folder)
+            val bitmap = createFilePreviewFallbackBitmap(
+                context,
+                fileInfo?.iconRes ?: R.drawable.ic_folder,
+            )
+            Icon.createWithBitmap(bitmap)
         }
     }
 
@@ -516,7 +514,7 @@ object ContactsTarget {
         // If contact photo is not available, create an icon with the first letter of the contact's name
         val initial = if (name.isNotEmpty()) name[0].uppercaseChar().toString() else "U"
         val textBitmap = createTextBitmap(context, initial)
-        return Icon.createWithBitmap(textBitmap)
+        return Icon.createWithAdaptiveBitmap(textBitmap)
     }
 }
 

--- a/lawnchair/src/app/lawnchair/search/adapter/SearchTargetFactory.kt
+++ b/lawnchair/src/app/lawnchair/search/adapter/SearchTargetFactory.kt
@@ -414,8 +414,8 @@ object FilesTarget {
     ): Icon {
         val fileInfo = info as? FileInfo
         return if (fileInfo?.isImageType == true) {
-            val bitmap = createFilePreviewFallbackBitmap(context, fileInfo.iconRes)
-            decodeThumbnailIcon(fileInfo.path) ?: Icon.createWithBitmap(bitmap)
+            decodeThumbnailIcon(fileInfo.path)
+                ?: Icon.createWithBitmap(createFilePreviewFallbackBitmap(context, fileInfo.iconRes))
         } else {
             val bitmap = createFilePreviewFallbackBitmap(
                 context,

--- a/lawnchair/src/app/lawnchair/theme/color/tokens/ColorTokens.kt
+++ b/lawnchair/src/app/lawnchair/theme/color/tokens/ColorTokens.kt
@@ -56,6 +56,8 @@ object ColorTokens {
     val Accent3_600 = SwatchColorToken(Swatch.Accent3, Shade.S600)
     val Accent3_800 = SwatchColorToken(Swatch.Accent3, Shade.S800)
 
+    @JvmField val SearchResultSmallIcon = DayNightColorToken(Accent1_100, Accent2_800)
+
     @JvmField val SurfaceContainerHighest = DayNightColorToken(Neutral1_500.setLStar(90.0), Neutral1_500.setLStar(22.0))
 
     @JvmField val SurfaceContainerLow = DayNightColorToken(Neutral1_500.setLStar(96.0), Neutral1_500.setLStar(10.0))

--- a/lawnchair/src/app/lawnchair/util/DrawableUtils.kt
+++ b/lawnchair/src/app/lawnchair/util/DrawableUtils.kt
@@ -5,7 +5,11 @@ import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.drawable.GradientDrawable
-import app.lawnchair.theme.color.generateColor
+import androidx.annotation.DrawableRes
+import androidx.core.content.ContextCompat
+import androidx.core.graphics.createBitmap
+import app.lawnchair.theme.color.tokens.ColorTokens
+import com.android.launcher3.R
 
 fun GradientDrawable.getCornerRadiiCompat(): FloatArray? = try {
     cornerRadii
@@ -13,15 +17,66 @@ fun GradientDrawable.getCornerRadiiCompat(): FloatArray? = try {
     null
 }
 
+/** Create a plain icon with [drawable] in the centre as fallback for file preview.
+ *
+ * For small icon search targets, use [createSmallSearchResultBitmap] instead. */
+fun createFilePreviewFallbackBitmap(context: Context, @DrawableRes drawable: Int): Bitmap {
+    val width = context.resources.getDimensionPixelSize(R.dimen.search_row_files_preview_width)
+    val height = context.resources.getDimensionPixelSize(R.dimen.search_row_files_preview_height)
+    val bitmap = createBitmap(width, height)
+    val canvas = Canvas(bitmap)
+
+    val backgroundColor = ColorTokens.SearchResultSmallIcon.resolveColor(context)
+    canvas.drawColor(backgroundColor)
+
+    val iconDrawable = ContextCompat.getDrawable(context, drawable)
+    iconDrawable?.let { d ->
+        d.mutate()
+        d.setTint(ColorTokens.TextColorPrimary.resolveColor(context))
+        val iconSize = (height * .6f).toInt()
+        val left = (width - iconSize) / 2
+        val top = (height - iconSize) / 2
+        d.setBounds(left, top, left + iconSize, top + iconSize)
+        d.draw(canvas)
+    }
+    return bitmap
+}
+
+/** Create a plain icon with [drawable] in the centre as small icon for search target.
+ *
+ * For file preview, use [createFilePreviewFallbackBitmap] instead. */
+fun createSmallSearchResultBitmap(context: Context, @DrawableRes drawable: Int): Bitmap {
+    val iconSize = context.resources.getDimensionPixelSize(android.R.dimen.app_icon_size)
+    val bitmap = createBitmap(iconSize, iconSize)
+    val canvas = Canvas(bitmap)
+
+    val backgroundColor = ColorTokens.SearchResultSmallIcon.resolveColor(context)
+    canvas.drawColor(backgroundColor)
+
+    val iconDrawable = ContextCompat.getDrawable(context, drawable)
+    iconDrawable?.let { drawable ->
+        drawable.mutate()
+        drawable.setTint(ColorTokens.TextColorPrimary.resolveColor(context))
+        val inset = (iconSize * .27f).toInt()
+        drawable.setBounds(inset, inset, iconSize - inset, iconSize - inset)
+        drawable.draw(canvas)
+    }
+    return bitmap
+}
+
+/** Create a plain icon with [text] in the centre as fallback for contacts search. */
 fun createTextBitmap(context: Context, text: String): Bitmap {
     val iconSize = context.resources.getDimensionPixelSize(android.R.dimen.app_icon_size)
-    val bitmap = Bitmap.createBitmap(iconSize, iconSize, Bitmap.Config.ARGB_8888)
+    val bitmap = createBitmap(iconSize, iconSize)
     val canvas = Canvas(bitmap)
+
+    val backgroundColor = ColorTokens.SearchResultSmallIcon.resolveColor(context)
+    canvas.drawColor(backgroundColor)
 
     // Set up paint for drawing text
     val paint = Paint().apply {
-        color = generateColor(context)
-        textSize = context.resources.getDimensionPixelSize(android.R.dimen.app_icon_size).toFloat()
+        color = ColorTokens.TextColorPrimary.resolveColor(context)
+        textSize = iconSize * .4f
         isAntiAlias = true
         textAlign = Paint.Align.CENTER
     }


### PR DESCRIPTION
Change-Id: 6a369c846fbc76e5767dc111

<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Set custom background colour for search result icons so that the background will be coloured instead of being plain white.

Additionally, fix preview placeholder icon from being out of margin/overblowed to full size

Additionally, make the contact placeholder background colour being deterministic instead of randomised

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->


### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **New feature** (A non-breaking change that adds functionality)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a theme color token for small search result icons.

* **Bug Fixes**
  * Improved icon rendering for web suggestions, calculator results, search history, and settings tiles to better match modern adaptive icon behavior.
  * Enhanced file preview and contact photo fallbacks for more consistent visuals.

* **Style**
  * Updated search result icon and text bitmap coloring to use the new token-based styling for improved consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->