### PR TITLE
fix: align home screen icons based on text size

### DIFF
--- a/src/com/android/launcher3/DeviceProfile.java
+++ b/src/com/android/launcher3/DeviceProfile.java
@@ -1201,7 +1201,7 @@ public class DeviceProfile {
         final boolean isVerticalLayout = isVerticalBarLayout();
         cellLayoutBorderSpacePx = getCellLayoutBorderSpace(inv, scale);
 
-        // Get initial text size before calculating layout
+        // Lawnchair: Get initial text size before calculating layout
         // This scales offset with text sizing, all the way down to zero
         iconTextSizePx *= mTextFactors.getIconTextSizeFactor();
 

--- a/src/com/android/launcher3/DeviceProfile.java
+++ b/src/com/android/launcher3/DeviceProfile.java
@@ -1201,6 +1201,10 @@ public class DeviceProfile {
         final boolean isVerticalLayout = isVerticalBarLayout();
         cellLayoutBorderSpacePx = getCellLayoutBorderSpace(inv, scale);
 
+        // Get initial text size before calculating layout
+        // This scales offset with text sizing, all the way down to zero
+        iconTextSizePx *= mTextFactors.getIconTextSizeFactor();
+
         if (mIsResponsiveGrid) {
             cellWidthPx = mResponsiveWorkspaceWidthSpec.getCellSizePx();
             cellHeightPx = mResponsiveWorkspaceHeightSpec.getCellSizePx();
@@ -1313,8 +1317,6 @@ public class DeviceProfile {
                 iconDrawablePaddingPx = cellPaddingY;
             }
         }
-
-        iconTextSizePx *= mTextFactors.getIconTextSizeFactor();
 
         // All apps
         if (mIsResponsiveGrid) {


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Account for text size when calculating icon alignment. With icon labels disabled on the home screen, this centers app icons.

Fixes #5231  <!-- optional -->

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->

The current behavior doesn't modify text size until after alignment calculations have occurred. This means icons are aligned to the top of their grid location regardless of text size or enabled/disabled status. The fix is just to move the text size update before the alignment calculations. If icons labels are disabled on the home screen, `iconTextSizePx` is set to zero already by existing code.


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

To test yourself, put icons on the desktop and enable/disable labels. For comparison, it's helpful to have a 1x1 widget as well. I used the Gemini widget (resized to 1x1) for this.

This is the original behavior with labels enabled.
<img width="270" height="600" alt="Screenshot_20260626_144959" src="https://github.com/user-attachments/assets/f32eee7a-a3c5-412c-8952-adbe0b3b23c4" />

This is the original behavior with labels disabled. Note how the icons are still aligned to top as if the text was present.
<img width="270" height="600" alt="Screenshot_20260626_144144" src="https://github.com/user-attachments/assets/9651cdb3-c755-4f7f-a0ca-dd8308b592c1" />

This is the new behavior with labels disabled. Note how the icons are now centered, or at least closer to centered.
<img width="270" height="600" alt="Screenshot_20260626_145054" src="https://github.com/user-attachments/assets/4dd2a592-799c-4632-b612-11460b259071" />

This is the new behavior with labels enabled. Icons are still spaced with enough room for the text.
<img width="270" height="600" alt="Screenshot_20260626_150908" src="https://github.com/user-attachments/assets/1bae9a05-a85d-478e-b5cc-9731adea3199" />



### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
:x: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where app icon label text could be scaled inconsistently in certain launcher layouts.
  * Improved consistency of icon label text sizing by ensuring the size factor is applied only once during layout calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->