### PR TITLE
build: Less aggressive proguard on common rules

### DIFF
--- a/proguard.pro
+++ b/proguard.pro
@@ -10,10 +10,10 @@
 -processkotlinnullchecks remove
 
 # Common rules.
--keep,allowshrinking,allowoptimization class android.window.** { *; }
--keep,allowshrinking,allowoptimization class android.view.** { *; }
--keep,allowshrinking,allowoptimization class com.android.systemui.** { *; }
--keep,allowshrinking,allowoptimization class com.android.wm.shell.** { *; }
+-keep,allowshrinking class android.window.** { *; }
+-keep,allowshrinking class android.view.** { *; }
+-keep,allowshrinking class com.android.systemui.** { *; }
+-keep,allowshrinking class com.android.wm.shell.** { *; }
 
 -keepclassmembers class * implements android.os.Parcelable {
   public static final ** CREATOR;


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Make all common rules section of Lawnchair proguard less aggressive by removing optimisation modifier.

No noticeable sizing difference.

Fixes #6853

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->


### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated app packaging rules for framework and UI components.
  * These classes will still be preserved and can be shrunk, but optimization is no longer explicitly enabled for them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->