### PR TITLE
fix: Don't crash from missing taskbar size for Android 8.X and 9

### DIFF
--- a/lawnchair/res/values-v26/config.xml
+++ b/lawnchair/res/values-v26/config.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="taskbar_size">60dp</dimen>
+</resources>

--- a/lawnchair/res/values-v29/config.xml
+++ b/lawnchair/res/values-v29/config.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <dimen name="taskbar_size">60dp</dimen>
-</resources>

--- a/lawnchair/res/values-v30/config.xml
+++ b/lawnchair/res/values-v30/config.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <dimen name="taskbar_size">60dp</dimen>
-</resources>


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Missing taskbar size on Android 8.0, 8.1 and 9 causes NFE on those devices.

This additionally also remove taskbar size from API 29 and 30, these API will fallback to 26 instead.

Fixes #6765
Fixes comment https://github.com/LawnchairLauncher/lawnchair/issues/5444#issuecomment-4678249982

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->


### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated taskbar sizing behavior for newer Android versions by removing an outdated size setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->