### PR TITLE
fix: Empty bound for Android 11 and older

### DIFF
--- a/lawnchair/src/app/lawnchair/util/LawnchairWindowManagerProxy.kt
+++ b/lawnchair/src/app/lawnchair/util/LawnchairWindowManagerProxy.kt
@@ -70,9 +70,9 @@ class LawnchairWindowManagerProxy @Inject constructor() : WindowManagerProxy(Uti
             }
         }
 
-        val estimateWindowBounds = estimateWindowBounds(displayInfoContext, info)
-        return estimateWindowBounds.getOrNull(info.rotation)
-            ?: estimateWindowBounds.first()
+        val estimateBounds = estimateWindowBounds(displayInfoContext, info)
+        return estimateBounds.getOrNull(info.rotation)
+            ?: estimateBounds.first()
     }
 
     override fun normalizeWindowInsets(context: Context, oldInsets: WindowInsets, outInsets: Rect): WindowInsets {

--- a/lawnchair/src/app/lawnchair/util/LawnchairWindowManagerProxy.kt
+++ b/lawnchair/src/app/lawnchair/util/LawnchairWindowManagerProxy.kt
@@ -69,8 +69,10 @@ class LawnchairWindowManagerProxy @Inject constructor() : WindowManagerProxy(Uti
                 return WindowBounds(windowMetrics.bounds, insets, info.rotation)
             }
         }
-        return estimateWindowBounds(displayInfoContext, info).getOrNull(info.rotation)
-            ?: estimateWindowBounds(displayInfoContext, info).first()
+
+        val estimateWindowBounds = estimateWindowBounds(displayInfoContext, info)
+        return estimateWindowBounds.getOrNull(info.rotation)
+            ?: estimateWindowBounds.first()
     }
 
     override fun normalizeWindowInsets(context: Context, oldInsets: WindowInsets, outInsets: Rect): WindowInsets {

--- a/lawnchair/src/app/lawnchair/util/LawnchairWindowManagerProxy.kt
+++ b/lawnchair/src/app/lawnchair/util/LawnchairWindowManagerProxy.kt
@@ -61,18 +61,16 @@ class LawnchairWindowManagerProxy @Inject constructor() : WindowManagerProxy(Uti
     }
 
     override fun getRealBounds(displayInfoContext: Context, info: CachedDisplayInfo): WindowBounds {
-        val windowMetrics = if (Utilities.ATLEAST_R) {
-            displayInfoContext.getSystemService(WindowManager::class.java)?.maximumWindowMetrics
-        } else {
-            null
+        if (Utilities.ATLEAST_R) {
+            val windowMetrics = displayInfoContext.getSystemService(WindowManager::class.java)?.maximumWindowMetrics
+            if (windowMetrics != null) {
+                val insets = Rect()
+                normalizeWindowInsets(displayInfoContext, windowMetrics.windowInsets, insets)
+                return WindowBounds(windowMetrics.bounds, insets, info.rotation)
+            }
         }
-        return if (windowMetrics != null) {
-            val insets = Rect()
-            normalizeWindowInsets(displayInfoContext, windowMetrics.windowInsets, insets)
-            WindowBounds(windowMetrics.bounds, insets, info.rotation)
-        } else {
-            WindowBounds(Rect(), Rect(), info.rotation)
-        }
+        return estimateWindowBounds(displayInfoContext, info).getOrNull(info.rotation)
+            ?: estimateWindowBounds(displayInfoContext, info).first()
     }
 
     override fun normalizeWindowInsets(context: Context, oldInsets: WindowInsets, outInsets: Rect): WindowInsets {


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Don't return empty bound when `maximumWindowMetrics` API isn't available.

Fixes Android 11 compatibility issue, see https://github.com/LawnchairLauncher/lawnchair/issues/6442 https://github.com/LawnchairLauncher/lawnchair/issues/6681

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->

We returned zero dimensions, so DP thinks there's zero dimensions so it shows the specification in a way broken way like app icon being below the text.

Widget preview renderer also thinks there's zero dimensions so it crash with IAE height/width must be > 0

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Tested on Huawei Honor 10 Lite - Android 10 (EMUI 10)

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window bounds handling on newer Android versions when full window metrics aren’t available.
  * The app now uses the best available maximum metrics for bounds, otherwise it falls back to estimated bounds per rotation—avoiding empty window sizes and improving rotation/display sizing reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->