### PR TITLE
chore: Bump material 3 to v1.5.0-alpha23

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -70,7 +70,7 @@ compose-bom = "androidx.compose:compose-bom:2026.06.01"
 compose-foundation = { module = "androidx.compose.foundation:foundation" }
 compose-foundation-layout = { module = "androidx.compose.foundation:foundation-layout" }
 compose-material-icons = "androidx.compose.material:material-icons-extended:1.7.8"
-compose-material3 = "androidx.compose.material3:material3:1.5.0-alpha22"
+compose-material3 = "androidx.compose.material3:material3:1.5.0-alpha23"
 compose-material3-windowSizeClass = { module = "androidx.compose.material3:material3-window-size-class" }
 compose-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata" }
 compose-ui = { module = "androidx.compose.ui:ui" }

--- a/lawnchair/src/app/lawnchair/ui/OverflowMenuGrouped.kt
+++ b/lawnchair/src/app/lawnchair/ui/OverflowMenuGrouped.kt
@@ -10,8 +10,6 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.DpOffset
-import androidx.compose.ui.unit.dp
 import app.lawnchair.ui.preferences.components.layout.ClickableIcon
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
@@ -33,7 +31,6 @@ fun OverflowMenuGrouped(
         DropdownMenuPopup(
             expanded = showMenu.value,
             onDismissRequest = { showMenu.value = false },
-            offset = DpOffset(x = (-2).dp, y = (-48).dp),
         ) {
             block(overflowMenuGroupedScope)
         }


### PR DESCRIPTION
Signed-off-by: Pun Butrach <pun.butrach@gmail.com><!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Get rid of removed API usages to bump material3 dependency to `v1.5.0-alpha23`

Succeed #6942

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Trivial, manual test on preference dropdown

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Chore** (Changes to the build process or other tooling)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the app to a newer Compose Material 3 release, bringing the latest stability and compatibility improvements.
  * Adjusted overflow menu positioning so it appears more naturally on screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->