### PR TITLE
Add a separate icon pack option for the app drawer

### DIFF
--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -368,6 +368,10 @@
     <string name="themed_icons_home_and_drawer_label">Home screen and app drawer</string>
     <string name="lawnicons_not_installed_description">No supported icon packs</string>
 
+    <string name="separate_drawer_icon_pack_label">Different app drawer icons</string>
+    <string name="separate_drawer_icon_pack_description">Use a separate icon pack for the app drawer</string>
+    <string name="home_and_drawer_icon_pack_subtitle">%1$s (home), %2$s (drawer)</string>
+
     <!-- Fonts -->
     <string name="pref_fonts_add_fonts">Add fonts</string>
     <string name="pref_fonts_add_fonts_summary">OTF and TTF fonts are supported</string>

--- a/lawnchair/src/app/lawnchair/LawnchairActivityCachingLogic.kt
+++ b/lawnchair/src/app/lawnchair/LawnchairActivityCachingLogic.kt
@@ -7,7 +7,9 @@ import android.os.Build
 import android.os.Build.VERSION
 import android.os.UserHandle
 import android.util.Log
+import app.lawnchair.icons.LawnchairIconProvider
 import app.lawnchair.icons.getCustomAppNameForComponent
+import app.lawnchair.icons.iconpack.IconPack
 import app.lawnchair.preferences.PreferenceManager
 import com.android.launcher3.Flags.useNewIconForArchivedApps
 import com.android.launcher3.dagger.ApplicationContext
@@ -52,6 +54,20 @@ class LawnchairActivityCachingLogic @Inject constructor(
         context: Context,
         cache: BaseIconCache,
         info: LauncherActivityInfo,
+    ): BitmapInfo = loadIconForPack(context, cache, info, null)
+
+    /**
+     * Bakes a [BitmapInfo] for [info]. When [pack] is null the normal home/global icon pack is used
+     * (this is the standard cache path). When [pack] is non-null that pack is used instead, letting
+     * the app drawer produce icons from a separate pack while reusing the exact same badging /
+     * adaptive / archived / source-hint pipeline. The result is NOT written into the shared icon
+     * cache (which is keyed by component only); the caller is responsible for storing it.
+     */
+    fun loadIconForPack(
+        context: Context,
+        cache: BaseIconCache,
+        info: LauncherActivityInfo,
+        pack: IconPack?,
     ): BitmapInfo {
         // LC-Note: LauncherActivityInfo.getActivityInfo or known as info.getActivityInfo in the code requires Android 12
         val activityInfo = if (VERSION.SDK_INT >= Build.VERSION_CODES.S) {
@@ -68,7 +84,12 @@ class LawnchairActivityCachingLogic @Inject constructor(
                         activityInfo.isArchived,
                 )
                 .setSourceHint(getSourceHint(info, cache))
-            val iconDrawable = cache.iconProvider.getIcon(activityInfo, li.fullResIconDpi)
+            val iconProvider = cache.iconProvider
+            val iconDrawable = if (pack != null && iconProvider is LawnchairIconProvider) {
+                iconProvider.getIconForPack(activityInfo, activityInfo.applicationInfo, li.fullResIconDpi, pack)
+            } else {
+                iconProvider.getIcon(activityInfo, li.fullResIconDpi)
+            }
             if (VERSION.SDK_INT >= 30 && context.packageManager.isDefaultApplicationIcon(
                     iconDrawable,
                 )

--- a/lawnchair/src/app/lawnchair/icons/DrawerIconCache.kt
+++ b/lawnchair/src/app/lawnchair/icons/DrawerIconCache.kt
@@ -1,0 +1,180 @@
+package app.lawnchair.icons
+
+import android.content.ComponentCallbacks2
+import android.content.Context
+import android.content.pm.LauncherActivityInfo
+import android.content.pm.LauncherApps
+import android.content.res.Configuration
+import android.util.Log
+import androidx.core.content.getSystemService
+import app.lawnchair.LawnchairActivityCachingLogic
+import app.lawnchair.icons.iconpack.IconPack
+import app.lawnchair.icons.iconpack.IconPackProvider
+import app.lawnchair.preferences.PreferenceManager
+import com.android.launcher3.LauncherAppState
+import com.android.launcher3.dagger.ApplicationContext
+import com.android.launcher3.dagger.LauncherAppComponent
+import com.android.launcher3.dagger.LauncherAppSingleton
+import com.android.launcher3.icons.BitmapInfo
+import com.android.launcher3.model.data.ItemInfoWithIcon
+import com.android.launcher3.util.ComponentKey
+import com.android.launcher3.util.DaggerSingletonObject
+import com.android.launcher3.util.Executors
+import com.android.launcher3.util.SafeCloseable
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.inject.Inject
+
+/**
+ * Memory-only store of app-drawer icons baked from a *separate* icon pack
+ * ([PreferenceManager.drawerIconPackPackage]), used only while
+ * [PreferenceManager.useSeparateDrawerIcons] is enabled.
+ *
+ * The home/global icon cache ([com.android.launcher3.icons.IconCache], keyed by component with no
+ * surface dimension) is deliberately left untouched: home, hotseat, taskbar, folders and search
+ * keep the global pack. Drawer surfaces consult this cache at render time and only fall back here
+ * when the toggle is on.
+ *
+ * Icons are baked lazily, one component at a time, off the UI thread, reusing the exact same recipe
+ * as the normal cache ([LawnchairActivityCachingLogic.loadIconForPack]) so badging, adaptive
+ * shaping, archived and themed layers all match the rest of the launcher. A component that can't be
+ * baked (e.g. no longer a launchable activity) is remembered in [negative] so it isn't retried on
+ * every rebind. Baking only what is actually rendered keeps memory bounded and lets newly installed
+ * apps pick up a drawer icon on their first appearance without any explicit invalidation.
+ *
+ * Known v1 limitation: a dynamic calendar/clock icon from the drawer pack is baked once and won't
+ * roll over at midnight until the drawer pack/toggle changes (the global cache does refresh). This
+ * niche combination is intentionally not handled here to avoid a second broadcast receiver.
+ */
+@LauncherAppSingleton
+class DrawerIconCache @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : SafeCloseable {
+
+    private val prefs = PreferenceManager.getInstance(context)
+    private val iconPackProvider = IconPackProvider.INSTANCE.get(context)
+
+    private val memo = ConcurrentHashMap<ComponentKey, BitmapInfo>()
+    private val negative = ConcurrentHashMap.newKeySet<ComponentKey>()
+    private val pending = ConcurrentHashMap.newKeySet<ComponentKey>()
+    private val bakeScheduled = AtomicBoolean(false)
+
+    private val enabled get() = prefs.useSeparateDrawerIcons.get()
+
+    private val drawerPack: IconPack?
+        get() = iconPackProvider.getIconPack(prefs.drawerIconPackPackage.get())?.apply { loadBlocking() }
+
+    // Drop the baked drawer icons under memory pressure; they lazily re-bake on next render.
+    private val memoryCallbacks = object : ComponentCallbacks2 {
+        override fun onTrimMemory(level: Int) {
+            if (level >= ComponentCallbacks2.TRIM_MEMORY_BACKGROUND) clear()
+        }
+
+        override fun onConfigurationChanged(newConfig: Configuration) = Unit
+
+        override fun onLowMemory() = clear()
+    }
+
+    init {
+        context.registerComponentCallbacks(memoryCallbacks)
+    }
+
+    /**
+     * The drawer-pack [BitmapInfo] for [info], or null when the feature is off, no drawer pack is
+     * selected, the item has no launchable component, or it hasn't been baked yet. On a not-yet-baked
+     * miss the component is queued for a background bake; the caller should fall back to the item's
+     * normal bitmap until the drawer rebinds.
+     */
+    fun getBitmapInfoOrNull(info: ItemInfoWithIcon): BitmapInfo? {
+        if (!enabled || prefs.drawerIconPackPackage.get().isEmpty()) return null
+        val component = info.targetComponent ?: return null
+        val key = ComponentKey(component, info.user)
+        memo[key]?.let { return it }
+        if (!negative.contains(key) && pending.add(key)) {
+            scheduleBake()
+        }
+        return null
+    }
+
+    private fun scheduleBake() {
+        if (!bakeScheduled.compareAndSet(false, true)) return
+        Executors.MODEL_EXECUTOR.execute {
+            // Allow the next miss to reschedule while this batch runs.
+            bakeScheduled.set(false)
+            try {
+                if (bakePending()) {
+                    // Rebind existing callbacks so drawer views re-render from the freshly baked
+                    // icons. This re-binds all surfaces from the already-loaded model (no DB
+                    // reload); home/workspace icons are unchanged and just repaint identically.
+                    LauncherAppState.getInstance(context).model.rebindCallbacks()
+                }
+            } catch (t: Throwable) {
+                // Never let a drawer-icon bake or rebind bring down the launcher process.
+                Log.e(TAG, "Failed to bake drawer icons", t)
+            }
+        }
+    }
+
+    /** Bakes the queued components. Returns true if at least one new icon was produced. */
+    private fun bakePending(): Boolean {
+        val pack = drawerPack ?: run {
+            // The selected drawer pack can't be resolved (e.g. it was uninstalled). Blacklist the
+            // queued components so we don't reschedule a bake on every rebind; selecting another
+            // pack clears the negative set via clear().
+            val keys = pending.toList()
+            pending.removeAll(keys.toSet())
+            negative.addAll(keys)
+            return false
+        }
+        val launcherApps = context.getSystemService<LauncherApps>() ?: return false
+        val cache = LauncherAppState.getInstance(context).iconCache
+        val cachingLogic = LawnchairActivityCachingLogic.INSTANCE.get(context)
+        val keys = pending.toList()
+        pending.removeAll(keys.toSet())
+        var baked = false
+        for (key in keys) {
+            if (memo.containsKey(key)) continue
+            val activityInfo = resolveActivity(launcherApps, key)
+            if (activityInfo == null) {
+                negative.add(key)
+                continue
+            }
+            try {
+                memo[key] = cachingLogic.loadIconForPack(context, cache, activityInfo, pack)
+                baked = true
+            } catch (_: Throwable) {
+                // This component simply falls back to the normal icon.
+                negative.add(key)
+            }
+        }
+        return baked
+    }
+
+    private fun resolveActivity(launcherApps: LauncherApps, key: ComponentKey): LauncherActivityInfo? {
+        return try {
+            launcherApps.getActivityList(key.componentName.packageName, key.user)
+                .firstOrNull { it.componentName == key.componentName }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    /** Drops all baked drawer icons; called when the drawer pack or toggle changes. */
+    fun clear() {
+        memo.clear()
+        negative.clear()
+        pending.clear()
+    }
+
+    override fun close() {
+        context.unregisterComponentCallbacks(memoryCallbacks)
+        clear()
+    }
+
+    companion object {
+        private const val TAG = "DrawerIconCache"
+
+        @JvmField
+        val INSTANCE = DaggerSingletonObject(LauncherAppComponent::getDrawerIconCache)
+    }
+}

--- a/lawnchair/src/app/lawnchair/icons/LawnchairIconProvider.kt
+++ b/lawnchair/src/app/lawnchair/icons/LawnchairIconProvider.kt
@@ -89,7 +89,7 @@ class LawnchairIconProvider @Inject constructor(
 
     val systemIconState = themeManager.iconState
 
-    private fun resolveIconEntry(componentName: ComponentName, user: UserHandle): IconEntry? {
+    private fun resolveIconEntry(componentName: ComponentName, user: UserHandle, pack: IconPack?): IconEntry? {
         val componentKey = ComponentKey(componentName, user)
         // first look for user-overridden icon
         val overrideItem = overrideRepo.overridesMap[componentKey]
@@ -97,7 +97,7 @@ class LawnchairIconProvider @Inject constructor(
             return overrideItem.toIconEntry()
         }
 
-        val iconPack = iconPack ?: return null
+        val iconPack = pack ?: return null
         // then look for dynamic calendar
         val calendarEntry = iconPack.getCalendar(componentName)
         if (calendarEntry != null) {
@@ -111,6 +111,18 @@ class LawnchairIconProvider @Inject constructor(
         info: PackageItemInfo,
         appInfo: ApplicationInfo,
         iconDpi: Int,
+    ): Drawable = getIconForPack(info, appInfo, iconDpi, iconPack)
+
+    /**
+     * Resolves an icon for [appInfo] using the given [pack] (override -> dynamic calendar -> pack),
+     * falling back to the system icon. The home/global path passes the [iconPack]; the app-drawer
+     * path passes the separate drawer pack so both surfaces reuse the exact same resolution logic.
+     */
+    fun getIconForPack(
+        info: PackageItemInfo,
+        appInfo: ApplicationInfo,
+        iconDpi: Int,
+        pack: IconPack?,
     ): Drawable {
         val packageName = appInfo.packageName
         val componentName = context.packageManager.getLaunchIntentForPackage(packageName)?.component
@@ -118,7 +130,7 @@ class LawnchairIconProvider @Inject constructor(
 
         var iconEntry: IconEntry? = null
         if (componentName != null) {
-            iconEntry = resolveIconEntry(componentName, user)
+            iconEntry = resolveIconEntry(componentName, user, pack)
         }
 
         var iconPackEntry = iconEntry

--- a/lawnchair/src/app/lawnchair/preferences/PreferenceManager.kt
+++ b/lawnchair/src/app/lawnchair/preferences/PreferenceManager.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 import app.lawnchair.LawnchairLauncher
 import app.lawnchair.font.FontCache
+import app.lawnchair.icons.DrawerIconCache
 import app.lawnchair.util.getApkVersionComparison
 import app.lawnchair.util.isGestureNavContractCompatible
 import app.lawnchair.util.isOnePlusStock
@@ -52,7 +53,21 @@ class PreferenceManager @Inject constructor(
         mRecentsModel.onThemeChanged()
         Executors.MODEL_EXECUTOR.execute {
             LauncherAppState.INSTANCE.get(context).iconCache.clearMemoryCache()
+            // Appearance changes (themed icons, tint, ...) also affect the baked drawer icons.
+            // Guard on the toggle so users without the feature never instantiate DrawerIconCache.
+            if (useSeparateDrawerIcons.get()) {
+                DrawerIconCache.INSTANCE.get(context).clear()
+            }
             LauncherAppState.INSTANCE.get(context).model.reloadIfActive()
+        }
+    }
+    // Scoped reload for the drawer icon pack: the home/global icon cache is untouched (drawer
+    // icons are resolved at render time), so we only drop the drawer memo and rebind the existing
+    // views (rebindCallbacks re-renders without re-querying the whole model).
+    private val reloadDrawerIcons: () -> Unit = {
+        Executors.MODEL_EXECUTOR.execute {
+            DrawerIconCache.INSTANCE.get(context).clear()
+            LauncherAppState.INSTANCE.get(context).model.rebindCallbacks()
         }
     }
     private val reloadGrid: () -> Unit = { idp.onPreferencesChanged(context) }
@@ -66,6 +81,10 @@ class PreferenceManager @Inject constructor(
 
     val iconPackPackage = StringPref("pref_iconPackPackage", "", reloadIcons)
     val themedIconPackPackage = StringPref("pref_themedIconPackPackage", "", reloadIcons)
+    // When enabled, the app drawer uses its own icon pack (drawerIconPackPackage) instead of the
+    // global iconPackPackage that the home screen and everything else use.
+    val useSeparateDrawerIcons = BoolPref("pref_useSeparateDrawerIcons", false, reloadDrawerIcons)
+    val drawerIconPackPackage = StringPref("pref_drawerIconPackPackage", "", reloadDrawerIcons)
     val allowRotation = BoolPref("pref_allowRotation", false)
     val wrapAdaptiveIcons = BoolPref("prefs_wrapAdaptive", true)
     val transparentIconBackground = BoolPref("prefs_transparentIconBackground", false)

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/GeneralPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/GeneralPreferences.kt
@@ -67,18 +67,32 @@ fun GeneralPreferences() {
     val currentIconPackName = iconPacks
         .find { it.packageName == preferenceManager().iconPackPackage.get() }
         ?.name
+    val useSeparateDrawerIcons = prefs.useSeparateDrawerIcons.getAdapter().state.value
+    val drawerIconPack = prefs.drawerIconPackPackage.getAdapter().state.value
+    val currentDrawerIconPackName = iconPacks
+        .find { it.packageName == drawerIconPack }
+        ?.name
+    // Only reflect a separate drawer pack once a real pack is chosen; an empty selection just
+    // mirrors the home pack, so the plain home-pack subtitle stays accurate.
+    val drawerPackSelected = useSeparateDrawerIcons && drawerIconPack.isNotEmpty()
     val themedIconsEnabled = ThemedIconsState.getForSettings(
         themedIcons = themedIconsAdapter.state.value,
         drawerThemedIcons = drawerThemedIconsAdapter.state.value,
     ) != ThemedIconsState.Off
-    val iconStyleSubtitle = if (currentIconPackName != null && themedIconsEnabled) {
-        stringResource(
-            id = R.string.x_and_y,
-            currentIconPackName,
-            stringResource(id = R.string.themed_icon_title),
-        )
-    } else {
-        currentIconPackName
+    val iconStyleSubtitle = when {
+        drawerPackSelected && currentIconPackName != null && currentDrawerIconPackName != null ->
+            stringResource(
+                id = R.string.home_and_drawer_icon_pack_subtitle,
+                currentIconPackName,
+                currentDrawerIconPackName,
+            )
+        currentIconPackName != null && themedIconsEnabled ->
+            stringResource(
+                id = R.string.x_and_y,
+                currentIconPackName,
+                stringResource(id = R.string.themed_icon_title),
+            )
+        else -> currentIconPackName
     }
     val iconShapeSubtitle = iconShapeEntries(context)
         .firstOrNull { it.value == iconShapeAdapter.state.value }

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/IconPackPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/IconPackPreferences.kt
@@ -122,6 +122,8 @@ fun IconPackPreferences(
     val themedIconPackAdapter = prefs.themedIconPackPackage.getAdapter()
     val themedIconsAdapter = prefs.themedIcons.getAdapter()
     val drawerThemedIconsAdapter = prefs.drawerThemedIcons.getAdapter()
+    val useSeparateDrawerIconsAdapter = prefs.useSeparateDrawerIcons.getAdapter()
+    val drawerIconPackAdapter = prefs.drawerIconPackPackage.getAdapter()
     val isPortrait = LocalConfiguration.current.orientation == Configuration.ORIENTATION_PORTRAIT
     val scrollState = rememberScrollState()
     val drawerThemedIconsEnabled = drawerThemedIconsAdapter.state.value
@@ -163,9 +165,10 @@ fun IconPackPreferences(
             }
         }
         Column {
+            val separateDrawerIcons = useSeparateDrawerIconsAdapter.state.value
             val pagerState = rememberPagerState(
                 initialPage = 0,
-                pageCount = { 2 },
+                pageCount = { if (separateDrawerIcons) 3 else 2 },
             )
 
             val scope = rememberCoroutineScope()
@@ -177,7 +180,10 @@ fun IconPackPreferences(
                 modifier = Modifier.padding(horizontal = 16.dp),
             ) {
                 Chip(
-                    label = stringResource(id = R.string.icon_pack),
+                    // When the drawer uses a separate pack, page 0 is specifically the home pack.
+                    label = stringResource(
+                        id = if (separateDrawerIcons) R.string.home_screen_label else R.string.icon_pack,
+                    ),
                     onClick = { scrollToPage(0) },
                     currentOffset = pagerState.currentPage + pagerState.currentPageOffsetFraction,
                     page = 0,
@@ -188,6 +194,14 @@ fun IconPackPreferences(
                     currentOffset = pagerState.currentPage + pagerState.currentPageOffsetFraction,
                     page = 1,
                 )
+                if (separateDrawerIcons) {
+                    Chip(
+                        label = stringResource(id = R.string.app_drawer_label),
+                        onClick = { scrollToPage(2) },
+                        currentOffset = pagerState.currentPage + pagerState.currentPageOffsetFraction,
+                        page = 2,
+                    )
+                }
             }
 
             Spacer(Modifier.height(16.dp))
@@ -204,6 +218,15 @@ fun IconPackPreferences(
                                 adapter = iconPackAdapter,
                                 false,
                             )
+                            PreferenceGroup {
+                                Item {
+                                    SwitchPreference(
+                                        adapter = useSeparateDrawerIconsAdapter,
+                                        label = stringResource(id = R.string.separate_drawer_icon_pack_label),
+                                        description = stringResource(id = R.string.separate_drawer_icon_pack_description),
+                                    )
+                                }
+                            }
                         }
 
                         1 -> {
@@ -261,6 +284,14 @@ fun IconPackPreferences(
                                 }
                             }
                         }
+
+                        2 -> {
+                            IconPackGrid(
+                                adapter = drawerIconPackAdapter,
+                                isThemedIconPack = false,
+                                includeSystem = false,
+                            )
+                        }
                     }
                 }
             }
@@ -273,6 +304,7 @@ fun IconPackGrid(
     adapter: PreferenceAdapter<String>,
     isThemedIconPack: Boolean,
     modifier: Modifier = Modifier,
+    includeSystem: Boolean = true,
 ) {
     val preferenceInteractor = LocalPreferenceInteractor.current
 
@@ -282,7 +314,9 @@ fun IconPackGrid(
     val lazyListState = rememberLazyListState()
     val padding = 12.dp
 
-    val iconPacksLocal = iconPacks
+    // The empty-package "System icons" entry means "no pack"; hide it where that isn't selectable
+    // (the app-drawer picker, where an empty selection just mirrors the home pack).
+    val iconPacksLocal = if (includeSystem) iconPacks else iconPacks.filter { it.packageName.isNotEmpty() }
 
     val selectedPack = adapter.state.value
     LaunchedEffect(selectedPack) {

--- a/src/com/android/launcher3/BubbleTextView.java
+++ b/src/com/android/launcher3/BubbleTextView.java
@@ -85,6 +85,7 @@ import com.android.launcher3.dragndrop.DragOptions.PreDragCondition;
 import com.android.launcher3.dragndrop.DraggableView;
 import com.android.launcher3.folder.FolderIcon;
 import com.android.launcher3.graphics.PreloadIconDrawable;
+import com.android.launcher3.icons.BitmapInfo;
 import com.android.launcher3.icons.DotRenderer;
 import com.android.launcher3.icons.FastBitmapDrawable;
 import com.android.launcher3.icons.IconCache.ItemInfoUpdateReceiver;
@@ -113,6 +114,7 @@ import java.util.Objects;
 import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 import app.lawnchair.LawnchairApp;
 import app.lawnchair.font.FontManager;
+import app.lawnchair.icons.DrawerIconCache;
 import app.lawnchair.gestures.IconGestureListener;
 import app.lawnchair.preferences.PreferenceManager;
 import app.lawnchair.preferences2.PreferenceManager2;
@@ -567,7 +569,13 @@ public class BubbleTextView extends TextView implements ItemInfoUpdateReceiver,
         if (mSkipUserBadge) {
             flags |= FLAG_SKIP_USER_BADGE;
         }
-        FastBitmapDrawable iconDrawable = info.newIcon(getContext(), flags);
+        // Lawnchair: in the app drawer, optionally render the icon from a separate icon pack.
+        BitmapInfo drawerBitmap = null;
+        if (isDrawerDisplay() && !isPrivateSpaceIcon
+                && PreferenceManager.getInstance(getContext()).getUseSeparateDrawerIcons().get()) {
+            drawerBitmap = DrawerIconCache.INSTANCE.get(getContext()).getBitmapInfoOrNull(info);
+        }
+        FastBitmapDrawable iconDrawable = info.newIcon(getContext(), flags, drawerBitmap);
         mDotParams.appColor = iconDrawable.getIconColor();
         mDotParams.dotColor = Themes.getAttrColor(getContext(), R.attr.notificationDotColor);
         if (isPrivateSpaceIcon) {
@@ -582,6 +590,13 @@ public class BubbleTextView extends TextView implements ItemInfoUpdateReceiver,
         }
         return mDisplay == DISPLAY_WORKSPACE || mDisplay == DISPLAY_FOLDER
                 || mDisplay == DISPLAY_TASKBAR;
+    }
+
+    /** Whether this icon is shown in an app-drawer surface (grid, predictions row, drawer folder). */
+    private boolean isDrawerDisplay() {
+        return mDisplay == DISPLAY_ALL_APPS
+                || mDisplay == DISPLAY_PREDICTION_ROW
+                || mDisplay == DISPLAY_DRAWER_FOLDER;
     }
 
     /**

--- a/src/com/android/launcher3/dagger/LauncherBaseAppComponent.java
+++ b/src/com/android/launcher3/dagger/LauncherBaseAppComponent.java
@@ -67,6 +67,7 @@ import app.lawnchair.data.wallpaper.service.WallpaperService;
 import app.lawnchair.font.FontCache;
 import app.lawnchair.font.FontManager;
 import app.lawnchair.font.googlefonts.GoogleFontsListing;
+import app.lawnchair.icons.DrawerIconCache;
 import app.lawnchair.icons.iconpack.IconPackProvider;
 import app.lawnchair.icons.shape.IconShapeManager;
 import app.lawnchair.preferences.PreferenceManager;
@@ -142,6 +143,7 @@ public interface LauncherBaseAppComponent {
     FontManager getFontManager();
     IconShapeManager getIconShapeManager();
     IconPackProvider getIconPackProvider();
+    DrawerIconCache getDrawerIconCache();
     GoogleFontsListing getGoogleFontsListing();
     WallpaperService getWallpaperService();
     IconOverrideRepository getIconOverrideRepository();

--- a/src/com/android/launcher3/folder/PreviewItemManager.java
+++ b/src/com/android/launcher3/folder/PreviewItemManager.java
@@ -51,6 +51,7 @@ import com.android.launcher3.Utilities;
 import com.android.launcher3.apppairs.AppPairIcon;
 import com.android.launcher3.apppairs.AppPairIconDrawingParams;
 import com.android.launcher3.apppairs.AppPairIconGraphic;
+import com.android.launcher3.icons.BitmapInfo;
 import com.android.launcher3.model.data.AppPairInfo;
 import com.android.launcher3.model.data.FolderInfo;
 import com.android.launcher3.model.data.ItemInfo;
@@ -62,6 +63,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
 
+import app.lawnchair.icons.DrawerIconCache;
 import app.lawnchair.preferences.PreferenceManager;
 
 /**
@@ -469,11 +471,19 @@ public class PreviewItemManager {
     public void setDrawable(PreviewItemDrawingParams p, ItemInfo item) {
         // Lawnchair: Find the correct folder size depending on which parent owned them
         int iconSize = getChildIconSize();
+        // Lawnchair: closed drawer-folder preview mini-icons bypass BubbleTextView, so apply the
+        // separate drawer icon pack here too when this folder lives in the app drawer. The lookup
+        // (which may queue a background bake) is deferred to the branches that actually render an
+        // app icon, so pending/promise icons and app pairs don't trigger it.
+        boolean useDrawerPack = mIcon.isInAppDrawer()
+                && PreferenceManager.getInstance(mContext).getUseSeparateDrawerIcons().get();
         if (item instanceof WorkspaceItemInfo wii) {
             if (isActivePendingIcon(wii)) {
                 p.drawable = newPendingIcon(mContext, wii);
             } else {
-                p.drawable = wii.newIcon(mContext, FLAG_THEMED);
+                BitmapInfo drawerBitmap = useDrawerPack
+                        ? DrawerIconCache.INSTANCE.get(mContext).getBitmapInfoOrNull(wii) : null;
+                p.drawable = wii.newIcon(mContext, FLAG_THEMED, drawerBitmap);
             }
             p.drawable.setBounds(0, 0, iconSize, iconSize);
         } else if (item instanceof AppPairInfo api) {
@@ -482,7 +492,9 @@ public class PreviewItemManager {
             p.drawable.setBounds(0, 0, iconSize, iconSize);
         } else if (item instanceof ItemInfoWithIcon withIcon){
             var isThemed = PreferenceManager.getInstance(mContext).getDrawerThemedIcons().get() ? FLAG_THEMED : 0;
-            p.drawable = withIcon.newIcon(mContext, isThemed);
+            BitmapInfo drawerBitmap = useDrawerPack
+                    ? DrawerIconCache.INSTANCE.get(mContext).getBitmapInfoOrNull(withIcon) : null;
+            p.drawable = withIcon.newIcon(mContext, isThemed, drawerBitmap);
             p.drawable.setBounds(0, 0, iconSize, iconSize);
         }
 

--- a/src/com/android/launcher3/model/data/ItemInfoWithIcon.java
+++ b/src/com/android/launcher3/model/data/ItemInfoWithIcon.java
@@ -331,11 +331,22 @@ public abstract class ItemInfoWithIcon extends ItemInfo {
      * Returns a FastBitmapDrawable with the icon and context theme applied
      */
     public FastBitmapDrawable newIcon(Context context, @DrawableCreationFlags int creationFlags) {
+        return newIcon(context, creationFlags, null);
+    }
+
+    /**
+     * Returns a FastBitmapDrawable built from {@code overrideBitmap} instead of {@link #bitmap} when
+     * it is non-null (used by the app drawer to render a separate icon pack), otherwise identical to
+     * {@link #newIcon(Context, int)}.
+     */
+    public FastBitmapDrawable newIcon(Context context, @DrawableCreationFlags int creationFlags,
+            @Nullable BitmapInfo overrideBitmap) {
         var shouldTheme = PreferenceManager.getInstance(context).getThemedIcons().get();
         if (!shouldTheme) {
             creationFlags &= ~FLAG_THEMED;
         }
-        FastBitmapDrawable drawable = bitmap.newIcon(
+        BitmapInfo source = overrideBitmap != null ? overrideBitmap : bitmap;
+        FastBitmapDrawable drawable = source.newIcon(
                 context, creationFlags, Utilities.getIconShapeOrNull(context));
         drawable.setDisabled(isDisabled());
         return drawable;


### PR DESCRIPTION
## What

Adds an optional **separate icon pack for the app drawer**, like Nova. A new **"Different app drawer icons"** switch (default **off**) lets the app drawer use its own icon pack while the home screen (and everything else) keeps the global one. When off, behaviour is unchanged.

## Why it's built this way

Lawnchair resolves icons **globally** — one `BitmapInfo` per component in a shared `IconCache` (backed by an external lib) with **no surface dimension** — and home, hotseat, taskbar, folders and search all read that one bitmap. The existing themed-icon split works only because both color and mono layers are baked into that single bitmap; two different *packs* can't share it.

So the global/home pack is left completely untouched and only the **drawer** diverges, via a render-time override:

- A memory-only `DrawerIconCache` bakes drawer-pack icons **lazily, per component, off the UI thread**, reusing the exact same recipe as the normal cache (`LawnchairActivityCachingLogic.loadIconForPack`) so badging, adaptive shaping, archived and themed layers all match. Components that can't be baked are remembered so they aren't retried, and newly installed apps pick up a drawer icon on first render.
- `BubbleTextView` (all-apps grid, predictions row, drawer folders, drawer app-search) and `PreviewItemManager` (closed drawer-folder previews) swap in the drawer bitmap when the toggle is on, via a new `ItemInfoWithIcon.newIcon(..., overrideBitmap)` overload.
- `LawnchairIconProvider` is parameterized by pack (`getIconForPack`) so the drawer reuses the same override → calendar → pack → themed resolution as the home path.
- The home icon-DB freshness key is intentionally untouched, so changing the drawer pack never rebuilds home icons.

## UI

A **"Different app drawer icons"** switch plus, when enabled, a third **"App drawer"** tab on the Icon Style screen for picking the drawer pack. The General → Icons subtitle reflects both packs when a separate drawer pack is chosen.

## Behaviour / scope

- **Default off → no change** for existing users; new prefs default to off/unset and never touch existing settings.
- **Zero overhead when off:** the cache is never instantiated and home/workspace icon binding does no extra work.
- **Drawer surfaces covered:** all-apps grid, predictions row, open + closed drawer folders, drawer app-search results, work profile / private-space app tabs. Private-space lock/header and non-app items are left alone.
- Dropping an app from the drawer to the home screen uses the home pack, as expected.
- Under memory pressure the drawer cache is dropped and lazily re-baked.

### Known limitations
- A dynamic calendar/clock icon **from the drawer pack** is baked once and won't roll over at midnight until the drawer pack/toggle changes (the global cache still refreshes normally).
- Themed drawer icons follow Lawnchair's existing rule that themed icons require the global "themed icons" setting; this is inherited behaviour, identical to using that pack globally.

## Files

Core: `icons/DrawerIconCache.kt` (new), `icons/LawnchairIconProvider.kt`, `LawnchairActivityCachingLogic.kt`, `preferences/PreferenceManager.kt`, `BubbleTextView.java`, `folder/PreviewItemManager.java`, `model/data/ItemInfoWithIcon.java`, `dagger/LauncherBaseAppComponent.java`. UI: `ui/preferences/destinations/IconPackPreferences.kt`, `GeneralPreferences.kt`, `res/values/strings.xml`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for selecting a separate icon pack for the app drawer.
  * Updated icon previews and folder items to reflect drawer-specific icons where enabled.
  * Improved icon pack labels and subtitles in settings to show both home and drawer selections.

* **Bug Fixes**
  * Drawer icons now refresh independently when their pack changes.
  * App drawer icons are cached and reloaded more reliably without affecting the home icon pack.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->