### PR TITLE
feat: Vertical icon swipe gesture

### DIFF
--- a/lawnchair/src/app/lawnchair/gestures/IconGestureListener.kt
+++ b/lawnchair/src/app/lawnchair/gestures/IconGestureListener.kt
@@ -33,6 +33,12 @@ class IconGestureListener(
             hasGestureConfigured(GestureType.SWIPE_RIGHT)
     }
 
+    /** Check if there's a vertical gesture configured for this entry. (Swipe up/down) */
+    fun hasVerticalGestureConfigured(): Boolean {
+        return hasGestureConfigured(GestureType.SWIPE_UP) ||
+            hasGestureConfigured(GestureType.SWIPE_DOWN)
+    }
+
     /** Check if there's a specific gesture configured for this entry
      * @param gestureType The type of gesture to check */
     private fun hasGestureConfigured(gestureType: GestureType): Boolean {

--- a/lawnchair/src/app/lawnchair/gestures/VerticalSwipeTouchController.kt
+++ b/lawnchair/src/app/lawnchair/gestures/VerticalSwipeTouchController.kt
@@ -81,6 +81,15 @@ class VerticalSwipeTouchController(
         if ((ev.edgeFlags and Utilities.EDGE_NAV_BAR) != 0) {
             return false
         }
+        // LC: Icon Swipe Gestures (For vertical gestures)
+        val isIconSwipe = launcher.workspace?.let {
+            val coord = floatArrayOf(ev.x, ev.y)
+            launcher.dragLayer.mapCoordInSelfToDescendant(it, coord)
+            it.isTouchOnIconWithSwipeGesture(coord[0], coord[1], true)
+        } ?: false
+        if (isIconSwipe) {
+            return false
+        }
         return AbstractFloatingView.getTopOpenView(launcher) == null &&
             launcher.isInState(LauncherState.NORMAL)
     }

--- a/lawnchair/src/app/lawnchair/override/CustomizeDialog.kt
+++ b/lawnchair/src/app/lawnchair/override/CustomizeDialog.kt
@@ -196,6 +196,8 @@ fun CustomizeAppDialog(
         if (context.launcher.stateManager.state != LauncherState.ALL_APPS) {
             PreferenceGroup(heading = stringResource(R.string.gestures_label)) {
                 listOf(
+                    GestureType.SWIPE_UP,
+                    GestureType.SWIPE_DOWN,
                     GestureType.SWIPE_LEFT,
                     GestureType.SWIPE_RIGHT,
                 ).map { gestureType ->

--- a/quickstep/src/com/android/launcher3/uioverrides/touchcontrollers/PortraitStatesTouchController.java
+++ b/quickstep/src/com/android/launcher3/uioverrides/touchcontrollers/PortraitStatesTouchController.java
@@ -62,8 +62,10 @@ public class PortraitStatesTouchController extends AbstractStateChangeTouchContr
         if (mLauncher.getWorkspace() != null && mLauncher.getDragLayer() != null) {
             float[] coord = new float[]{ev.getX(), ev.getY()};
             mLauncher.getDragLayer().mapCoordInSelfToDescendant(mLauncher.getWorkspace(), coord);
-            return !mLauncher.getWorkspace()
-                .isTouchOnIconWithSwipeGesture(coord[0], coord[1], true);
+                if (mLauncher.getWorkspace()
+                        .isTouchOnIconWithSwipeGesture(coord[0], coord[1], true)) {
+                    return false;
+                }
         }
         // If we are swiping to all apps instead of overview, allow it from anywhere.
         boolean interceptAnywhere = mLauncher.isInState(NORMAL);

--- a/quickstep/src/com/android/launcher3/uioverrides/touchcontrollers/PortraitStatesTouchController.java
+++ b/quickstep/src/com/android/launcher3/uioverrides/touchcontrollers/PortraitStatesTouchController.java
@@ -58,6 +58,13 @@ public class PortraitStatesTouchController extends AbstractStateChangeTouchContr
 
     @Override
     protected boolean canInterceptTouch(MotionEvent ev) {
+        // Lawnchair: Icon Swipe Gestures (For vertical up gestures)
+        if (mLauncher.getWorkspace() != null && mLauncher.getDragLayer() != null) {
+            float[] coord = new float[]{ev.getX(), ev.getY()};
+            mLauncher.getDragLayer().mapCoordInSelfToDescendant(mLauncher.getWorkspace(), coord);
+            return !mLauncher.getWorkspace()
+                .isTouchOnIconWithSwipeGesture(coord[0], coord[1], true);
+        }
         // If we are swiping to all apps instead of overview, allow it from anywhere.
         boolean interceptAnywhere = mLauncher.isInState(NORMAL);
         if (mCurrentAnimation != null) {

--- a/quickstep/src/com/android/launcher3/uioverrides/touchcontrollers/StatusBarTouchController.java
+++ b/quickstep/src/com/android/launcher3/uioverrides/touchcontrollers/StatusBarTouchController.java
@@ -215,8 +215,10 @@ public class StatusBarTouchController implements TouchController {
             if (launcher.getWorkspace() != null && launcher.getDragLayer() != null) {
                 float[] coord = new float[]{ev.getX(), ev.getY()};
                 launcher.getDragLayer().mapCoordInSelfToDescendant(launcher.getWorkspace(), coord);
-                return !launcher.getWorkspace()
-                    .isTouchOnIconWithSwipeGesture(coord[0], coord[1], true);
+                if (launcher.getWorkspace()
+                        .isTouchOnIconWithSwipeGesture(coord[0], coord[1], true)) {
+                    return false;
+                }
             }
         }
         if (isTrackpadScroll(ev) || !mIsEnabledCheck.get()

--- a/quickstep/src/com/android/launcher3/uioverrides/touchcontrollers/StatusBarTouchController.java
+++ b/quickstep/src/com/android/launcher3/uioverrides/touchcontrollers/StatusBarTouchController.java
@@ -39,6 +39,7 @@ import android.view.WindowManager;
 import com.android.launcher3.AbstractFloatingView;
 import com.android.launcher3.BaseActivity;
 import com.android.launcher3.DeviceProfile;
+import com.android.launcher3.Launcher;
 import com.android.launcher3.Utilities;
 import com.android.launcher3.util.MSDLPlayerWrapper;
 import com.android.launcher3.util.TouchController;
@@ -209,6 +210,15 @@ public class StatusBarTouchController implements TouchController {
     }
 
     private boolean canInterceptTouch(MotionEvent ev) {
+        // Lawnchair: Icon Swipe Gestures (For vertical down gestures)
+        if (mLauncher instanceof Launcher launcher) {
+            if (launcher.getWorkspace() != null && launcher.getDragLayer() != null) {
+                float[] coord = new float[]{ev.getX(), ev.getY()};
+                launcher.getDragLayer().mapCoordInSelfToDescendant(launcher.getWorkspace(), coord);
+                return !launcher.getWorkspace()
+                    .isTouchOnIconWithSwipeGesture(coord[0], coord[1], true);
+            }
+        }
         if (isTrackpadScroll(ev) || !mIsEnabledCheck.get()
                 || AbstractFloatingView.getTopOpenViewWithType(mLauncher,
                 AbstractFloatingView.TYPE_STATUS_BAR_SWIPE_DOWN_DISALLOW) != null || (

--- a/src/com/android/launcher3/BubbleTextView.java
+++ b/src/com/android/launcher3/BubbleTextView.java
@@ -785,6 +785,14 @@ public class BubbleTextView extends TextView implements ItemInfoUpdateReceiver,
                 && mGestureListener.hasHorizontalGestureConfigured();
     }
 
+    /** Lawnchair: Check if icon swipe feature is enabled, 
+     * and has a vertical gesture configured for it */
+    public boolean hasConfiguredVerticalIconSwipeGesture() {
+        return mGestureListener != null
+            && isIconSwipeGestureEnabledForCurrentState()
+            && mGestureListener.hasVerticalGestureConfigured();
+    }
+
     /** Lawnchair: Get supported swipe target which are within workspace or within folder */
     private boolean shouldSupportIconSwipeGestures() {
         return mDisplay == DISPLAY_WORKSPACE || mDisplay == DISPLAY_FOLDER;

--- a/src/com/android/launcher3/Workspace.java
+++ b/src/com/android/launcher3/Workspace.java
@@ -1199,8 +1199,8 @@ public class Workspace<T extends View & PageIndicator> extends PagedView<T>
     private boolean shouldSkipPagedViewInterceptionForIconSwipe(MotionEvent ev) {
         switch (ev.getActionMasked()) {
             case MotionEvent.ACTION_DOWN:
-                mDisallowPagedViewInterceptForIconSwipe = isTouchOnIconWithHorizontalSwipeGesture(
-                        ev.getX(), ev.getY());
+                mDisallowPagedViewInterceptForIconSwipe = isTouchOnIconWithSwipeGesture(
+                        ev.getX(), ev.getY(), false);
                 if (mDisallowPagedViewInterceptForIconSwipe) {
                     resetTouchState();
                     return true;
@@ -1225,9 +1225,17 @@ public class Workspace<T extends View & PageIndicator> extends PagedView<T>
     }
 
     // Lawnchair: Icon swipe gesture feature
-    private boolean isTouchOnIconWithHorizontalSwipeGesture(float x, float y) {
+    public boolean isTouchOnIconWithSwipeGesture(float x, float y, boolean vertical) {
+        boolean hasConfiguredIconSwipeGesture = false;
         BubbleTextView touchedIcon = findIconAtPosition(x, y);
-        return touchedIcon != null && touchedIcon.hasConfiguredHorizontalIconSwipeGesture();
+        if (touchedIcon != null) {
+            if (vertical) {
+                hasConfiguredIconSwipeGesture = touchedIcon.hasConfiguredVerticalIconSwipeGesture();
+            } else {
+                hasConfiguredIconSwipeGesture = touchedIcon.hasConfiguredHorizontalIconSwipeGesture();
+            }
+        }
+        return hasConfiguredIconSwipeGesture;
     }
 
     // Lawnchair: Icon swipe gesture feature


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Override priority for vertical swipe for up and down to choose from Lawnchair icon swipe gesture feature first.

Fixes task of https://github.com/LawnchairLauncher/lawnchair/issues/6442

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Manual testing, swipe up/down on any app icon that set vertical feature. (Lawnchair should override the default vertical gesture)

Swipe left/right on any icon with vertical feature (Lawnchair shouldn't override the default vertical gesture)

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **New feature** (A non-breaking change that adds functionality)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for vertical icon swipe gestures (swipe up/down) alongside existing horizontal swipes.
  * Updated gesture customization options to include swipe up and swipe down (when applicable).
* **Bug Fixes**
  * Improved touch handling so swipe gestures starting on configured app icons are recognized reliably and prevent unwanted interception by other touch controllers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->