### PR TITLE
[Forwardport] Support importing Nova Launcher backup (#6504)

### DIFF
--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -575,9 +575,20 @@
     <string name="backup_restore_success">Backup restored</string>
     <string name="backup_restore_error">Failed to restore backup</string>
     <string name="invalid_backup_file">Invalid backup file</string>
+    <string name="restore_nova_backup">Restore Nova backup</string>
+    <string name="invalid_nova_backup_file">Invalid Nova backup file</string>
+    <string name="nova_grid_label">Grid</string>
+    <string name="nova_grid_value">%1$d x %2$d</string>
+    <string name="nova_dock_label">Dock</string>
+    <string name="nova_app_label">Apps</string>
+    <string name="nova_widget_label">Widgets</string>
+    <string name="nova_folder_label">Folders</string>
+    <string name="nova_shortcut_label">Shortcuts</string>
+    <string name="nova_icon_pack_label">Icon pack</string>
 
     <string name="create_backup_description">Export settings and launcher layout</string>
     <string name="restore_backup_description">Import a previously created backup</string>
+    <string name="restore_nova_backup_description">Import layout from a Nova Launcher backup</string>
 
     <!--
 

--- a/lawnchair/src/app/lawnchair/backup/NovaBackupConverter.kt
+++ b/lawnchair/src/app/lawnchair/backup/NovaBackupConverter.kt
@@ -1,0 +1,464 @@
+package app.lawnchair.backup
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.LauncherApps
+import android.content.pm.PackageManager
+import android.database.sqlite.SQLiteDatabase
+import android.net.Uri
+import android.os.Process
+import android.util.Log
+import app.lawnchair.DeviceProfileOverrides
+import app.lawnchair.preferences.PreferenceManager
+import com.android.launcher3.GridType
+import com.android.launcher3.InvariantDeviceProfile
+import com.android.launcher3.LauncherSettings.Favorites
+import com.android.launcher3.model.DatabaseHelper
+import com.android.launcher3.model.DeviceGridState
+import com.android.launcher3.model.ModelDbController
+import com.android.launcher3.pm.UserCache
+import com.android.launcher3.provider.RestoreDbTask
+import com.android.launcher3.shortcuts.ShortcutKey
+import com.android.launcher3.shortcuts.ShortcutRequest
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.net.URISyntaxException
+import java.util.UUID
+import java.util.zip.ZipInputStream
+import javax.xml.parsers.DocumentBuilderFactory
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class NovaBackupConverter(
+    private val context: Context,
+    private val uri: Uri,
+) {
+
+    companion object {
+        private const val TAG = "NovaBackupConverter"
+        private const val NOVA_XML = "nova.xml"
+        private const val NOVA_DB = "nova.db"
+        private const val NOVA_CONTAINER_DESKTOP = -100
+        private const val NOVA_CONTAINER_HOTSEAT = -101
+        private const val FOLDER_PAGE_RANK_OFFSET = 1_000
+        private const val FOLDER_ROW_RANK_OFFSET = 100
+        private const val NOVA_TEMP_DIR_PREFIX = "nova_"
+        private const val NOVA_WORKSPACE_DB = "nova_workspace.db"
+        private const val NOVA_TABLE_FAVORITES = "favorites"
+        private const val NOVA_XML_TAG_STRING = "string"
+        private const val NOVA_XML_TAG_INT = "int"
+        private const val NOVA_XML_ATTR_NAME = "name"
+        private const val NOVA_XML_ATTR_VALUE = "value"
+        private const val NOVA_XML_KEY_DESKTOP_GRID = "desktop_grid"
+        private const val NOVA_XML_KEY_ICON_PACK = "theme_icon_pack"
+        private const val NOVA_XML_KEY_DOCK_COLS = "dock_grid_cols"
+        private const val NOVA_ICON_PACK_MIN_PARTS = 3
+        private const val NOVA_ICON_PACK_PACKAGE_INDEX = 2
+        private const val NOVA_COL_ID = "_id"
+        private const val NOVA_COL_CONTAINER = "container"
+        private const val NOVA_COL_ITEM_TYPE = "itemType"
+        private const val NOVA_COL_TITLE = "title"
+        private const val NOVA_COL_INTENT = "intent"
+        private const val NOVA_COL_CELL_X = "cellX"
+        private const val NOVA_COL_CELL_Y = "cellY"
+        private const val NOVA_COL_SCREEN = "screen"
+        private const val NOVA_COL_SPAN_X = "spanX"
+        private const val NOVA_COL_SPAN_Y = "spanY"
+        private const val NOVA_COL_ICON = "icon"
+        private const val NOVA_COL_APP_WIDGET_PROVIDER = "appWidgetProvider"
+    }
+
+    private val novaGridRegex = Regex("(\\d+)x(\\d+)")
+
+    data class NovaBackupInfo(
+        val columns: Int?,
+        val rows: Int?,
+        val hotseatCount: Int?,
+        val appCount: Int,
+        val widgetCount: Int,
+        val folderCount: Int,
+        val shortcutCount: Int,
+        val iconPackPackage: String?,
+        val iconPackLabel: String?,
+    )
+
+    private data class NovaConfig(
+        val columns: Int?,
+        val rows: Int?,
+        val dockCols: Int?,
+        val iconPackPackage: String?,
+    )
+
+    private data class ItemCounts(
+        val apps: Int,
+        val widgets: Int,
+        val folders: Int,
+        val shortcuts: Int,
+    )
+
+    private data class ImportedDeepShortcut(
+        val packageName: String,
+        val shortcutId: String,
+    ) {
+        fun toLauncherIntentUri(): String = ShortcutKey.makeIntent(shortcutId, packageName).toUri(0)
+    }
+
+    suspend fun parseInfo(): NovaBackupInfo = withContext(Dispatchers.IO) {
+        val tempDir = File(context.cacheDir, "$NOVA_TEMP_DIR_PREFIX${UUID.randomUUID()}")
+        tempDir.mkdirs()
+
+        try {
+            extractFromZip(uri, tempDir, setOf(NOVA_XML, NOVA_DB))
+
+            val xmlFile = File(tempDir, NOVA_XML)
+            val dbFile = File(tempDir, NOVA_DB)
+            require(xmlFile.exists() && dbFile.exists()) { "Missing $NOVA_XML or $NOVA_DB" }
+
+            val novaConfig = parseNovaConfig(xmlFile)
+            val (apps, widgets, folders, shortcuts) = countItems(dbFile)
+
+            NovaBackupInfo(
+                columns = novaConfig.columns,
+                rows = novaConfig.rows,
+                hotseatCount = novaConfig.dockCols,
+                appCount = apps,
+                widgetCount = widgets,
+                folderCount = folders,
+                shortcutCount = shortcuts,
+                iconPackPackage = novaConfig.iconPackPackage,
+                iconPackLabel = novaConfig.iconPackPackage?.let { packageName ->
+                    resolveIconPackLabel(packageName)
+                },
+            )
+        } finally {
+            tempDir.deleteRecursively()
+        }
+    }
+
+    suspend fun convertAndRestore(info: NovaBackupInfo) = withContext(Dispatchers.IO) {
+        val tempDir = File(context.cacheDir, "$NOVA_TEMP_DIR_PREFIX${UUID.randomUUID()}")
+        tempDir.mkdirs()
+
+        try {
+            extractFromZip(uri, tempDir, setOf(NOVA_DB))
+
+            val novaDbFile = File(tempDir, NOVA_DB)
+            require(novaDbFile.exists()) { "Missing $NOVA_DB" }
+
+            val stagedDbFile = File(tempDir, NOVA_WORKSPACE_DB)
+            val importedDeepShortcuts = createRestoredDb(novaDbFile, stagedDbFile)
+
+            val columns = info.columns
+            val rows = info.rows
+            val hotseatCount = info.hotseatCount
+            if (columns != null && rows != null && hotseatCount != null) {
+                val gridInfo = DeviceProfileOverrides.DBGridInfo(
+                    numHotseatColumns = hotseatCount,
+                    numRows = rows,
+                    numColumns = columns,
+                )
+                val gridState = DeviceGridState(
+                    columns,
+                    rows,
+                    hotseatCount,
+                    InvariantDeviceProfile.TYPE_PHONE,
+                    gridInfo.dbFile,
+                    GridType.GRID_TYPE_ANY,
+                )
+                gridState.writeToPrefs(context, true)
+                gridState.writeToPrefs(context)
+                InvariantDeviceProfile.INSTANCE.get(context).dbFile = gridInfo.dbFile
+            }
+            writeGridToLawnchairPrefs(info)
+
+            val restoredDbFile = context.getDatabasePath(LawnchairBackup.RESTORED_DB_FILE_NAME)
+            restoredDbFile.parentFile?.mkdirs()
+            stagedDbFile.copyTo(restoredDbFile, overwrite = true)
+
+            val dbController = ModelDbController(context)
+            RestoreDbTask.performRestore(context, dbController)
+
+            pinImportedDeepShortcuts(importedDeepShortcuts)
+        } finally {
+            tempDir.deleteRecursively()
+        }
+    }
+
+    private fun resolveIconPackLabel(packageName: String): String = try {
+        val pm = context.packageManager
+        pm.getApplicationInfo(packageName, 0).loadLabel(pm).toString()
+    } catch (_: PackageManager.NameNotFoundException) {
+        packageName
+    }
+
+    private fun writeGridToLawnchairPrefs(info: NovaBackupInfo) {
+        val prefs = PreferenceManager.getInstance(context)
+        prefs.sp.edit().apply {
+            info.columns?.let { putInt(prefs.workspaceColumns.key, it) }
+            info.rows?.let { putInt(prefs.workspaceRows.key, it) }
+            info.hotseatCount?.let { putInt(prefs.hotseatColumns.key, it) }
+            info.iconPackPackage?.let { putString(prefs.iconPackPackage.key, it) }
+        }.commit()
+    }
+
+    private fun parseNovaConfig(xmlFile: File): NovaConfig {
+        val doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(xmlFile)
+        val root = doc.documentElement
+        var columns: Int? = null
+        var rows: Int? = null
+        var dockCols: Int? = null
+        var iconPackPackage: String? = null
+
+        val stringNodes = root.getElementsByTagName(NOVA_XML_TAG_STRING)
+        for (i in 0 until stringNodes.length) {
+            val node = stringNodes.item(i)
+            val name = node.attributes.getNamedItem(NOVA_XML_ATTR_NAME)?.nodeValue ?: continue
+            val text = node.textContent ?: continue
+            when (name) {
+                NOVA_XML_KEY_DESKTOP_GRID -> {
+                    val match = novaGridRegex.find(text) ?: continue
+                    columns = match.groupValues[1].toIntOrNull() ?: continue
+                    rows = match.groupValues[2].toIntOrNull() ?: continue
+                }
+
+                NOVA_XML_KEY_ICON_PACK -> {
+                    val parts = text.split(":")
+                    if (parts.size >= NOVA_ICON_PACK_MIN_PARTS) iconPackPackage = parts[NOVA_ICON_PACK_PACKAGE_INDEX]
+                }
+            }
+        }
+
+        val intNodes = root.getElementsByTagName(NOVA_XML_TAG_INT)
+        for (i in 0 until intNodes.length) {
+            val node = intNodes.item(i)
+            val name = node.attributes.getNamedItem(NOVA_XML_ATTR_NAME)?.nodeValue ?: continue
+            val value = node.attributes.getNamedItem(NOVA_XML_ATTR_VALUE)?.nodeValue?.toIntOrNull() ?: continue
+            if (name == NOVA_XML_KEY_DOCK_COLS) dockCols = value
+        }
+
+        return NovaConfig(columns, rows, dockCols, iconPackPackage)
+    }
+
+    private fun countItems(dbFile: File): ItemCounts {
+        val db = SQLiteDatabase.openDatabase(dbFile.absolutePath, null, SQLiteDatabase.OPEN_READONLY)
+        return db.use {
+            it.rawQuery(
+                """SELECT $NOVA_COL_ITEM_TYPE, COUNT(*) FROM $NOVA_TABLE_FAVORITES
+                    WHERE $NOVA_COL_ITEM_TYPE != -1
+                    AND ($NOVA_COL_CONTAINER = $NOVA_CONTAINER_DESKTOP
+                        OR $NOVA_COL_CONTAINER = $NOVA_CONTAINER_HOTSEAT
+                        OR $NOVA_COL_CONTAINER >= 0)
+                    GROUP BY $NOVA_COL_ITEM_TYPE""",
+                null,
+            ).use { cursor ->
+                var apps = 0
+                var widgets = 0
+                var folders = 0
+                var shortcuts = 0
+                while (cursor.moveToNext()) {
+                    val type = cursor.getInt(0)
+                    val count = cursor.getInt(1)
+                    when (type) {
+                        Favorites.ITEM_TYPE_APPLICATION -> apps += count
+                        Favorites.ITEM_TYPE_APPWIDGET, Favorites.ITEM_TYPE_CUSTOM_APPWIDGET -> widgets += count
+                        Favorites.ITEM_TYPE_FOLDER -> folders += count
+                        Favorites.ITEM_TYPE_SHORTCUT, Favorites.ITEM_TYPE_DEEP_SHORTCUT -> shortcuts += count
+                    }
+                }
+                ItemCounts(apps, widgets, folders, shortcuts)
+            }
+        }
+    }
+
+    private fun createRestoredDb(
+        novaDbFile: File,
+        targetDbFile: File,
+    ): Map<String, Set<String>> {
+        val profileId = UserCache.INSTANCE.get(context)
+            .getSerialNumberForUser(Process.myUserHandle())
+        val importedDeepShortcuts = mutableMapOf<String, MutableSet<String>>()
+
+        val targetDb = SQLiteDatabase.openOrCreateDatabase(targetDbFile, null)
+        targetDb.use { db ->
+            db.version = DatabaseHelper.SCHEMA_VERSION
+            Favorites.addTableToDb(db, profileId, false)
+
+            val novaDb = SQLiteDatabase.openDatabase(
+                novaDbFile.absolutePath,
+                null,
+                SQLiteDatabase.OPEN_READONLY,
+            )
+            novaDb.use { src ->
+                db.beginTransaction()
+                try {
+                    insertNovaItems(src, db, profileId, importedDeepShortcuts)
+                    db.setTransactionSuccessful()
+                } finally {
+                    db.endTransaction()
+                }
+            }
+        }
+        return importedDeepShortcuts.mapValues { (_, shortcutIds) -> shortcutIds.toSet() }
+    }
+
+    private fun insertNovaItems(
+        src: SQLiteDatabase,
+        db: SQLiteDatabase,
+        profileId: Long,
+        importedDeepShortcuts: MutableMap<String, MutableSet<String>>,
+    ) {
+        src.rawQuery(
+            "SELECT * FROM $NOVA_TABLE_FAVORITES WHERE $NOVA_COL_ITEM_TYPE != -1",
+            null,
+        ).use { cursor ->
+            val now = System.currentTimeMillis()
+
+            while (cursor.moveToNext()) {
+                val novaId = cursor.getInt(cursor.getColumnIndexOrThrow(NOVA_COL_ID))
+                val novaContainer = cursor.getInt(cursor.getColumnIndexOrThrow(NOVA_COL_CONTAINER))
+                val itemType = cursor.getInt(cursor.getColumnIndexOrThrow(NOVA_COL_ITEM_TYPE))
+
+                val isDesktop = novaContainer == NOVA_CONTAINER_DESKTOP
+                val isHotseat = novaContainer == NOVA_CONTAINER_HOTSEAT
+                val isFolderChild = novaContainer >= 0
+
+                if (!isDesktop && !isHotseat && !isFolderChild) continue
+
+                val container = when {
+                    isDesktop -> Favorites.CONTAINER_DESKTOP
+                    isHotseat -> Favorites.CONTAINER_HOTSEAT
+                    else -> novaContainer
+                }
+
+                val title = getStringOrNull(cursor, NOVA_COL_TITLE)
+                val rawIntent = getStringOrNull(cursor, NOVA_COL_INTENT)
+                val importedDeepShortcut = if (itemType == Favorites.ITEM_TYPE_DEEP_SHORTCUT) {
+                    parseNovaDeepShortcut(rawIntent)?.also { shortcut ->
+                        importedDeepShortcuts.getOrPut(shortcut.packageName) { mutableSetOf() }
+                            .add(shortcut.shortcutId)
+                    }
+                } else {
+                    null
+                }
+                val intent = importedDeepShortcut?.toLauncherIntentUri() ?: rawIntent
+                val cellX = cursor.getDouble(cursor.getColumnIndexOrThrow(NOVA_COL_CELL_X)).toInt()
+                val cellY = cursor.getDouble(cursor.getColumnIndexOrThrow(NOVA_COL_CELL_Y)).toInt()
+                val screen = if (isHotseat) cellX else cursor.getInt(cursor.getColumnIndexOrThrow(NOVA_COL_SCREEN))
+                val spanX = cursor.getDouble(cursor.getColumnIndexOrThrow(NOVA_COL_SPAN_X)).toInt().coerceAtLeast(1)
+                val spanY = cursor.getDouble(cursor.getColumnIndexOrThrow(NOVA_COL_SPAN_Y)).toInt().coerceAtLeast(1)
+                val icon = getBlobOrNull(cursor, NOVA_COL_ICON)
+                val appWidgetProvider = getStringOrNull(cursor, NOVA_COL_APP_WIDGET_PROVIDER)
+                val rank = when {
+                    isFolderChild -> calculateFolderRank(screen, cellX, cellY)
+                    isHotseat -> screen
+                    else -> 0
+                }
+
+                db.execSQL(
+                    """INSERT INTO favorites (
+                        _id, title, intent, container, screen, cellX, cellY,
+                        spanX, spanY, itemType, appWidgetId, icon,
+                        appWidgetProvider, modified, restored, profileId,
+                        rank, options, appWidgetSource
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, -1, ?, ?, ?, 0, ?, ?, 0, -1)""",
+                    arrayOf(
+                        novaId,
+                        title,
+                        intent,
+                        container,
+                        screen,
+                        cellX,
+                        if (isHotseat) 0 else cellY,
+                        spanX,
+                        spanY,
+                        itemType,
+                        icon,
+                        appWidgetProvider,
+                        now,
+                        profileId,
+                        rank,
+                    ),
+                )
+            }
+        }
+    }
+
+    private fun pinImportedDeepShortcuts(importedDeepShortcuts: Map<String, Set<String>>) {
+        if (importedDeepShortcuts.isEmpty()) return
+
+        val launcherApps = context.getSystemService(LauncherApps::class.java) ?: return
+        val user = Process.myUserHandle()
+
+        importedDeepShortcuts.forEach { (packageName, shortcutIds) ->
+            val pinnedShortcutIds = linkedSetOf<String>()
+            val currentPinnedShortcuts = ShortcutRequest(context, user)
+                .forPackage(packageName)
+                .query(ShortcutRequest.PINNED or LauncherApps.ShortcutQuery.FLAG_GET_KEY_FIELDS_ONLY)
+            if (currentPinnedShortcuts.wasSuccess()) {
+                currentPinnedShortcuts.mapTo(pinnedShortcutIds) { it.id }
+            }
+            pinnedShortcutIds.addAll(shortcutIds)
+
+            try {
+                launcherApps.pinShortcuts(packageName, pinnedShortcutIds.toList(), user)
+            } catch (e: SecurityException) {
+                Log.w(TAG, "Failed to pin imported deep shortcuts for $packageName", e)
+            } catch (e: IllegalStateException) {
+                Log.w(TAG, "Failed to pin imported deep shortcuts for $packageName", e)
+            }
+        }
+    }
+
+    private fun getStringOrNull(cursor: android.database.Cursor, column: String): String? {
+        val idx = cursor.getColumnIndex(column)
+        return if (idx >= 0 && !cursor.isNull(idx)) cursor.getString(idx) else null
+    }
+
+    private fun getBlobOrNull(cursor: android.database.Cursor, column: String): ByteArray? {
+        val idx = cursor.getColumnIndex(column)
+        return if (idx >= 0 && !cursor.isNull(idx)) cursor.getBlob(idx) else null
+    }
+
+    private fun extractFromZip(uri: Uri, destDir: File, fileNames: Set<String>) {
+        val pfd = context.contentResolver.openFileDescriptor(uri, "r")
+            ?: throw IllegalStateException("Unable to open backup URI")
+        val destCanonical = destDir.canonicalPath
+        pfd.use {
+            FileInputStream(it.fileDescriptor).use { fis ->
+                ZipInputStream(fis).use { zis ->
+                    var entry = zis.nextEntry
+                    while (entry != null) {
+                        if (!entry.isDirectory && entry.name in fileNames) {
+                            val outFile = File(destDir, entry.name)
+                            require(outFile.canonicalPath.startsWith(destCanonical + File.separator)) {
+                                "Zip entry outside target dir: ${entry.name}"
+                            }
+                            outFile.parentFile?.mkdirs()
+                            FileOutputStream(outFile).use { fos -> zis.copyTo(fos) }
+                        }
+                        entry = zis.nextEntry
+                    }
+                }
+            }
+        }
+    }
+
+    private fun calculateFolderRank(screen: Int, cellX: Int, cellY: Int): Int {
+        return (screen * FOLDER_PAGE_RANK_OFFSET) + (cellY * FOLDER_ROW_RANK_OFFSET) + cellX
+    }
+
+    private fun parseNovaDeepShortcut(intentUri: String?): ImportedDeepShortcut? {
+        if (intentUri.isNullOrEmpty()) return null
+
+        val intent = try {
+            Intent.parseUri(intentUri, 0)
+        } catch (_: URISyntaxException) {
+            return null
+        }
+
+        val packageName = intent.`package` ?: intent.component?.packageName ?: return null
+        val shortcutId = intent.getStringExtra(ShortcutKey.EXTRA_SHORTCUT_ID) ?: return null
+        return ImportedDeepShortcut(packageName, shortcutId)
+    }
+}

--- a/lawnchair/src/app/lawnchair/backup/ui/RestoreNovaBackupScreen.kt
+++ b/lawnchair/src/app/lawnchair/backup/ui/RestoreNovaBackupScreen.kt
@@ -1,0 +1,216 @@
+package app.lawnchair.backup.ui
+
+import android.app.Activity
+import android.content.Intent
+import android.widget.Toast
+import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import androidx.navigation.toRoute
+import app.lawnchair.backup.NovaBackupConverter.NovaBackupInfo
+import app.lawnchair.backup.ui.RestoreNovaBackupViewModel.Event
+import app.lawnchair.backup.ui.RestoreNovaBackupViewModel.State
+import app.lawnchair.ui.preferences.LocalIsExpandedScreen
+import app.lawnchair.ui.preferences.LocalNavController
+import app.lawnchair.ui.preferences.components.layout.PreferenceGroup
+import app.lawnchair.ui.preferences.components.layout.PreferenceLayout
+import app.lawnchair.ui.preferences.components.layout.PreferenceTemplate
+import app.lawnchair.ui.preferences.navigation.RestoreNovaBackup
+import app.lawnchair.util.BackHandler
+import app.lawnchair.util.restartLauncher
+import com.android.launcher3.R
+import java.util.Base64
+import kotlinx.coroutines.flow.Flow
+
+fun NavGraphBuilder.restoreNovaBackupGraph() {
+    composable<RestoreNovaBackup> { backStackEntry ->
+        val route: RestoreNovaBackup = backStackEntry.toRoute()
+        val backupUri = remember {
+            String(Base64.getDecoder().decode(route.base64Uri)).toUri()
+        }
+        val viewModel: RestoreNovaBackupViewModel = viewModel()
+        DisposableEffect(key1 = null) {
+            viewModel.init(backupUri)
+            onDispose { }
+        }
+        RestoreNovaBackupScreen()
+    }
+}
+
+@Composable
+internal fun RestoreNovaBackupScreen(
+    viewModel: RestoreNovaBackupViewModel = viewModel(),
+) {
+    val state = viewModel.state.collectAsStateWithLifecycle()
+
+    CollectEvents(viewModel.events)
+
+    PreferenceLayout(
+        label = stringResource(id = R.string.restore_nova_backup),
+        backArrowVisible = !LocalIsExpandedScreen.current,
+    ) {
+        when (val stateValue = state.value) {
+            is State.Success -> {
+                RestoreNovaBackupContent(
+                    state = stateValue,
+                    onRestore = viewModel::restore,
+                )
+            }
+
+            is State.Loading -> RestoreNovaBackupLoading()
+
+            is State.Error -> RestoreNovaBackupError()
+        }
+    }
+}
+
+@Composable
+internal fun ColumnScope.RestoreNovaBackupContent(
+    state: State.Success,
+    onRestore: () -> Unit,
+) {
+    if (state.isRestoring) {
+        BackHandler {}
+    }
+
+    BackupInfoGroup(state.info)
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 8.dp)
+            .padding(horizontal = 16.dp),
+    ) {
+        Button(
+            onClick = onRestore,
+            modifier = Modifier
+                .align(Alignment.CenterEnd)
+                .fillMaxWidth(),
+            enabled = !state.isRestoring,
+        ) {
+            Text(text = stringResource(id = R.string.action_restore))
+        }
+    }
+}
+
+@Composable
+private fun BackupInfoGroup(info: NovaBackupInfo) {
+    PreferenceGroup {
+        if (info.columns != null && info.rows != null) {
+            BackupInfoStringPreference(
+                R.string.nova_grid_label,
+                stringResource(R.string.nova_grid_value, info.columns, info.rows),
+            )
+        }
+        BackupInfoIntPreference(R.string.nova_dock_label, info.hotseatCount)
+        BackupInfoIntPreference(R.string.nova_app_label, info.appCount)
+        BackupInfoIntPreference(R.string.nova_widget_label, info.widgetCount)
+        BackupInfoIntPreference(R.string.nova_folder_label, info.folderCount)
+        BackupInfoIntPreference(R.string.nova_shortcut_label, info.shortcutCount)
+        BackupInfoStringPreference(R.string.nova_icon_pack_label, info.iconPackLabel)
+    }
+}
+
+@Composable
+private fun BackupInfoIntPreference(@StringRes labelRes: Int, value: Int?) {
+    if (value != null && value > 0) {
+        PreferenceTemplate(
+            title = { Text(text = stringResource(labelRes)) },
+            description = { Text(text = value.toString()) },
+        )
+    }
+}
+
+@Composable
+private fun BackupInfoStringPreference(@StringRes labelRes: Int, value: String?) {
+    if (!value.isNullOrEmpty()) {
+        PreferenceTemplate(
+            title = { Text(text = stringResource(labelRes)) },
+            description = { Text(text = value) },
+        )
+    }
+}
+
+@Composable
+private fun RestoreNovaBackupLoading() {
+    Box(modifier = Modifier.fillMaxSize()) {
+        CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+    }
+}
+
+@Composable
+private fun RestoreNovaBackupError() {
+    val context = LocalContext.current
+    val backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
+
+    LaunchedEffect(Unit) {
+        Toast.makeText(context, R.string.invalid_nova_backup_file, Toast.LENGTH_SHORT).show()
+        backDispatcher?.onBackPressed()
+    }
+}
+
+@Composable
+private fun CollectEvents(events: Flow<Event>) {
+    val context = LocalContext.current
+
+    LaunchedEffect(Unit) {
+        events.collect { event ->
+            when (event) {
+                is Event.RestoreSuccess -> {
+                    Toast.makeText(context, R.string.backup_restore_success, Toast.LENGTH_SHORT)
+                        .show()
+                    restartLauncher(context)
+                }
+
+                is Event.RestoreError -> {
+                    Toast.makeText(context, R.string.backup_restore_error, Toast.LENGTH_SHORT)
+                        .show()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun restoreNovaBackupOpener(): () -> Unit {
+    val navController = LocalNavController.current
+
+    val request =
+        rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+            if (it.resultCode != Activity.RESULT_OK) return@rememberLauncherForActivityResult
+            val uri = it.data?.data ?: return@rememberLauncherForActivityResult
+
+            val base64Uri = Base64.getEncoder().encodeToString(uri.toString().toByteArray())
+            navController.navigate(RestoreNovaBackup(base64Uri))
+        }
+
+    return {
+        Intent(Intent.ACTION_OPEN_DOCUMENT)
+            .addCategory(Intent.CATEGORY_OPENABLE)
+            .setType("*/*")
+            .let { request.launch(it) }
+    }
+}

--- a/lawnchair/src/app/lawnchair/backup/ui/RestoreNovaBackupViewModel.kt
+++ b/lawnchair/src/app/lawnchair/backup/ui/RestoreNovaBackupViewModel.kt
@@ -1,0 +1,78 @@
+package app.lawnchair.backup.ui
+
+import android.app.Application
+import android.net.Uri
+import android.util.Log
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import app.lawnchair.backup.NovaBackupConverter
+import app.lawnchair.backup.NovaBackupConverter.NovaBackupInfo
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+
+internal class RestoreNovaBackupViewModel(
+    application: Application,
+) : AndroidViewModel(application) {
+
+    sealed interface Event {
+        data object RestoreSuccess : Event
+        data object RestoreError : Event
+    }
+
+    sealed interface State {
+        data class Success(
+            val info: NovaBackupInfo,
+            val isRestoring: Boolean = false,
+        ) : State
+
+        data object Loading : State
+
+        data object Error : State
+    }
+
+    private var initialized = false
+    private lateinit var converter: NovaBackupConverter
+
+    private val _state = MutableStateFlow<State>(State.Loading)
+    val state: StateFlow<State> = _state.asStateFlow()
+
+    private val _events = Channel<Event>(Channel.BUFFERED)
+    val events = _events.receiveAsFlow()
+
+    fun init(backupUri: Uri) {
+        if (initialized) return
+        initialized = true
+        converter = NovaBackupConverter(getApplication(), backupUri)
+
+        viewModelScope.launch {
+            try {
+                val info = converter.parseInfo()
+                _state.value = State.Success(info)
+            } catch (t: Throwable) {
+                Log.e("RestoreNovaBackupViewModel", "failed to parse Nova backup", t)
+                _state.value = State.Error
+            }
+        }
+    }
+
+    fun restore() {
+        val state = _state.value as? State.Success ?: return
+        if (state.isRestoring) return
+
+        viewModelScope.launch {
+            _state.value = state.copy(isRestoring = true)
+            try {
+                converter.convertAndRestore(state.info)
+                _events.send(Event.RestoreSuccess)
+            } catch (t: Throwable) {
+                Log.e("RestoreNovaBackup", "failed to restore Nova backup", t)
+                _state.value = state.copy(isRestoring = false)
+                _events.send(Event.RestoreError)
+            }
+        }
+    }
+}

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/BackupAndRestorePreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/BackupAndRestorePreference.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import app.lawnchair.backup.ui.restoreBackupOpener
+import app.lawnchair.backup.ui.restoreNovaBackupOpener
 import app.lawnchair.ui.preferences.LocalIsExpandedScreen
 import app.lawnchair.ui.preferences.components.NavigationActionPreference
 import app.lawnchair.ui.preferences.components.controls.ClickablePreference
@@ -34,6 +35,13 @@ fun BackupAndRestorePreference(
                     label = stringResource(R.string.restore_backup),
                     subtitle = stringResource(R.string.restore_backup_description),
                     onClick = restoreBackupOpener(),
+                )
+            }
+            Item {
+                ClickablePreference(
+                    label = stringResource(R.string.restore_nova_backup),
+                    subtitle = stringResource(R.string.restore_nova_backup_description),
+                    onClick = restoreNovaBackupOpener(),
                 )
             }
         }

--- a/lawnchair/src/app/lawnchair/ui/preferences/navigation/PreferenceNavigation.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/navigation/PreferenceNavigation.kt
@@ -15,6 +15,7 @@ import androidx.navigation.navDeepLink
 import androidx.navigation.toRoute
 import app.lawnchair.backup.ui.CreateBackupScreen
 import app.lawnchair.backup.ui.restoreBackupGraph
+import app.lawnchair.backup.ui.restoreNovaBackupGraph
 import app.lawnchair.preferences.BasePreferenceManager
 import app.lawnchair.preferences.preferenceManager
 import app.lawnchair.ui.preferences.LocalIsExpandedScreen
@@ -233,5 +234,6 @@ fun PreferenceNavigation(
         ) { CreateBackupScreen(viewModel()) }
 
         restoreBackupGraph()
+        restoreNovaBackupGraph()
     }
 }

--- a/lawnchair/src/app/lawnchair/ui/preferences/navigation/PreferenceRoutes.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/navigation/PreferenceRoutes.kt
@@ -203,3 +203,6 @@ data object CreateBackup : PreferenceRoute, PreferenceDeepLink {
 
 @Serializable
 data class RestoreBackup(val base64Uri: String) : PreferenceRoute
+
+@Serializable
+data class RestoreNovaBackup(val base64Uri: String) : PreferenceRoute


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Fixes task of #6442

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->

This is a cherry-pick of f973986d, and forward ported to `16-dev`
* Backup/Restore popup were moved to `BackupAndRestorePreference`
* `DeviceGridState` use `GridType.GRID_TYPE_ANY`

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

None, in theory this should work:tm:

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **New feature** (A non-breaking change that adds functionality)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new option to restore a Nova Launcher backup from the Backup & restore section.
  * Shows backup details before restoring, including grid, dock, app, widget, folder, shortcut, and icon pack information.
  * Added support for importing the selected backup and restarting the launcher after completion.

* **Bug Fixes**
  * Added feedback for invalid backup files and restore failures.
  * Prevents accidental interruption while a restore is in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->