### PR TITLE
fix: crashes on android 8

### DIFF
--- a/quickstep/src/com/android/launcher3/model/QuickstepModelDelegate.java
+++ b/quickstep/src/com/android/launcher3/model/QuickstepModelDelegate.java
@@ -110,7 +110,7 @@ public class QuickstepModelDelegate extends ModelDelegate {
     private final PredictedItemFactory.Factory mItemParserFactory;
     private final AppEventProducer mAppEventProducer;
 
-    private final StatsManager mStatsManager;
+    private final Object mStatsManager;
 
     protected boolean mActive = false;
 
@@ -132,8 +132,12 @@ public class QuickstepModelDelegate extends ModelDelegate {
 
         // Only register for launcher snapshot logging if this is the primary ModelDelegate
         // instance, as there will be additional instances that may be destroyed at any time.
-        mStatsManager = TextUtils.isEmpty(dbFileName)
-                ? null : context.getSystemService(StatsManager.class);
+        // StatsManager was added in API 28, so guard against NoClassDefFoundError on older devices.
+        if (Utilities.ATLEAST_P && !TextUtils.isEmpty(dbFileName)) {
+            mStatsManager = context.getSystemService(StatsManager.class);
+        } else {
+            mStatsManager = null;
+        }
     }
 
     @Override
@@ -214,10 +218,11 @@ public class QuickstepModelDelegate extends ModelDelegate {
     private void registerSnapshotLoggingCallback() {
         if (mStatsManager == null || !LawnchairQuickstepCompat.ATLEAST_R) {
             Log.d(TAG, "Skipping snapshot logging");
+            return;
         }
 
         try {
-            mStatsManager.setPullAtomCallback(
+            ((StatsManager) mStatsManager).setPullAtomCallback(
                     SysUiStatsLog.LAUNCHER_LAYOUT_SNAPSHOT,
                     null /* PullAtomMetadata */,
                     MODEL_EXECUTOR,
@@ -284,7 +289,7 @@ public class QuickstepModelDelegate extends ModelDelegate {
         StatsLogCompatManager.LOGS_CONSUMER.remove(mAppEventProducer);
         if (mStatsManager != null && LawnchairQuickstepCompat.ATLEAST_R) {
             try {
-                mStatsManager.clearPullAtomCallback(SysUiStatsLog.LAUNCHER_LAYOUT_SNAPSHOT);
+                ((StatsManager) mStatsManager).clearPullAtomCallback(SysUiStatsLog.LAUNCHER_LAYOUT_SNAPSHOT);
             } catch (Throwable e) {
                 Log.e(TAG, "Failed to unregister snapshot logging callback with StatsManager", e);
             }

--- a/src/com/android/launcher3/preview/PreviewSurfaceRenderer.java
+++ b/src/com/android/launcher3/preview/PreviewSurfaceRenderer.java
@@ -52,6 +52,7 @@ import androidx.annotation.UiThread;
 
 import com.android.launcher3.InvariantDeviceProfile;
 import com.android.launcher3.LauncherPrefs;
+import com.android.launcher3.Utilities;
 import com.android.launcher3.dagger.LauncherComponentProvider;
 import com.android.launcher3.graphics.GridCustomizationsProxy;
 import com.android.launcher3.preview.PreviewContext.PreviewAppComponent;
@@ -321,8 +322,9 @@ public class PreviewSurfaceRenderer {
             wallpaperColorResources = LocalColorExtractor.newInstance(context)
                     .generateColorsOverride(mWallpaperColors);
         } else {
-            WallpaperColors wallpaperColors =
-                    WallpaperManager.getInstance(context).getWallpaperColors(FLAG_SYSTEM);
+            WallpaperColors wallpaperColors = Utilities.ATLEAST_O_MR1
+                    ? WallpaperManager.getInstance(context).getWallpaperColors(FLAG_SYSTEM)
+                    : null;
             wallpaperColorResources = wallpaperColors == null ? null
                     : LocalColorExtractor.newInstance(context)
                             .generateColorsOverride(wallpaperColors);

--- a/systemUI/shared/src/app/lawnchair/compat/LawnchairQuickstepCompat.kt
+++ b/systemUI/shared/src/app/lawnchair/compat/LawnchairQuickstepCompat.kt
@@ -45,23 +45,25 @@ object LawnchairQuickstepCompat {
     val ATLEAST_BAKLAVA: Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA
 
     @JvmStatic
-    val factory: QuickstepCompatFactory = when {
-        ATLEAST_BAKLAVA -> QuickstepCompatFactoryVBaklava()
-        ATLEAST_V -> QuickstepCompatFactoryVV()
-        ATLEAST_U -> QuickstepCompatFactoryVU()
-        ATLEAST_T -> QuickstepCompatFactoryVT()
-        ATLEAST_S -> QuickstepCompatFactoryVS()
-        ATLEAST_R -> QuickstepCompatFactoryVR()
-        ATLEAST_Q -> QuickstepCompatFactoryVQ()
-        else -> error("Unsupported SDK version")
+    val factory: QuickstepCompatFactory by lazy {
+        when {
+            ATLEAST_BAKLAVA -> QuickstepCompatFactoryVBaklava()
+            ATLEAST_V -> QuickstepCompatFactoryVV()
+            ATLEAST_U -> QuickstepCompatFactoryVU()
+            ATLEAST_T -> QuickstepCompatFactoryVT()
+            ATLEAST_S -> QuickstepCompatFactoryVS()
+            ATLEAST_R -> QuickstepCompatFactoryVR()
+            ATLEAST_Q -> QuickstepCompatFactoryVQ()
+            else -> error("Unsupported SDK version")
+        }
     }
 
     @JvmStatic
-    val activityManagerCompat: ActivityManagerCompat = factory.activityManagerCompat
+    val activityManagerCompat: ActivityManagerCompat by lazy { factory.activityManagerCompat }
 
     @JvmStatic
-    val activityOptionsCompat: ActivityOptionsCompat = factory.activityOptionsCompat
+    val activityOptionsCompat: ActivityOptionsCompat by lazy { factory.activityOptionsCompat }
 
     @JvmStatic
-    val remoteTransitionCompat: RemoteTransitionCompat = factory.remoteTransitionCompat
+    val remoteTransitionCompat: RemoteTransitionCompat by lazy { factory.remoteTransitionCompat }
 }


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

- Closes: #6977 

### Reasoning

1. QuickstepModelDelegate.java — StatsManager crash (primary fix)
android.app.StatsManager was added in API 28, but the field was declared as private final StatsManager mStatsManager. On API 26, this causes a NoClassDefFoundError at class load time because the DEX verifier can't resolve the type.

Fix: Changed the field type from StatsManager to Object to avoid class verification failure
Added Utilities.ATLEAST_P guard around getSystemService(StatsManager.class)
Added a missing return statement after the null/version check in registerSnapshotLoggingCallback() (this was also a bug — it logged "Skipping" but then proceeded to call mStatsManager.setPullAtomCallback() which would NPE)
Added explicit casts (StatsManager) mStatsManager at the two usage sites (registerSnapshotLoggingCallback and destroy)

2. LawnchairQuickstepCompat.kt — Factory crash on API < 29
The factory property was eagerly initialized with = when { ... else -> error("Unsupported SDK version") }. Since this is a Kotlin object, accessing ANY field (including ATLEAST_R used by QuickstepModelDelegate) would trigger initialization of all properties, including factory, causing a crash on API 26-28.

Fix: Changed factory, activityManagerCompat, activityOptionsCompat, and remoteTransitionCompat to use by lazy { } initialization so they only crash if actually accessed on an unsupported SDK level.

3. PreviewSurfaceRenderer.java — getWallpaperColors crash
WallpaperManager.getWallpaperColors(int) was added in API 27 (O_MR1). The code called it without any version guard.

Fix: Added Utilities.ATLEAST_O_MR1 check, returning null on API 26, which gracefully falls through to the existing null-handling logic.

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
:x: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with older Android versions by preventing unsupported system APIs from being accessed.
  * Fixed preview rendering on devices that do not support wallpaper color retrieval.
  * Improved startup reliability by delaying compatibility setup until required features are used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->