### PR TITLE
fix: Apply icon packs to work/private profile apps

### DIFF
--- a/lawnchair/src/app/lawnchair/icons/LawnchairIconProvider.kt
+++ b/lawnchair/src/app/lawnchair/icons/LawnchairIconProvider.kt
@@ -14,6 +14,8 @@ import android.content.Intent.ACTION_TIME_CHANGED
 import android.content.Intent.ACTION_TIME_TICK
 import android.content.IntentFilter
 import android.content.pm.ApplicationInfo
+import android.content.pm.ComponentInfo
+import android.content.pm.LauncherApps
 import android.content.pm.PackageItemInfo
 import android.content.res.Resources
 import android.graphics.drawable.Drawable
@@ -32,6 +34,7 @@ import app.lawnchair.icons.picker.IconType
 import app.lawnchair.preferences.PreferenceManager
 import app.lawnchair.util.MultiSafeCloseable
 import app.lawnchair.util.isPackageInstalled
+import app.lawnchair.util.requireSystemService
 import com.android.launcher3.R
 import com.android.launcher3.dagger.ApplicationContext
 import com.android.launcher3.dagger.LauncherAppSingleton
@@ -107,14 +110,42 @@ class LawnchairIconProvider @Inject constructor(
         return iconPack.getIcon(componentName)
     }
 
+    /**
+     * Resolves the launch component for icon-pack lookup.
+     *
+     * Avoid [android.content.pm.PackageManager.getLaunchIntentForPackage], which only sees the
+     * current user — work/private profile apps would otherwise fall back to the system icon.
+     * Prefer the real component from [ComponentInfo], then [LauncherApps] for the app's user.
+     */
+    private fun resolveComponentName(
+        info: PackageItemInfo,
+        appInfo: ApplicationInfo,
+        user: UserHandle,
+    ): ComponentName? {
+        if (info is ComponentInfo && !info.name.isNullOrEmpty()) {
+            return ComponentName(info.packageName ?: appInfo.packageName, info.name)
+        }
+        return resolveLaunchComponent(appInfo.packageName, user)
+    }
+
+    private fun resolveLaunchComponent(packageName: String, user: UserHandle): ComponentName? {
+        return try {
+            val launcherApps: LauncherApps = context.requireSystemService()
+            launcherApps.getActivityList(packageName, user).firstOrNull()?.componentName
+        } catch (t: Throwable) {
+            Log.w(TAG, "Failed to resolve launch component for $packageName user=$user", t)
+            null
+        }
+    }
+
     override fun getIcon(
         info: PackageItemInfo,
         appInfo: ApplicationInfo,
         iconDpi: Int,
     ): Drawable {
         val packageName = appInfo.packageName
-        val componentName = context.packageManager.getLaunchIntentForPackage(packageName)?.component
         val user = UserHandle.getUserHandleForUid(appInfo.uid)
+        val componentName = resolveComponentName(info, appInfo, user)
 
         var iconEntry: IconEntry? = null
         if (componentName != null) {

--- a/lawnchair/src/app/lawnchair/icons/iconpack/SystemIconPack.kt
+++ b/lawnchair/src/app/lawnchair/icons/iconpack/SystemIconPack.kt
@@ -26,7 +26,13 @@ class SystemIconPack(context: Context, pkg: String) : IconPack(context, pkg) {
         val profiles = UserCache.INSTANCE.get(context).userProfiles
         val launcherApps: LauncherApps = context.requireSystemService()
         profiles
-            .flatMap { launcherApps.getActivityList(null, Process.myUserHandle()) }
+            .flatMap { profile ->
+                try {
+                    launcherApps.getActivityList(null, profile)
+                } catch (_: Throwable) {
+                    emptyList()
+                }
+            }
             .associateBy { ComponentKey(it.componentName, it.user) }
     }
 
@@ -34,7 +40,11 @@ class SystemIconPack(context: Context, pkg: String) : IconPack(context, pkg) {
         startLoad()
     }
 
-    override fun getIcon(componentName: ComponentName) = IconEntry(packPackageName, ComponentKey(componentName, Process.myUserHandle()).toString(), IconType.Normal)
+    override fun getIcon(componentName: ComponentName): IconEntry {
+        val matching = appMap.keys.firstOrNull { it.componentName == componentName }
+        val key = matching ?: ComponentKey(componentName, Process.myUserHandle())
+        return IconEntry(packPackageName, key.toString(), IconType.Normal)
+    }
     override fun getCalendar(componentName: ComponentName): IconEntry? = null
     override fun getClock(entry: IconEntry): ClockMetadata? = null
 

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/SelectIconPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/SelectIconPreference.kt
@@ -113,12 +113,13 @@ private fun resolveAppLabel(launcherApps: LauncherApps, componentKey: ComponentK
         Log.w(TAG, "resolveActivity failed for $componentKey", t)
     }
     try {
-        launcherApps.getActivityList(componentName.packageName, user)
+        val activities = launcherApps.getActivityList(componentName.packageName, user)
+        activities
             .firstOrNull { it.componentName == componentName }
             ?.label
             ?.toString()
             ?.let { return it }
-        launcherApps.getActivityList(componentName.packageName, user)
+        activities
             .firstOrNull()
             ?.label
             ?.toString()

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/SelectIconPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/SelectIconPreference.kt
@@ -3,6 +3,7 @@ package app.lawnchair.ui.preferences.destinations
 import android.app.Activity
 import android.content.Intent
 import android.content.pm.LauncherApps
+import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -27,14 +28,13 @@ import com.android.launcher3.R
 import com.android.launcher3.util.ComponentKey
 import kotlinx.coroutines.launch
 
+private const val TAG = "SelectIconPreference"
+
 @Composable
 fun SelectIconPreference(componentKey: ComponentKey) {
     val context = LocalContext.current
     val label = remember(componentKey) {
-        val launcherApps: LauncherApps = context.requireSystemService()
-        val intent = Intent().setComponent(componentKey.componentName)
-        val activity = launcherApps.resolveActivity(intent, componentKey.user)
-        activity.label.toString()
+        resolveAppLabel(context.requireSystemService(), componentKey)
     }
     val iconPacks by LocalPreferenceInteractor.current.iconPacks.collectAsStateWithLifecycle()
     val navController = LocalNavController.current
@@ -95,4 +95,36 @@ fun SelectIconPreference(componentKey: ComponentKey) {
             )
         }
     }
+}
+
+/**
+ * Resolves a display label for [componentKey], including work/private profiles.
+ *
+ * [LauncherApps.resolveActivity] can return null or throw for non-current users; fall back to
+ * [LauncherApps.getActivityList] and finally the activity class name.
+ */
+private fun resolveAppLabel(launcherApps: LauncherApps, componentKey: ComponentKey): String {
+    val componentName = componentKey.componentName
+    val user = componentKey.user
+    try {
+        val intent = Intent().setComponent(componentName)
+        launcherApps.resolveActivity(intent, user)?.label?.toString()?.let { return it }
+    } catch (t: Throwable) {
+        Log.w(TAG, "resolveActivity failed for $componentKey", t)
+    }
+    try {
+        launcherApps.getActivityList(componentName.packageName, user)
+            .firstOrNull { it.componentName == componentName }
+            ?.label
+            ?.toString()
+            ?.let { return it }
+        launcherApps.getActivityList(componentName.packageName, user)
+            .firstOrNull()
+            ?.label
+            ?.toString()
+            ?.let { return it }
+    } catch (t: Throwable) {
+        Log.w(TAG, "getActivityList failed for $componentKey", t)
+    }
+    return componentName.shortClassName?.trimStart('.') ?: componentName.packageName
 }

--- a/src/com/android/launcher3/model/data/ItemInfoWithIcon.java
+++ b/src/com/android/launcher3/model/data/ItemInfoWithIcon.java
@@ -16,7 +16,6 @@
 
 package com.android.launcher3.model.data;
 
-import static com.android.launcher3.icons.BitmapInfo.FLAG_NO_BADGE;
 import static com.android.launcher3.icons.BitmapInfo.FLAG_THEMED;
 
 import android.content.Context;
@@ -324,7 +323,8 @@ public abstract class ItemInfoWithIcon extends ItemInfo {
      */
     public FastBitmapDrawable newIcon(Context context) {
         var shouldTheme = PreferenceManager.getInstance(context).getThemedIcons().get();
-        return newIcon(context, shouldTheme ? BitmapInfo.FLAG_THEMED : BitmapInfo.FLAG_NO_BADGE);
+        // Use 0 (not FLAG_NO_BADGE) when theming is off so work/clone profile badges still draw.
+        return newIcon(context, shouldTheme ? FLAG_THEMED : 0);
     }
 
     /**


### PR DESCRIPTION
### Description

Icon packs and per-app icon customization failed for work/private profile apps because components were resolved with `PackageManager.getLaunchIntentForPackage`, which only sees the current user. Resolve via `ActivityInfo` / `LauncherApps` for the correct `UserHandle`, harden `SelectIconPreference`, and stop suppressing work badges when themed icons are off.

Fixes #5202
Fixes #4988

### Testing

1. Install a custom icon pack and enable it in Lawnchair.
2. Open the Work tab in the app drawer — work-only apps should use pack icons (with work badge).
3. Long-press a work app → Customize → change icon → confirm it applies to the work app, not the personal twin.
4. With themed icons off, confirm work badges still show.

### Type of change

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
:x: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app icon and component resolution for work and private profiles.
  * Expanded system icon mapping to correctly cover apps across all cached user profiles.
  * Enhanced icon label detection with more resilient, multi-step lookups and sensible fallbacks.
  * Fixed icon rendering when themed icons are disabled.
* **UI / Layout**
  * Updated all-apps search bar handling so the hidden-search mode uses dedicated layout and header behavior.
* **Resources**
  * Refined all-apps header spacing via new dimen values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->