### PR TITLE
fix: Tighten app drawer spacing around search and tabs

### DIFF
--- a/lawnchair/res/values/dimens.xml
+++ b/lawnchair/res/values/dimens.xml
@@ -67,7 +67,16 @@
     <dimen name="search_result_text_height">52dp</dimen>
     <dimen name="search_result_subtitle_padding_start">4dp</dimen>
 
+    <!-- Header is aligned to the search container top with this margin. 60dp search
+         container + a small gap; keep in sync with search_box_container_height. -->
     <dimen name="all_apps_header_top_margin">64dp</dimen>
+    <!-- AOSP uses 36dp to clear an overlapping search bar; Lawnchair's larger
+         top_margin already clears the search, so keep this tight. -->
+    <dimen name="all_apps_header_top_padding">4dp</dimen>
+    <dimen name="all_apps_tabs_margin_top">4dp</dimen>
+    <!-- Match the search→tabs gap so the app grid sits equally close under the tabs. -->
+    <dimen name="all_apps_paged_view_top_padding">8dp</dimen>
+    <dimen name="all_apps_header_bottom_padding">4dp</dimen>
 
     <!-- smartspace -->
     <dimen name="smartspaceAmbientShadowBlur">1.5dp</dimen>

--- a/lawnchair/src/app/lawnchair/allapps/AllAppsSearchInput.kt
+++ b/lawnchair/src/app/lawnchair/allapps/AllAppsSearchInput.kt
@@ -445,10 +445,12 @@ class AllAppsSearchInput(context: Context, attrs: AttributeSet?) :
         (layoutParams as MarginLayoutParams).apply {
             topMargin = when {
                 hideSearchBar -> 0
+
                 // Sheet mode already pads the container with status-bar insets; only clear the
                 // drag handle. Re-applying insets.top here created the large empty band under it.
                 launcher.deviceProfile.shouldShowAllAppsOnSheet() ->
                     resources.getDimensionPixelSize(R.dimen.bottom_sheet_handle_area_height)
+
                 else -> max(-allAppsSearchVerticalOffset, insets.top - qsbMarginTopAdjusting)
             }
         }

--- a/lawnchair/src/app/lawnchair/allapps/AllAppsSearchInput.kt
+++ b/lawnchair/src/app/lawnchair/allapps/AllAppsSearchInput.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.view.ViewCompat
+import androidx.core.view.isGone
 import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import androidx.core.widget.addTextChangedListener
@@ -110,6 +111,7 @@ class AllAppsSearchInput(context: Context, attrs: AttributeSet?) :
 
     private var initialPaddingLeft: Int = 0
     private var initialPaddingRight: Int = 0
+    private var hideSearchBar = false
 
     override fun onFinishInflate() {
         super.onFinishInflate()
@@ -271,9 +273,10 @@ class AllAppsSearchInput(context: Context, attrs: AttributeSet?) :
             },
         )
 
-        val hide = prefs2.hideAppDrawerSearchBar.firstCached()
-        if (hide) {
-            isInvisible = true
+        hideSearchBar = prefs2.hideAppDrawerSearchBar.firstCached()
+        if (hideSearchBar) {
+            // GONE so top margin/height do not reserve empty space above the app list.
+            isGone = true
             layoutParams.height = 0
         }
     }
@@ -440,18 +443,16 @@ class AllAppsSearchInput(context: Context, attrs: AttributeSet?) :
 
     override fun setInsets(insets: Rect) {
         (layoutParams as MarginLayoutParams).apply {
-            topMargin = if (isInvisible) {
-                insets.top - allAppsSearchVerticalOffset
-            } else {
-                max(-allAppsSearchVerticalOffset, insets.top - qsbMarginTopAdjusting)
+            topMargin = when {
+                hideSearchBar -> 0
+                // Sheet mode already pads the container with status-bar insets; only clear the
+                // drag handle. Re-applying insets.top here created the large empty band under it.
+                launcher.deviceProfile.shouldShowAllAppsOnSheet() ->
+                    resources.getDimensionPixelSize(R.dimen.bottom_sheet_handle_area_height)
+                else -> max(-allAppsSearchVerticalOffset, insets.top - qsbMarginTopAdjusting)
             }
         }
         requestLayout()
-    }
-
-    override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
-        super.onLayout(changed, l, t, r, b)
-        offsetTopAndBottom(allAppsSearchVerticalOffset)
     }
 
     override fun getEditText() = input

--- a/src/com/android/launcher3/allapps/ActivityAllAppsContainerView.java
+++ b/src/com/android/launcher3/allapps/ActivityAllAppsContainerView.java
@@ -812,7 +812,10 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
 
         removeCustomRules(rvContainer);
         removeCustomRules(getSearchRecyclerView());
-        if (isSearchBarFloating()) {
+        if (isAppDrawerSearchBarHidden()) {
+            layoutWithoutSearchContainer(rvContainer, showTabs);
+            layoutWithoutSearchContainer(getSearchRecyclerView(), /* tabs= */ false);
+        } else if (isSearchBarFloating()) {
             alignParentTop(rvContainer, showTabs);
             alignParentTop(getSearchRecyclerView(), /* tabs= */ false);
         } else {
@@ -826,8 +829,9 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
     void setupHeader() {
         mAdditionalHeaderRows.forEach(row -> mHeader.onPluginDisconnected(row));
 
-        var hideHeader = PreferenceCacheExtensionsKt.firstCached(pref2.getHideAppDrawerSearchBar());
-        mHeader.setVisibility(hideHeader ? View.GONE : View.VISIBLE);
+        boolean hideSearchBar = isAppDrawerSearchBarHidden();
+        // Keep personal/work tabs visible when search is off; only hide the empty header shell.
+        mHeader.setVisibility((hideSearchBar && !mUsingTabs) ? View.GONE : View.VISIBLE);
         boolean tabsHidden = !mUsingTabs;
         mHeader.setup(
                 mAH.get(AdapterHolder.MAIN).mRecyclerView,
@@ -836,7 +840,7 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
                 getCurrentPage(),
                 tabsHidden);
 
-        int padding = mHeader.getMaxTranslation();
+        int padding = (hideSearchBar && !mUsingTabs) ? 0 : mHeader.getMaxTranslation();
         mAH.forEach(adapterHolder -> {
             adapterHolder.mPadding.top = padding;
             adapterHolder.applyPadding();
@@ -847,7 +851,9 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
         mAdditionalHeaderRows.forEach(row -> mHeader.onPluginConnected(row, mActivityContext));
 
         removeCustomRules(mHeader);
-        if (isSearchBarFloating()) {
+        if (hideSearchBar) {
+            layoutWithoutSearchContainer(mHeader, false /* includeTabsMargin */);
+        } else if (isSearchBarFloating()) {
             alignParentTop(mHeader, false /* includeTabsMargin */);
         } else {
             layoutBelowSearchContainer(mHeader, false /* includeTabsMargin */);
@@ -879,7 +885,7 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
     }
 
     protected void updateHeaderScroll(int scrolledOffset) {
-        if (PreferenceCacheExtensionsKt.firstCached(pref2.getHideAppDrawerSearchBar()))
+        if (isAppDrawerSearchBarHidden() && !mUsingTabs)
             return;
         
         // Check if tab container background should be shown
@@ -1024,6 +1030,10 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
         return dp.allAppsLeftRightMargin + dp.getAllAppsIconStartMargin(mActivityContext);
     }
 
+    private boolean isAppDrawerSearchBarHidden() {
+        return PreferenceCacheExtensionsKt.firstCached(pref2.getHideAppDrawerSearchBar());
+    }
+
     private void layoutBelowSearchContainer(View v, boolean includeTabsMargin) {
         if (!(v.getLayoutParams() instanceof RelativeLayout.LayoutParams)) {
             return;
@@ -1042,8 +1052,7 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
     }
 
     private void alignParentTop(View v, boolean includeTabsMargin) {
-        if (!(v.getLayoutParams() instanceof RelativeLayout.LayoutParams)
-                || PreferenceCacheExtensionsKt.firstCached(pref2.getHideAppDrawerSearchBar())) {
+        if (!(v.getLayoutParams() instanceof RelativeLayout.LayoutParams)) {
             return;
         }
 
@@ -1057,8 +1066,7 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
     }
 
     private void removeCustomRules(View v) {
-        if (!(v.getLayoutParams() instanceof RelativeLayout.LayoutParams)
-                || PreferenceCacheExtensionsKt.firstCached(pref2.getHideAppDrawerSearchBar())) {
+        if (!(v.getLayoutParams() instanceof RelativeLayout.LayoutParams)) {
             return;
         }
 
@@ -1066,6 +1074,26 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
         layoutParams.removeRule(RelativeLayout.ABOVE);
         layoutParams.removeRule(RelativeLayout.ALIGN_TOP);
         layoutParams.removeRule(RelativeLayout.ALIGN_PARENT_TOP);
+    }
+
+    private void layoutWithoutSearchContainer(View v, boolean includeTabsMargin) {
+        if (!(v.getLayoutParams() instanceof RelativeLayout.LayoutParams)) {
+            return;
+        }
+
+        RelativeLayout.LayoutParams layoutParams = (LayoutParams) v.getLayoutParams();
+        layoutParams.addRule(RelativeLayout.ALIGN_PARENT_TOP);
+        int topMargin = 0;
+        if (mActivityContext.getDeviceProfile().shouldShowAllAppsOnSheet()) {
+            // Clear the bottom-sheet drag handle when search is not reserving that space.
+            topMargin = getContext().getResources().getDimensionPixelSize(
+                    R.dimen.bottom_sheet_handle_area_height);
+        }
+        if (includeTabsMargin) {
+            topMargin += getContext().getResources().getDimensionPixelSize(
+                    R.dimen.all_apps_header_pill_height);
+        }
+        layoutParams.topMargin = topMargin;
     }
 
     protected BaseAllAppsAdapter<T> createAdapter(AlphabeticalAppsList<T> appsList) {

--- a/src/com/android/launcher3/allapps/ActivityAllAppsContainerView.java
+++ b/src/com/android/launcher3/allapps/ActivityAllAppsContainerView.java
@@ -1415,7 +1415,9 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
         } else {
             getSearchRecyclerView().setVisibility(GONE);
             getAppsRecyclerViewContainer().setVisibility(VISIBLE);
-            mHeader.setVisibility(VISIBLE);
+            // Keep the empty header shell hidden when search is off and there are no tabs.
+            mHeader.setVisibility(
+                    (isAppDrawerSearchBarHidden() && !mUsingTabs) ? View.GONE : View.VISIBLE);
         }
         if (mHeader.isSetUp()) {
             mHeader.setActiveRV(getCurrentPage());


### PR DESCRIPTION
### Description

Fixes uneven spacing in the app drawer: a large empty band above the search bar (from stacking status-bar insets on sheet mode), leftover AOSP header padding between search and personal/work tabs, and excess paged-view padding above the app grid. Also collapses the reserved top space when the drawer search bar is hidden, instead of leaving a blank gap.

### Testing

1. Open the app drawer on a phone (bottom-sheet layout).
2. Confirm the gap under the drag handle → search → tabs → first app row looks even.
3. Disable the drawer search bar and reopen the drawer — empty space where the search bar was should collapse; personal/work tabs (if present) should still show.
4. Re-enable search and confirm spacing is still correct.

### Type of change

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
:x: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced support for hiding the app drawer search bar by fully removing its reserved space and switching to a no-search layout mode for the app list.
  * Updated “all apps” header spacing with new top padding, tabs margin, paged-view top padding, and bottom padding values.

* **Bug Fixes**
  * Fixed header visibility, positioning, and scroll behavior when the search bar is disabled, including correct header/container alignment.
  * Improved handling of the empty header shell when the search bar is hidden and tabs are not active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->