### PR TITLE
fix(allapps): Hide work/private badges on their drawer tabs

### DIFF
--- a/src/com/android/launcher3/allapps/AlphabeticalAppsList.java
+++ b/src/com/android/launcher3/allapps/AlphabeticalAppsList.java
@@ -572,6 +572,11 @@ public class AlphabeticalAppsList<T extends Context & ActivityContext> implement
         return mPrivateProviderManager;
     }
 
+    /** Returns true when this list is the Work tab (work-only apps). */
+    public boolean isWorkAppsList() {
+        return mWorkProviderManager != null;
+    }
+
     public void dump(String prefix, PrintWriter writer) {
         writer.println(prefix + "SectionInfo[] size: " + mFastScrollerSections.size());
         for (int i = 0; i < mFastScrollerSections.size(); i++) {

--- a/src/com/android/launcher3/allapps/BaseAllAppsAdapter.java
+++ b/src/com/android/launcher3/allapps/BaseAllAppsAdapter.java
@@ -284,9 +284,15 @@ public abstract class BaseAllAppsAdapter<T extends Context & ActivityContext> ex
                 AdapterItem adapterItem = mApps.getAdapterItems().get(position);
                 BubbleTextView icon = (BubbleTextView) holder.itemView;
                 icon.reset();
+                // Work/Private contexts already imply the profile; skip redundant user badges.
+                // Keep badges on home, search, and personal icons (including clones).
+                PrivateProfileManager privateProfileManager = mApps.getPrivateProfileManager();
+                boolean skipUserBadge = mApps.isWorkAppsList()
+                        || (privateProfileManager != null
+                                && privateProfileManager.isPrivateSpaceItem(adapterItem));
+                icon.setSkipUserBadge(skipUserBadge);
                 icon.applyFromApplicationInfo(adapterItem.itemInfo);
                 icon.setOnFocusChangeListener(mIconFocusListener);
-                PrivateProfileManager privateProfileManager = mApps.getPrivateProfileManager();
                 if (privateProfileManager != null) {
                     // Set the alpha of the private space icon to 0 upon expanding the header so the
                     // alpha can animate -> 1. This should only be in effect when doing a

--- a/src/com/android/launcher3/allapps/BaseAllAppsAdapter.java
+++ b/src/com/android/launcher3/allapps/BaseAllAppsAdapter.java
@@ -287,9 +287,10 @@ public abstract class BaseAllAppsAdapter<T extends Context & ActivityContext> ex
                 // Work/Private contexts already imply the profile; skip redundant user badges.
                 // Keep badges on home, search, and personal icons (including clones).
                 PrivateProfileManager privateProfileManager = mApps.getPrivateProfileManager();
-                boolean skipUserBadge = mApps.isWorkAppsList()
-                        || (privateProfileManager != null
-                                && privateProfileManager.isPrivateSpaceItem(adapterItem));
+                boolean skipUserBadge = !mApps.hasSearchResults()
+                        && (mApps.isWorkAppsList()
+                                || (privateProfileManager != null
+                                        && privateProfileManager.isPrivateSpaceItem(adapterItem)));
                 icon.setSkipUserBadge(skipUserBadge);
                 icon.applyFromApplicationInfo(adapterItem.itemInfo);
                 icon.setOnFocusChangeListener(mIconFocusListener);


### PR DESCRIPTION
### Description

Hide work/private user badges in the app drawer when the profile context is already clear: the Work tab and the Private Space section. Badges remain on the home screen and in search so personal and work apps stay distinguishable.

### Testing

1. Open the Work tab in the app drawer — work badges should not appear on icons.
2. Open Private Space in the drawer — private badges should not appear on those icons.
3. Check home screen work/private shortcuts — badges should still show.
4. Search for a work app — badge should still show in search results.

### Type of change

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
:x: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected user badge display for apps in the Work tab and when Private Space is active.
  - Ensured app icons consistently show or hide badges based on the current app list context and search results.
  - Improved visual consistency when browsing apps across personal, work, and private spaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->