### PR TITLE
fix: Auto-contrast Personal/Work tab text against background

### DIFF
--- a/lawnchair/src/app/lawnchair/theme/color/tokens/AllAppsTabColors.kt
+++ b/lawnchair/src/app/lawnchair/theme/color/tokens/AllAppsTabColors.kt
@@ -1,0 +1,43 @@
+package app.lawnchair.theme.color.tokens
+
+import android.content.Context
+import androidx.core.graphics.luminance
+import app.lawnchair.preferences2.PreferenceManager2
+import app.lawnchair.preferences2.firstCached
+import app.lawnchair.theme.UiColorMode
+import dev.kdrag0n.monet.theme.ColorScheme
+
+/** Shared colors for Personal/Work tabs in the app drawer. */
+object AllAppsTabColors {
+
+    fun selectedBackground(
+        context: Context,
+        scheme: ColorScheme,
+        uiColorMode: UiColorMode,
+    ): Int {
+        val prefs2 = PreferenceManager2.getInstance(context)
+        val customColor = prefs2.workProfileTabBackgroundColor.firstCached()
+            .colorPreferenceEntry.lightColor.invoke(context)
+        return if (customColor != 0) {
+            customColor
+        } else {
+            ColorTokens.AllAppsTabBackgroundSelected.resolveColor(context, scheme, uiColorMode)
+        }
+    }
+
+    /**
+     * Text color for the selected tab, chosen for contrast against [selectedBackground].
+     */
+    fun selectedText(
+        context: Context,
+        scheme: ColorScheme,
+        uiColorMode: UiColorMode,
+    ): Int {
+        val background = selectedBackground(context, scheme, uiColorMode)
+        return if (background.luminance > 0.5f) {
+            ColorTokens.Neutral1_900.resolveColor(context, scheme, uiColorMode)
+        } else {
+            ColorTokens.Neutral1_50.resolveColor(context, scheme, uiColorMode)
+        }
+    }
+}

--- a/lawnchair/src/app/lawnchair/theme/color/tokens/ColorStateListTokens.kt
+++ b/lawnchair/src/app/lawnchair/theme/color/tokens/ColorStateListTokens.kt
@@ -11,7 +11,7 @@ object ColorStateListTokens {
             intArrayOf(),
         )
         val colors = intArrayOf(
-            ColorTokens.TextColorPrimaryInverse.resolveColor(context, scheme, uiColorMode),
+            AllAppsTabColors.selectedText(context, scheme, uiColorMode),
             ColorTokens.TextColorSecondary.resolveColor(context, scheme, uiColorMode),
         )
         ColorStateList(states, colors)
@@ -23,7 +23,7 @@ object ColorStateListTokens {
             intArrayOf(),
         )
         val colors = intArrayOf(
-            ColorTokens.TextColorPrimaryInverse.resolveColor(context, scheme, uiColorMode),
+            AllAppsTabColors.selectedText(context, scheme, uiColorMode),
             ColorTokens.TextColorSecondary.resolveColor(context, scheme, uiColorMode),
         )
         ColorStateList(states, colors)

--- a/lawnchair/src/app/lawnchair/theme/drawable/DrawableTokens.kt
+++ b/lawnchair/src/app/lawnchair/theme/drawable/DrawableTokens.kt
@@ -7,8 +7,7 @@ import android.graphics.drawable.InsetDrawable
 import android.graphics.drawable.RippleDrawable
 import android.graphics.drawable.StateListDrawable
 import androidx.appcompat.content.res.AppCompatResources
-import app.lawnchair.preferences2.PreferenceManager2
-import app.lawnchair.preferences2.firstCached
+import app.lawnchair.theme.color.tokens.AllAppsTabColors
 import app.lawnchair.theme.color.tokens.ColorTokens
 import com.android.launcher3.R
 
@@ -141,16 +140,8 @@ object DrawableTokens {
             R.drawable.all_apps_tabs_background,
         )
 
-        // Get custom color from preferences
-        val prefs2 = PreferenceManager2.getInstance(context)
-        val colorOption = prefs2.workProfileTabBackgroundColor.firstCached()
-        val customColor = colorOption.colorPreferenceEntry.lightColor.invoke(context)
-
-        val selectedColor = if (customColor != 0) {
-            customColor
-        } else {
-            ColorTokens.AllAppsTabBackgroundSelected.resolveColor(context, scheme, uiColorMode)
-        }
+        // Prefer the user-selected tab color when set; otherwise the themed default.
+        val selectedColor = AllAppsTabColors.selectedBackground(context, scheme, uiColorMode)
 
         selected?.setTint(selectedColor)
 


### PR DESCRIPTION
### Description

Selected Personal/Work tab text always used an inverse color token, which looks wrong on custom (especially dark/grey) tab backgrounds. Choose light or dark selected-tab text from the tab background luminance so the label stays readable with the existing tab color preference, without adding a separate text-color setting.

### Testing

1. Open the app drawer with Personal/Work tabs.
2. Set a dark or grey work profile tab background in App drawer settings — selected tab text should be light.
3. Set a light tab background — selected tab text should be dark.
4. Reset to the default tab color and confirm selected text is still readable.
5. Confirm unselected tab text is unchanged.

### Type of change

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
:white_check_mark: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added adaptive colors for selected Personal and Work app drawer tabs.
  * Selected tab text now automatically adjusts for readable contrast against its background.

* **Bug Fixes**
  * Improved handling of customized Work profile tab backgrounds, with a consistent fallback when no custom color is set.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->