### PR TITLE
fix: Respect folder color preference in spring folder animations

### DIFF
--- a/lawnchair/src/app/lawnchair/ui/preferences/components/colorpreference/ColorSelectionPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/colorpreference/ColorSelectionPreference.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import app.lawnchair.preferences.getAdapter
 import app.lawnchair.theme.color.ColorOption
+import app.lawnchair.ui.preferences.LocalNavController
 import app.lawnchair.ui.preferences.components.colorpreference.pickers.CustomColorPicker
 import app.lawnchair.ui.preferences.components.colorpreference.pickers.PresetsList
 import app.lawnchair.ui.preferences.components.colorpreference.pickers.SwatchGrid
@@ -48,6 +49,7 @@ fun ColorSelection(
     val adapter = preference.getAdapter()
     val appliedColor = adapter.state.value
     val context = LocalContext.current
+    val navController = LocalNavController.current
     val selectedColor = remember { mutableIntStateOf(appliedColor.forCustomPicker(context)) }
     val selectedColorApplied = remember {
         derivedStateOf {
@@ -83,7 +85,10 @@ fun ColorSelection(
             ) {
                 Button(
                     enabled = !selectedColorApplied.value,
-                    onClick = { adapter.onChange(newValue = ColorOption.CustomColor(selectedColor.intValue)) },
+                    onClick = {
+                        adapter.onChange(newValue = ColorOption.CustomColor(selectedColor.intValue))
+                        navController.popBackStack()
+                    },
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(all = 16.dp),

--- a/lawnchair/src/app/lawnchair/util/LawnchairUtils.kt
+++ b/lawnchair/src/app/lawnchair/util/LawnchairUtils.kt
@@ -186,6 +186,40 @@ fun getFolderBackgroundAlpha(context: Context): Int {
     return (prefs2.folderBackgroundOpacity.firstCached() * 255).toInt()
 }
 
+/**
+ * Custom folder color from preferences, or `0` when the theme default should be used.
+ *
+ * Note: pure black (`#FF000000`) is a valid custom color and is not treated as default.
+ */
+fun getCustomFolderColor(context: Context): Int {
+    val prefs2 = PreferenceManager2.getInstance(context)
+    return prefs2.folderColor.firstCached().colorPreferenceEntry.lightColor(context)
+}
+
+/** Closed-folder preview circle color (includes preview opacity). */
+fun resolveFolderPreviewColor(context: Context): Int {
+    val custom = getCustomFolderColor(context)
+    val base = if (custom != 0) {
+        custom
+    } else {
+        ColorTokens.FolderPreviewColor.resolveColor(context)
+    }
+    return ColorUtils.setAlphaComponent(base, getFolderPreviewAlpha(context))
+}
+
+/**
+ * Open-folder background fill color.
+ * Opacity is applied separately via [getFolderBackgroundAlpha] on the drawable.
+ */
+fun resolveFolderBackgroundColor(context: Context): Int {
+    val custom = getCustomFolderColor(context)
+    return if (custom != 0) {
+        custom
+    } else {
+        ColorTokens.FolderBackgroundColor.resolveColor(context)
+    }
+}
+
 /** Apply Lawnchair custom allapps colour to the provided colour */
 private fun getAllAppsBaseColor(context: Context, defaultColor: Int): Int {
     val prefs2 = PreferenceManager2.getInstance(context)

--- a/src/com/android/launcher3/folder/Folder.java
+++ b/src/com/android/launcher3/folder/Folder.java
@@ -337,6 +337,7 @@ public class Folder extends AbstractFloatingView implements ClipPathView, DragSo
         final int paddingLeftRight = dp.folderContentPaddingLeftRight;
 
         mBackground = DrawableTokens.RoundRectFolder.resolve(getContext());
+        mBackground.setColor(LawnchairUtilsKt.resolveFolderBackgroundColor(getContext()));
         var alpha = LawnchairUtilsKt.getFolderBackgroundAlpha(getContext());
         mBackground.setAlpha(alpha);
 

--- a/src/com/android/launcher3/folder/Folder.java
+++ b/src/com/android/launcher3/folder/Folder.java
@@ -1092,12 +1092,15 @@ public class Folder extends AbstractFloatingView implements ClipPathView, DragSo
         mActivityContext.getDragController().removeDropTarget(this);
         clearFocus();
         if (mFolderIcon != null) {
+            // Settle first-page preview before revealing the icon to avoid a rearrange flash.
+            if (wasAnimated) {
+                mFolderIcon.onFolderClose(mContent.getCurrentPage());
+            }
             mFolderIcon.setVisibility(View.VISIBLE);
             mFolderIcon.setIconVisible(true);
             mFolderIcon.mFolderName.setTextVisibility(true);
             if (wasAnimated) {
                 mFolderIcon.animateBgShadowAndStroke();
-                mFolderIcon.onFolderClose(mContent.getCurrentPage());
                 if (mFolderIcon.hasDot()) {
                     mFolderIcon.animateDotScale(0f, 1f);
                 }

--- a/src/com/android/launcher3/folder/FolderAnimationManager.java
+++ b/src/com/android/launcher3/folder/FolderAnimationManager.java
@@ -50,15 +50,10 @@ import com.android.launcher3.apppairs.AppPairIcon;
 import com.android.launcher3.celllayout.CellLayoutLayoutParams;
 import com.android.launcher3.graphics.ShapeDelegate;
 import com.android.launcher3.graphics.ThemeManager;
-import com.android.launcher3.util.Themes;
 import com.android.launcher3.views.BaseDragLayer;
-import com.androidinternal.graphics.ColorUtils;
-import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 
 import java.util.List;
 
-import app.lawnchair.theme.color.ColorOption;
-import app.lawnchair.theme.color.tokens.ColorTokens;
 import app.lawnchair.util.LawnchairUtilsKt;
 
 /**
@@ -192,18 +187,9 @@ public class FolderAnimationManager implements FolderAnimationCreator {
         final float xDistance = initialX - lp.x;
         final float yDistance = initialY - lp.y;
 
-        // Set up the Folder background.
-        int previewColor = ColorTokens.FolderPreviewColor.resolveColor(mContext);
-        int initialColor = ColorUtils.setAlphaComponent(previewColor, LawnchairUtilsKt.getFolderPreviewAlpha(mContext));
-        int finalColor = ColorTokens.FolderBackgroundColor.resolveColor(mContext);
-
-        ColorOption colorOption = PreferenceCacheExtensionsKt.firstCached(mFolder.preferenceManager2.getFolderColor(), mFolder.preferenceManager2);
-        int folderColor = colorOption.getColorPreferenceEntry().getLightColor().invoke(mContext);
-
-        if (folderColor != 0) {
-            initialColor = folderColor;
-            finalColor = folderColor;
-        }
+        // Set up the Folder background (respects Lawnchair folder color pref).
+        int initialColor = LawnchairUtilsKt.resolveFolderPreviewColor(mContext);
+        int finalColor = LawnchairUtilsKt.resolveFolderBackgroundColor(mContext);
 
         mFolderBackground.mutate();
         mFolderBackground.setColor(mIsOpening ? initialColor : finalColor);

--- a/src/com/android/launcher3/folder/FolderSpringAnimatorSet.kt
+++ b/src/com/android/launcher3/folder/FolderSpringAnimatorSet.kt
@@ -33,12 +33,10 @@ import com.android.launcher3.BubbleTextView
 import com.android.launcher3.LauncherAnimUtils
 import com.android.launcher3.LauncherAnimUtils.SCALE_PROPERTY
 import com.android.launcher3.LauncherState
-import com.android.launcher3.R
 import com.android.launcher3.Utilities.isDarkTheme
 import com.android.launcher3.anim.SpringAnimationBuilder
 import com.android.launcher3.apppairs.AppPairIcon
 import com.android.launcher3.folder.ClippedFolderIconLayoutRule.MAX_NUM_ITEMS_IN_PREVIEW
-import com.android.launcher3.util.Themes
 
 /** Holder for Animators created from [FolderAnimationSpringBuilderManager] */
 class FolderSpringAnimatorSet(val animatorSet: AnimatorSet) {
@@ -233,10 +231,10 @@ class FolderSpringAnimatorSet(val animatorSet: AnimatorSet) {
         ) {
             with(folder) {
                 val folderBackground = folder.background as GradientDrawable
-                // Set up the Folder background.
+                // Set up the Folder background (respects Lawnchair folder color pref).
                 val isOpening = animationData.isOpening
-                val initialColor = Themes.getAttrColor(context, R.attr.folderPreviewColor)
-                val finalColor = Themes.getAttrColor(context, R.attr.folderBackgroundColor)
+                val initialColor = app.lawnchair.util.resolveFolderPreviewColor(context)
+                val finalColor = app.lawnchair.util.resolveFolderBackgroundColor(context)
                 folderBackground.mutate()
                 folderBackground.setColor(if (isOpening) initialColor else finalColor)
                 // TODO: convert to spring animation?

--- a/src/com/android/launcher3/folder/PreviewBackground.java
+++ b/src/com/android/launcher3/folder/PreviewBackground.java
@@ -45,8 +45,6 @@ import android.view.animation.Interpolator;
 
 import androidx.annotation.VisibleForTesting;
 
-import androidx.core.graphics.ColorUtils;
-
 import com.android.launcher3.CellLayout;
 import com.android.launcher3.DeviceProfile;
 import com.android.launcher3.Flags;
@@ -191,20 +189,11 @@ public class PreviewBackground extends DelegatedCellDrawing {
 
         PreferenceManager2 preferenceManager2 = PreferenceManager2.INSTANCE.get(context);
 
-        // Load folder color
-        ColorOption colorOption = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getFolderColor());
-        int folderColor = colorOption.getColorPreferenceEntry().getLightColor().invoke(context);
-
         TypedArray ta = context.getTheme().obtainStyledAttributes(R.styleable.FolderIconPreview);
         ColorOption dotColorOption = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getNotificationDotColor());
         mDotColor = dotColorOption.getColorPreferenceEntry().getLightColor().invoke(context);
         mStrokeColor = ColorTokens.FolderIconBorderColor.resolveColor(context);
-        if (folderColor != 0) {
-            mBgColor = folderColor;
-        } else {
-            mBgColor = ColorTokens.FolderPreviewColor.resolveColor(context);
-        }
-        mBgColor = ColorUtils.setAlphaComponent(mBgColor, LawnchairUtilsKt.getFolderPreviewAlpha(context));
+        mBgColor = LawnchairUtilsKt.resolveFolderPreviewColor(context);
         ta.recycle();
 
         DeviceProfile grid = activity.getDeviceProfile();

--- a/src/com/android/launcher3/folder/PreviewItemManager.java
+++ b/src/com/android/launcher3/folder/PreviewItemManager.java
@@ -18,7 +18,6 @@ package com.android.launcher3.folder;
 
 import static com.android.launcher3.BubbleTextView.DISPLAY_FOLDER;
 import static com.android.launcher3.LauncherSettings.Favorites.DESKTOP_ICON_FLAG;
-import static com.android.launcher3.Utilities.dpToPx;
 import static com.android.launcher3.folder.ClippedFolderIconLayoutRule.ENTER_INDEX;
 import static com.android.launcher3.folder.ClippedFolderIconLayoutRule.EXIT_INDEX;
 import static com.android.launcher3.folder.ClippedFolderIconLayoutRule.MAX_NUM_ITEMS_IN_PREVIEW;
@@ -27,17 +26,12 @@ import static com.android.launcher3.graphics.PreloadIconDrawable.newPendingIcon;
 import static com.android.launcher3.icons.BitmapInfo.FLAG_THEMED;
 import static com.android.launcher3.model.data.ItemInfoWithIcon.FLAG_SHOW_DOWNLOAD_PROGRESS_MASK;
 
-import android.animation.Animator;
-import android.animation.AnimatorListenerAdapter;
-import android.animation.ObjectAnimator;
-import android.animation.ValueAnimator;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Path;
 import android.graphics.PointF;
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
-import android.util.FloatProperty;
 import android.util.Log;
 import android.view.View;
 
@@ -70,20 +64,6 @@ import app.lawnchair.preferences.PreferenceManager;
  */
 public class PreviewItemManager {
 
-    private static final FloatProperty<PreviewItemManager> CURRENT_PAGE_ITEMS_TRANS_X = new FloatProperty<PreviewItemManager>(
-            "currentPageItemsTransX") {
-        @Override
-        public void setValue(PreviewItemManager manager, float v) {
-            manager.mCurrentPageItemsTransX = v;
-            manager.onParamsChanged();
-        }
-
-        @Override
-        public Float get(PreviewItemManager manager) {
-            return manager.mCurrentPageItemsTransX;
-        }
-    };
-
     private final Context mContext;
     private final FolderIcon mIcon;
     @VisibleForTesting
@@ -105,28 +85,14 @@ public class PreviewItemManager {
     // the first page.
     private ArrayList<PreviewItemDrawingParams> mCurrentPageParams = new ArrayList<>();
 
-    // We clip the preview items during the middle of the animation, so that it does
-    // not go outside
-    // of the visual shape. We stop clipping at this threshold, since the preview
-    // items ultimately
-    // do not get cropped in their resting state.
-    private final float mClipThreshold;
-    private float mCurrentPageItemsTransX = 0;
-    private boolean mShouldSlideInFirstPage;
-
     static final int INITIAL_ITEM_ANIMATION_DURATION = 350;
     private static final int FINAL_ITEM_ANIMATION_DURATION = 200;
-
-    private static final int SLIDE_IN_FIRST_PAGE_ANIMATION_DURATION_DELAY = 100;
-    private static final int SLIDE_IN_FIRST_PAGE_ANIMATION_DURATION = 300;
-    private static final int ITEM_SLIDE_IN_OUT_DISTANCE_PX = 200;
 
     public PreviewItemManager(FolderIcon icon) {
         mContext = icon.getContext();
         mIcon = icon;
         mIconSize = ActivityContext.lookupContext(
                 mContext).getDeviceProfile().folderChildIconSizePx;
-        mClipThreshold = dpToPx(1f);
     }
 
     /**
@@ -220,19 +186,8 @@ public class PreviewItemManager {
         // The items are drawn in coordinates relative to the preview offset
         PreviewBackground bg = mIcon.getFolderBackground();
         Path clipPath = bg.getClipPath();
-        float firstPageItemsTransX = 0;
-        if (mShouldSlideInFirstPage) {
-            PointF firstPageOffset = new PointF(bg.basePreviewOffsetX + mCurrentPageItemsTransX,
-                    bg.basePreviewOffsetY);
-            boolean shouldClip = mCurrentPageItemsTransX > mClipThreshold;
-            drawParams(canvas, mCurrentPageParams, firstPageOffset, shouldClip, clipPath);
-            firstPageItemsTransX = -ITEM_SLIDE_IN_OUT_DISTANCE_PX + mCurrentPageItemsTransX;
-        }
-
-        PointF firstPageOffset = new PointF(bg.basePreviewOffsetX + firstPageItemsTransX,
-                bg.basePreviewOffsetY);
-        boolean shouldClipFirstPage = firstPageItemsTransX < -mClipThreshold;
-        drawParams(canvas, mFirstPageParams, firstPageOffset, shouldClipFirstPage, clipPath);
+        PointF firstPageOffset = new PointF(bg.basePreviewOffsetX, bg.basePreviewOffsetY);
+        drawParams(canvas, mFirstPageParams, firstPageOffset, /* shouldClipPath */ false, clipPath);
         canvas.restoreToCount(saveCount);
     }
 
@@ -324,27 +279,13 @@ public class PreviewItemManager {
     }
 
     void onFolderClose(int currentPage) {
-        // If we are not closing on the first page, we animate the current page preview
-        // items
-        // out, and animate the first page preview items in.
-        mShouldSlideInFirstPage = currentPage != 0;
-        if (mShouldSlideInFirstPage) {
-            mCurrentPageItemsTransX = 0;
-            buildParamsForPage(currentPage, mCurrentPageParams, false);
-            onParamsChanged();
-
-            ValueAnimator slideAnimator = ObjectAnimator
-                    .ofFloat(this, CURRENT_PAGE_ITEMS_TRANS_X, 0, ITEM_SLIDE_IN_OUT_DISTANCE_PX);
-            slideAnimator.addListener(new AnimatorListenerAdapter() {
-                @Override
-                public void onAnimationEnd(Animator animation) {
-                    mCurrentPageParams.clear();
-                }
-            });
-            slideAnimator.setStartDelay(SLIDE_IN_FIRST_PAGE_ANIMATION_DURATION_DELAY);
-            slideAnimator.setDuration(SLIDE_IN_FIRST_PAGE_ANIMATION_DURATION);
-            slideAnimator.start();
+        // Snap back to the first-page preview immediately. The previous slide animation
+        // showed a solid preview background while icons rearranged for ~400ms after close.
+        mCurrentPageParams.clear();
+        if (currentPage != 0) {
+            updatePreviewItems(false);
         }
+        onParamsChanged();
     }
 
     void updatePreviewItems(boolean animate) {

--- a/src/com/android/launcher3/folder/PreviewItemManager.java
+++ b/src/com/android/launcher3/folder/PreviewItemManager.java
@@ -81,9 +81,6 @@ public class PreviewItemManager {
 
     // These hold the first page preview items
     private ArrayList<PreviewItemDrawingParams> mFirstPageParams = new ArrayList<>();
-    // These hold the current page preview items. It is empty if the current page is
-    // the first page.
-    private ArrayList<PreviewItemDrawingParams> mCurrentPageParams = new ArrayList<>();
 
     static final int INITIAL_ITEM_ANIMATION_DURATION = 350;
     private static final int FINAL_ITEM_ANIMATION_DURATION = 200;
@@ -281,7 +278,6 @@ public class PreviewItemManager {
     void onFolderClose(int currentPage) {
         // Snap back to the first-page preview immediately. The previous slide animation
         // showed a solid preview background while icons rearranged for ~400ms after close.
-        mCurrentPageParams.clear();
         if (currentPage != 0) {
             updatePreviewItems(false);
         }
@@ -297,13 +293,6 @@ public class PreviewItemManager {
     void updatePreviewItems(Predicate<ItemInfo> itemCheck) {
         boolean modified = false;
         for (PreviewItemDrawingParams param : mFirstPageParams) {
-            if (itemCheck.test(param.item)
-                    || (param.item instanceof AppPairInfo api && api.anyMatch(itemCheck))) {
-                setDrawable(param, param.item);
-                modified = true;
-            }
-        }
-        for (PreviewItemDrawingParams param : mCurrentPageParams) {
             if (itemCheck.test(param.item)
                     || (param.item instanceof AppPairInfo api && api.anyMatch(itemCheck))) {
                 setDrawable(param, param.item);


### PR DESCRIPTION
### Description

The Folders → icon background color preference was ignored during expressive/spring folder open and close animations, so open folders always used the theme charcoal background even after applying a custom color. This PR resolves preview and open-folder colors from that preference in both animation paths, applies it when the folder background is inflated, snaps the first-page preview before revealing the folder icon on close (instead of the post-close page slide), and pops back after Apply in the custom color picker.

### Reasoning

With expressive folder expansion enabled on 16-dev, open/close uses `FolderSpringAnimatorSet`, which only read theme attrs and never `folderColor`. The older animation path already respected the preference, so the setting appeared broken. The post-close preview slide also left a solid disc with rearranging icons for a few hundred milliseconds; snapping the first-page preview before showing the icon removes that flash without changing the normal gather animation.

### Testing

1. Set **Folders → Icon background color** to a custom color, tap **Apply** — picker returns to the previous screen.
2. Open a folder — background matches the chosen color.
3. Restart Lawnchair and open a folder again — custom color still applies.
4. Close a multi-page folder from page 2+ — icon shows the first-page preview without a lingering rearrange flash.
5. Open/close a folder — icons still gather into the preview normally (no clipping during close).

### Type of change

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
:white_check_mark:  **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:white_check_mark:  **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for custom folder colors across folder previews, backgrounds, and related animations.
  - Applying a custom color now automatically returns to the previous screen.

- **Bug Fixes**
  - Improved custom color handling, including treating pure black as a valid custom color.
  - Refined folder open/close visual sequencing to help prevent rearrange/flash artifacts.

- **Style**
  - Simplified folder preview rendering by removing the current-page slide/transition logic and snapping back to the first-page preview state on close.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->