### PR TITLE
perf: optimize loading times in app drawer folder screens

### DIFF
--- a/lawnchair/src/app/lawnchair/allapps/LawnchairAlphabeticalAppsList.kt
+++ b/lawnchair/src/app/lawnchair/allapps/LawnchairAlphabeticalAppsList.kt
@@ -6,6 +6,7 @@ import androidx.activity.ComponentActivity
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
+import app.lawnchair.data.folder.FolderEntry
 import app.lawnchair.data.folder.model.FolderOrderUtils
 import app.lawnchair.data.folder.model.FolderViewModel
 import app.lawnchair.launcher
@@ -22,6 +23,7 @@ import com.android.launcher3.allapps.WorkProfileManager
 import com.android.launcher3.model.data.AppInfo
 import com.android.launcher3.model.data.FolderInfo
 import com.android.launcher3.model.data.ItemInfo
+import com.android.launcher3.util.ComponentKey
 import com.android.launcher3.views.ActivityContext
 import com.patrykmichalik.opto.core.onEach
 import java.util.function.Predicate
@@ -44,10 +46,10 @@ class LawnchairAlphabeticalAppsList<T>(
     private val viewModel = FolderViewModel(
         (context as? ComponentActivity)?.application ?: context.launcher.application,
     )
-    private var folderList = mutableListOf<FolderInfo>()
+    private var folderList = mutableListOf<FolderEntry>()
     private val filteredList = mutableListOf<AppInfo>()
 
-    private val folderOrder = FolderOrderUtils.stringToIntList(prefs.drawerListOrder.get())
+    private val folderOrder get() = FolderOrderUtils.stringToIntList(prefs.drawerListOrder.get())
 
     init {
         context.launcher.deviceProfile.inv.addOnChangeListener(this)
@@ -111,19 +113,26 @@ class LawnchairAlphabeticalAppsList<T>(
                 position++
             }
         } else {
-            folderList.forEach { folder ->
-                if (folder.getContents().size > 1) {
+            folderList.forEach { folderEntry ->
+                if (folderEntry.itemComponentKeys.size > 1) {
                     val folderInfo = FolderInfo()
-                    folderInfo.title = folder.title
-                    mAdapterItems.add(AdapterItem.asFolder(folderInfo))
-                    folder.getContents().forEach { app ->
-                        (appsStore.getApp(app.componentKey) as? AppInfo)?.let {
-                            folderInfo.add(it)
-                            if (prefs.folderApps.get()) filteredList.add(it)
+                    folderInfo.title = folderEntry.title
+                    folderEntry.itemComponentKeys.forEach { keyString ->
+                        val componentKey = ComponentKey.fromString(keyString)
+                        if (componentKey != null) {
+                            (appsStore.getApp(componentKey) as? AppInfo)?.let { appInfo ->
+                                folderInfo.add(appInfo)
+                                if (prefs.folderApps.get()) {
+                                    filteredList.add(appInfo)
+                                }
+                            }
                         }
                     }
+                    if (folderInfo.getContents().size > 1) {
+                        mAdapterItems.add(AdapterItem.asFolder(folderInfo))
+                        position++
+                    }
                 }
-                position++
             }
             val remainingApps = appList.filterNot { app -> filteredList.contains(app) && prefs.folderApps.get() }
             position = super.addAppsWithSections(remainingApps, position)

--- a/lawnchair/src/app/lawnchair/allapps/LawnchairAlphabeticalAppsList.kt
+++ b/lawnchair/src/app/lawnchair/allapps/LawnchairAlphabeticalAppsList.kt
@@ -73,7 +73,10 @@ class LawnchairAlphabeticalAppsList<T>(
         viewModel.folders.observeOnce(context as LifecycleOwner) { folders ->
             if (folders != null) {
                 folderList = folders
-                    .sortedBy { folderOrder.indexOf(it.id) }
+                    .sortedBy {
+                        val index = folderOrder.indexOf(it.id)
+                        if (index == -1) Int.MAX_VALUE else index
+                    }
                     .toMutableList()
                 updateAdapterItems()
             }
@@ -116,23 +119,21 @@ class LawnchairAlphabeticalAppsList<T>(
             }
         } else {
             folderList.forEach { folderEntry ->
-                if (folderEntry.itemComponentKeys.size > 1) {
-                    val folderInfo = FolderInfo()
-                    folderInfo.title = folderEntry.title
-                    folderEntry.itemComponentKeys.forEach { keyString ->
-                        val componentKey = ComponentKey.fromString(keyString)
-                        if (componentKey != null) {
-                            (appsStore.getApp(componentKey) as? AppInfo)?.let { appInfo ->
-                                folderInfo.add(appInfo)
-                                if (prefs.folderApps.get()) {
-                                    filteredList.add(appInfo)
-                                }
-                            }
-                        }
+                val resolvedApps = folderEntry.itemComponentKeys.mapNotNull { keyString ->
+                    val componentKey = ComponentKey.fromString(keyString) ?: return@mapNotNull null
+                    appsStore.getApp(componentKey) as? AppInfo
+                }
+
+                if (resolvedApps.size > 1) {
+                    val folderInfo = FolderInfo().apply {
+                        title = folderEntry.title
+                        resolvedApps.forEach { add(it) }
                     }
-                    if (folderInfo.getContents().size > 1) {
-                        mAdapterItems.add(AdapterItem.asFolder(folderInfo))
-                        position++
+                    mAdapterItems.add(AdapterItem.asFolder(folderInfo))
+                    position++
+
+                    if (prefs.folderApps.get()) {
+                        filteredList.addAll(resolvedApps)
                     }
                 }
             }

--- a/lawnchair/src/app/lawnchair/allapps/LawnchairAlphabeticalAppsList.kt
+++ b/lawnchair/src/app/lawnchair/allapps/LawnchairAlphabeticalAppsList.kt
@@ -71,10 +71,12 @@ class LawnchairAlphabeticalAppsList<T>(
 
     private fun observeFolders() {
         viewModel.folders.observeOnce(context as LifecycleOwner) { folders ->
-            folderList = folders
-                .sortedBy { folderOrder.indexOf(it.id) }
-                .toMutableList()
-            updateAdapterItems()
+            if (folders != null) {
+                folderList = folders
+                    .sortedBy { folderOrder.indexOf(it.id) }
+                    .toMutableList()
+                updateAdapterItems()
+            }
         }
     }
 

--- a/lawnchair/src/app/lawnchair/data/folder/FolderEntity.kt
+++ b/lawnchair/src/app/lawnchair/data/folder/FolderEntity.kt
@@ -1,5 +1,6 @@
 ﻿package app.lawnchair.data.folder
 
+import androidx.compose.runtime.Immutable
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.ForeignKey
@@ -36,6 +37,7 @@ data class FolderItemEntity(
     val timestamp: Long = System.currentTimeMillis(),
 )
 
+@Immutable
 data class FolderEntry(
     val id: Int,
     val title: String,

--- a/lawnchair/src/app/lawnchair/data/folder/FolderEntity.kt
+++ b/lawnchair/src/app/lawnchair/data/folder/FolderEntity.kt
@@ -35,3 +35,10 @@ data class FolderItemEntity(
     @ColumnInfo(name = "item_info") val componentKey: String?,
     val timestamp: Long = System.currentTimeMillis(),
 )
+
+data class FolderEntry(
+    val id: Int,
+    val title: String,
+    val hide: Boolean = false,
+    val itemComponentKeys: List<String> = emptyList(),
+)

--- a/lawnchair/src/app/lawnchair/data/folder/model/FolderViewModel.kt
+++ b/lawnchair/src/app/lawnchair/data/folder/model/FolderViewModel.kt
@@ -4,13 +4,13 @@ import android.app.Application
 import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import app.lawnchair.data.folder.FolderEntry
 import app.lawnchair.data.folder.service.FolderService
 import app.lawnchair.preferences2.ReloadHelper
-import com.android.launcher3.model.data.AppInfo
-import com.android.launcher3.model.data.FolderInfo
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.stateIn
@@ -21,7 +21,7 @@ class FolderViewModel(
 ) : AndroidViewModel(application) {
     private val repository: FolderService = FolderService.INSTANCE.get(application)
 
-    val folders: StateFlow<List<FolderInfo>> = repository.getFoldersFlow()
+    val folders: StateFlow<List<FolderEntry>> = repository.getFoldersFlow()
         .distinctUntilChanged()
         .catch { exception ->
             Log.e("FolderViewModel", "Error in folders flow", exception)
@@ -33,39 +33,35 @@ class FolderViewModel(
             initialValue = emptyList(),
         )
 
-    val folderInfo: StateFlow<FolderInfo?>
-        field = MutableStateFlow<FolderInfo?>(null)
+    private val _folderEntry = MutableStateFlow<FolderEntry?>(null)
+    val folderEntry: StateFlow<FolderEntry?> = _folderEntry.asStateFlow()
 
     private val reloadHelper = ReloadHelper(application)
 
-    // yeah these should be separate UI actions
-    fun setFolderInfo(folderInfoId: Int, hasId: Boolean) {
+    fun setFolderEntry(folderId: Int) {
         viewModelScope.launch {
-            folderInfo.value = repository.getFolderInfo(folderInfoId, hasId)
+            _folderEntry.value = repository.getFolderEntry(folderId)
         }
     }
 
-    fun renameFolder(folderInfo: FolderInfo, hide: Boolean) {
+    fun renameFolder(folderId: Int, title: String, hide: Boolean = false) {
         viewModelScope.launch {
-            repository.updateFolderInfo(folderInfo, hide)
+            repository.updateFolderInfo(folderId, title, hide)
         }
         reloadHelper.reloadGrid()
     }
 
-    fun updateFolderItems(id: Int, title: String, appInfo: List<AppInfo>) {
+    fun updateFolderItems(id: Int, title: String, componentKeys: List<String>) {
         viewModelScope.launch {
-            repository.updateFolderWithItems(id, title, appInfo)
-            // Update the local state flow so UI can observe changes without full reload if needed,
-            // though for now we just rely on reloadGrid to refresh the launcher.
-            // We call reloadGrid *after* the DB update is complete.
-            folderInfo.value = repository.getFolderInfo(id, true)
+            repository.updateFolderWithItems(id, title, componentKeys)
+            _folderEntry.value = repository.getFolderEntry(id)
             reloadHelper.reloadGrid()
         }
     }
 
-    fun createFolder(folderInfo: FolderInfo) {
+    fun createFolder(title: String) {
         viewModelScope.launch {
-            repository.saveFolderInfo(folderInfo)
+            repository.saveFolderInfo(title)
         }
     }
 

--- a/lawnchair/src/app/lawnchair/data/folder/model/FolderViewModel.kt
+++ b/lawnchair/src/app/lawnchair/data/folder/model/FolderViewModel.kt
@@ -7,12 +7,12 @@ import androidx.lifecycle.viewModelScope
 import app.lawnchair.data.folder.FolderEntry
 import app.lawnchair.data.folder.service.FolderService
 import app.lawnchair.preferences2.ReloadHelper
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
@@ -33,15 +33,22 @@ class FolderViewModel(
             initialValue = null,
         )
 
-    private val _folderEntry = MutableStateFlow<FolderEntry?>(null)
-    val folderEntry: StateFlow<FolderEntry?> = _folderEntry.asStateFlow()
+    val allFolderPackages: StateFlow<Set<String>?> = folders
+        .map { folderList ->
+            folderList?.flatMap { folder -> folder.itemComponentKeys }
+                ?.map { key -> key.substringBefore("/") }
+                ?.toSet()
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = null,
+        )
 
     private val reloadHelper = ReloadHelper(application)
 
-    fun setFolderEntry(folderId: Int) {
-        viewModelScope.launch {
-            _folderEntry.value = repository.getFolderEntry(folderId)
-        }
+    fun getFolderFlowForId(folderId: Int): Flow<FolderEntry?> {
+        return folders.map { list -> list?.find { it.id == folderId } }
     }
 
     fun renameFolder(folderId: Int, title: String, hide: Boolean = false) {
@@ -54,7 +61,6 @@ class FolderViewModel(
     fun updateFolderItems(id: Int, title: String, componentKeys: List<String>) {
         viewModelScope.launch {
             repository.updateFolderWithItems(id, title, componentKeys)
-            _folderEntry.value = repository.getFolderEntry(id)
             reloadHelper.reloadGrid()
         }
     }

--- a/lawnchair/src/app/lawnchair/data/folder/model/FolderViewModel.kt
+++ b/lawnchair/src/app/lawnchair/data/folder/model/FolderViewModel.kt
@@ -21,7 +21,7 @@ class FolderViewModel(
 ) : AndroidViewModel(application) {
     private val repository: FolderService = FolderService.INSTANCE.get(application)
 
-    val folders: StateFlow<List<FolderEntry>> = repository.getFoldersFlow()
+    val folders: StateFlow<List<FolderEntry>?> = repository.getFoldersFlow()
         .distinctUntilChanged()
         .catch { exception ->
             Log.e("FolderViewModel", "Error in folders flow", exception)
@@ -30,7 +30,7 @@ class FolderViewModel(
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5000),
-            initialValue = emptyList(),
+            initialValue = null,
         )
 
     private val _folderEntry = MutableStateFlow<FolderEntry?>(null)

--- a/lawnchair/src/app/lawnchair/data/folder/model/FolderViewModel.kt
+++ b/lawnchair/src/app/lawnchair/data/folder/model/FolderViewModel.kt
@@ -51,11 +51,11 @@ class FolderViewModel(
         return folders.map { list -> list?.find { it.id == folderId } }
     }
 
-    fun renameFolder(folderId: Int, title: String, hide: Boolean = false) {
+    fun renameFolder(folderId: Int, title: String) {
         viewModelScope.launch {
-            repository.updateFolderInfo(folderId, title, hide)
+            repository.renameFolderInfo(folderId, title)
+            reloadHelper.reloadGrid()
         }
-        reloadHelper.reloadGrid()
     }
 
     fun updateFolderItems(id: Int, title: String, componentKeys: List<String>) {

--- a/lawnchair/src/app/lawnchair/data/folder/service/FolderDao.kt
+++ b/lawnchair/src/app/lawnchair/data/folder/service/FolderDao.kt
@@ -16,41 +16,37 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface FolderDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insertFolder(folder: FolderInfoEntity)
+    suspend fun insertFolder(folder: FolderInfoEntity): Long
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertFolderItems(items: List<FolderItemEntity>)
 
-    @Query("SELECT * FROM Folders WHERE id = :folderId")
-    @Transaction
-    suspend fun getFolderWithItems(folderId: Int): FolderWithItems?
-
-    @Query("SELECT * FROM FolderItems WHERE folderId IS NOT :folderId")
-    @Transaction
-    suspend fun getItems(folderId: Int): List<FolderItemEntity>
-
     @Query("SELECT * FROM Folders")
-    fun getAllFolders(): Flow<List<FolderInfoEntity>>
-
     @Transaction
-    suspend fun insertFolderWithItems(folder: FolderInfoEntity, items: List<FolderItemEntity>) {
-        insertFolder(folder)
-        insertFolderItems(items)
-    }
+    fun getAllFoldersWithItems(): Flow<List<FolderWithItems>>
 
     @Query("DELETE FROM FolderItems WHERE folderId = :folderId")
     suspend fun deleteFolderItemsByFolderId(folderId: Int)
 
+    @Query("UPDATE Folders SET title = :title, timestamp = :timestamp WHERE id = :id")
+    suspend fun updateFolderTitle(id: Int, title: String, timestamp: Long = System.currentTimeMillis())
+
+    @Transaction
+    suspend fun replaceFolderItems(folderId: Int, title: String, items: List<FolderItemEntity>) {
+        updateFolderTitle(folderId, title)
+        deleteFolderItemsByFolderId(folderId)
+        insertFolderItems(items.map { it.copy(folderId = folderId) })
+    }
+
     @Query(
         value = """
                 UPDATE Folders
-                SET title = :newTitle, hide = :hide, timestamp = :timestamp
+                SET hide = :hide, timestamp = :timestamp
                 WHERE id = :folderId
             """,
     )
-    suspend fun updateFolderInfo(
+    suspend fun setFolderHidden(
         folderId: Int,
-        newTitle: String,
         hide: Boolean,
         timestamp: Long = System.currentTimeMillis(),
     )

--- a/lawnchair/src/app/lawnchair/data/folder/service/FolderService.kt
+++ b/lawnchair/src/app/lawnchair/data/folder/service/FolderService.kt
@@ -13,7 +13,6 @@ import com.android.launcher3.util.SafeCloseable
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 
@@ -25,58 +24,42 @@ class FolderService @Inject constructor(
     private val folderDao = AppDatabase.INSTANCE.get(context).folderDao()
 
     fun getFoldersFlow(): Flow<List<FolderEntry>> {
-        return folderDao.getAllFolders().map { folderEntities ->
-            folderEntities.mapNotNull { folderEntity ->
-                getFolderEntry(folderEntity.id)
-            }
+        return folderDao.getAllFoldersWithItems().map { list ->
+            list.map { it.toFolderEntry() }
         }
     }
 
     suspend fun updateFolderWithItems(folderInfoId: Int, title: String, componentKeys: List<String>) = withContext(Dispatchers.IO) {
-        folderDao.deleteFolderItemsByFolderId(folderInfoId)
-        folderDao.insertFolderWithItems(
-            FolderInfoEntity(id = folderInfoId, title = title),
-            componentKeys.mapIndexed { index, componentKey ->
-                FolderItemEntity(
-                    folderId = folderInfoId,
-                    rank = index,
-                    componentKey = componentKey,
-                )
-            },
-        )
+        val items = componentKeys.mapIndexed { index, componentKey ->
+            FolderItemEntity(
+                folderId = folderInfoId,
+                rank = index,
+                componentKey = componentKey,
+            )
+        }
+        folderDao.replaceFolderItems(folderInfoId, title, items)
     }
 
     suspend fun saveFolderInfo(title: String) = withContext(Dispatchers.IO) {
         folderDao.insertFolder(FolderInfoEntity(title = title))
     }
 
-    suspend fun updateFolderInfo(folderId: Int, title: String, hide: Boolean = false) = withContext(Dispatchers.IO) {
-        folderDao.updateFolderInfo(folderId, title, hide)
+    suspend fun renameFolderInfo(folderId: Int, title: String) = withContext(Dispatchers.IO) {
+        folderDao.updateFolderTitle(folderId, title)
     }
 
     suspend fun deleteFolderInfo(id: Int) = withContext(Dispatchers.IO) {
         folderDao.deleteFolder(id)
     }
 
-    suspend fun getFolderEntry(folderId: Int): FolderEntry? = withContext(Dispatchers.IO) {
-        folderDao.getFolderWithItems(folderId)?.let { folderWithItems ->
-            FolderEntry(
-                id = folderWithItems.folder.id,
-                title = folderWithItems.folder.title,
-                hide = folderWithItems.folder.hide,
-                itemComponentKeys = folderWithItems.items
-                    .sortedBy { it.rank }
-                    .mapNotNull { it.componentKey },
-            )
-        }
-    }
-
-    suspend fun getAllFolders(): List<FolderEntry> = withContext(Dispatchers.IO) {
-        val folderEntities = folderDao.getAllFolders().firstOrNull() ?: emptyList()
-        folderEntities.mapNotNull { folderEntity ->
-            getFolderEntry(folderEntity.id)
-        }
-    }
+    private fun FolderWithItems.toFolderEntry() = FolderEntry(
+        id = folder.id,
+        title = folder.title,
+        hide = folder.hide,
+        itemComponentKeys = items
+            .sortedBy { it.rank }
+            .mapNotNull { it.componentKey },
+    )
 
     override fun close() {
     }

--- a/lawnchair/src/app/lawnchair/data/folder/service/FolderService.kt
+++ b/lawnchair/src/app/lawnchair/data/folder/service/FolderService.kt
@@ -1,19 +1,13 @@
 ﻿package app.lawnchair.data.folder.service
 
 import android.content.Context
-import android.content.pm.LauncherApps
-import android.util.Log
 import app.lawnchair.data.AppDatabase
-import app.lawnchair.data.Converters
+import app.lawnchair.data.folder.FolderEntry
 import app.lawnchair.data.folder.FolderInfoEntity
-import app.lawnchair.data.toEntity
-import com.android.launcher3.AppFilter
+import app.lawnchair.data.folder.FolderItemEntity
 import com.android.launcher3.dagger.ApplicationContext
 import com.android.launcher3.dagger.LauncherAppComponent
 import com.android.launcher3.dagger.LauncherAppSingleton
-import com.android.launcher3.model.data.AppInfo
-import com.android.launcher3.model.data.FolderInfo
-import com.android.launcher3.pm.UserCache
 import com.android.launcher3.util.DaggerSingletonObject
 import com.android.launcher3.util.SafeCloseable
 import javax.inject.Inject
@@ -29,94 +23,62 @@ class FolderService @Inject constructor(
 ) : SafeCloseable {
 
     private val folderDao = AppDatabase.INSTANCE.get(context).folderDao()
-    private val launcherApps = context.getSystemService(LauncherApps::class.java)
-    private val userCache = UserCache.INSTANCE.get(context)
-    private val appFilter = AppFilter(context)
-    private val converters = Converters()
 
-    fun getFoldersFlow(): Flow<List<FolderInfo>> {
+    fun getFoldersFlow(): Flow<List<FolderEntry>> {
         return folderDao.getAllFolders().map { folderEntities ->
             folderEntities.mapNotNull { folderEntity ->
-                getFolderInfo(folderEntity.id, true)
+                getFolderEntry(folderEntity.id)
             }
         }
     }
 
-    suspend fun updateFolderWithItems(folderInfoId: Int, title: String, appInfos: List<AppInfo>) = withContext(Dispatchers.IO) {
+    suspend fun updateFolderWithItems(folderInfoId: Int, title: String, componentKeys: List<String>) = withContext(Dispatchers.IO) {
+        folderDao.deleteFolderItemsByFolderId(folderInfoId)
         folderDao.insertFolderWithItems(
             FolderInfoEntity(id = folderInfoId, title = title),
-            appInfos.mapIndexed { index, appInfo ->
-                appInfo.toEntity(folderInfoId).copy(rank = index)
-            }.toList(),
+            componentKeys.mapIndexed { index, componentKey ->
+                FolderItemEntity(
+                    folderId = folderInfoId,
+                    rank = index,
+                    componentKey = componentKey,
+                )
+            },
         )
     }
 
-    suspend fun saveFolderInfo(folderInfo: FolderInfo) = withContext(Dispatchers.IO) {
-        folderDao.insertFolder(FolderInfoEntity(title = folderInfo.title.toString()))
+    suspend fun saveFolderInfo(title: String) = withContext(Dispatchers.IO) {
+        folderDao.insertFolder(FolderInfoEntity(title = title))
     }
 
-    suspend fun updateFolderInfo(folderInfo: FolderInfo, hide: Boolean = false) = withContext(Dispatchers.IO) {
-        folderDao.updateFolderInfo(folderInfo.id, folderInfo.title.toString(), hide)
+    suspend fun updateFolderInfo(folderId: Int, title: String, hide: Boolean = false) = withContext(Dispatchers.IO) {
+        folderDao.updateFolderInfo(folderId, title, hide)
     }
 
     suspend fun deleteFolderInfo(id: Int) = withContext(Dispatchers.IO) {
         folderDao.deleteFolder(id)
     }
 
-    suspend fun getFolderInfo(folderId: Int, hasId: Boolean = false): FolderInfo? = withContext(Dispatchers.Default) {
-        folderDao.getFolderWithItems(folderId)?.let {
-            mapToFolderInfo(it, hasId)
+    suspend fun getFolderEntry(folderId: Int): FolderEntry? = withContext(Dispatchers.IO) {
+        folderDao.getFolderWithItems(folderId)?.let { folderWithItems ->
+            FolderEntry(
+                id = folderWithItems.folder.id,
+                title = folderWithItems.folder.title,
+                hide = folderWithItems.folder.hide,
+                itemComponentKeys = folderWithItems.items
+                    .sortedBy { it.rank }
+                    .mapNotNull { it.componentKey },
+            )
         }
     }
 
-    private fun mapToFolderInfo(folderWithItems: FolderWithItems, hasId: Boolean): FolderInfo? {
-        return try {
-            val domainFolderInfo = FolderInfo().apply {
-                // if no id, launcher automatically creates an id for this
-                if (hasId) id = folderWithItems.folder.id
-                title = folderWithItems.folder.title
-            }
-
-            folderWithItems.items.sortedBy { it.rank }.forEach { itemEntity ->
-                // Consider caching toItemInfo results if componentKey lookups are slow
-                // and items don't change frequently without folder data changing
-                toItemInfo(itemEntity.componentKey)?.let { appInfo ->
-                    domainFolderInfo.add(appInfo)
-                }
-            }
-            domainFolderInfo
-        } catch (e: Exception) {
-            Log.e("FolderService", "Failed to map FolderWithItems for id: ${folderWithItems.folder.id}", e)
-            null
-        }
-    }
-
-    private fun toItemInfo(componentKey: String?): AppInfo? {
-        if (launcherApps != null) {
-            return userCache.userProfiles.asSequence()
-                .flatMap { launcherApps.getActivityList(null, it) }
-                .filter { appFilter.shouldShowApp(it.componentName) }
-                .map { AppInfo(context, it, it.user) }
-                .filter { converters.fromComponentKey(it.componentKey) == componentKey }
-                .firstOrNull()
-        }
-        return null
-    }
-
-    suspend fun getAllFolders(): List<FolderInfo> = withContext(Dispatchers.Main) {
-        try {
-            val folderEntities = folderDao.getAllFolders().firstOrNull() ?: emptyList()
-            folderEntities.mapNotNull { folderEntity ->
-                getFolderInfo(folderEntity.id, true)
-            }
-        } catch (e: Exception) {
-            Log.e("FolderService", "Failed to get all folders", e)
-            emptyList()
+    suspend fun getAllFolders(): List<FolderEntry> = withContext(Dispatchers.IO) {
+        val folderEntities = folderDao.getAllFolders().firstOrNull() ?: emptyList()
+        folderEntities.mapNotNull { folderEntity ->
+            getFolderEntry(folderEntity.id)
         }
     }
 
     override fun close() {
-        TODO("Not yet implemented")
     }
 
     companion object {

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/AppDrawerFoldersPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/AppDrawerFoldersPreference.kt
@@ -89,7 +89,6 @@ fun AppDrawerFoldersPreference(
             viewModel.createFolder(label)
         },
         onEditFolderItems = {
-            viewModel.setFolderEntry(it)
             navController.navigate(AppDrawerAppListToFolder(it))
         },
         onRenameFolder = { folderId, newTitle ->

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/AppDrawerFoldersPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/AppDrawerFoldersPreference.kt
@@ -29,12 +29,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import app.lawnchair.data.folder.FolderEntry
 import app.lawnchair.data.folder.model.FolderOrderUtils
 import app.lawnchair.data.folder.model.FolderViewModel
 import app.lawnchair.preferences.getAdapter
@@ -52,9 +53,7 @@ import app.lawnchair.ui.preferences.components.reorderable.ReorderablePreference
 import app.lawnchair.ui.preferences.navigation.AppDrawerAppListToFolder
 import app.lawnchair.ui.preferences.navigation.AppDrawerFolder
 import app.lawnchair.ui.util.bottomSheetHandler
-import app.lawnchair.util.appsState
 import com.android.launcher3.R
-import com.android.launcher3.model.data.FolderInfo
 
 @Composable
 fun AppDrawerFolderPreferenceItem(
@@ -86,21 +85,15 @@ fun AppDrawerFoldersPreference(
     AppDrawerFoldersPreference(
         modifier = modifier,
         folders = folders,
-        onCreateFolder = { folderInfo, label ->
-            val newInfo = folderInfo.apply {
-                title = label
-            }
-            viewModel.createFolder(newInfo)
+        onCreateFolder = { label ->
+            viewModel.createFolder(label)
         },
         onEditFolderItems = {
-            viewModel.setFolderInfo(it, false)
+            viewModel.setFolderEntry(it)
             navController.navigate(AppDrawerAppListToFolder(it))
         },
-        onRenameFolder = { folderInfo, it ->
-            folderInfo.apply {
-                title = it
-                viewModel.renameFolder(this, false)
-            }
+        onRenameFolder = { folderId, newTitle ->
+            viewModel.renameFolder(folderId, newTitle)
         },
         onDeleteFolder = {
             viewModel.deleteFolder(it.id)
@@ -111,11 +104,11 @@ fun AppDrawerFoldersPreference(
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun AppDrawerFoldersPreference(
-    folders: List<FolderInfo>,
-    onCreateFolder: (FolderInfo, String) -> Unit,
+    folders: List<FolderEntry>,
+    onCreateFolder: (String) -> Unit,
     onEditFolderItems: (Int) -> Unit,
-    onRenameFolder: (FolderInfo, String) -> Unit,
-    onDeleteFolder: (FolderInfo) -> Unit,
+    onRenameFolder: (Int, String) -> Unit,
+    onDeleteFolder: (FolderEntry) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val bottomSheetHandler = bottomSheetHandler
@@ -127,10 +120,10 @@ fun AppDrawerFoldersPreference(
     var sortedDisplayList = remember(folders, folderOrderString) {
         Log.d("AppDrawerFolders", "Recalculating sortedDisplayList. Folders count: ${folders.size}")
         folders.sortedWith(
-            compareBy { folderInfo ->
+            compareBy { folderEntry ->
                 val index = FolderOrderUtils
                     .stringToIntList(folderOrderString)
-                    .indexOf(folderInfo.id)
+                    .indexOf(folderEntry.id)
                 if (index == -1) {
                     // New items go to the end
                     Integer.MAX_VALUE
@@ -141,6 +134,7 @@ fun AppDrawerFoldersPreference(
         )
     }
 
+    // proxy for detecting if all apps have been loaded, todo change
     val apps by appsState()
 
     LoadingScreen(
@@ -174,10 +168,10 @@ fun AppDrawerFoldersPreference(
                     onClick = {
                         bottomSheetHandler.show {
                             FolderEditSheet(
-                                FolderInfo().apply {
-                                    title = stringResource(R.string.my_folder_label)
-                                },
-                                onRename = onCreateFolder,
+                                folderId = 0,
+                                initialTitle = stringResource(R.string.my_folder_label),
+                                itemCount = 0,
+                                onRename = { _, title -> onCreateFolder(title) },
                                 onNavigate = {},
                                 onDismiss = {
                                     bottomSheetHandler.hide()
@@ -192,24 +186,26 @@ fun AppDrawerFoldersPreference(
                 label = null,
                 items = sortedDisplayList,
                 defaultList = sortedDisplayList,
-                onOrderChange = { folders ->
-                    val newOrder = folders.map { it.id }
+                onOrderChange = { updatedFolders ->
+                    val newOrder = updatedFolders.map { it.id }
 
                     folderOrderAdapter.onChange(
                         FolderOrderUtils.intListToString(
                             newOrder,
                         ),
                     )
-                    sortedDisplayList = folders
+                    sortedDisplayList = updatedFolders
                 },
-            ) { folderInfo, _, _ ->
+            ) { folderEntry, _, _ ->
                 val interactionSource = remember { MutableInteractionSource() }
                 FolderItem(
-                    folderInfo = folderInfo,
+                    folderEntry = folderEntry,
                     onItemClick = {
                         bottomSheetHandler.show {
                             FolderEditSheet(
-                                folderInfo,
+                                folderId = folderEntry.id,
+                                initialTitle = folderEntry.title,
+                                itemCount = folderEntry.itemComponentKeys.size,
                                 onRename = onRenameFolder,
                                 onNavigate = {
                                     onEditFolderItems(it)
@@ -249,15 +245,17 @@ fun AppDrawerFoldersPreference(
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun FolderEditSheet(
-    folderInfo: FolderInfo,
-    onRename: (FolderInfo, String) -> Unit,
+    folderId: Int,
+    initialTitle: String,
+    itemCount: Int,
+    onRename: (Int, String) -> Unit,
     onNavigate: (Int) -> Unit,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
     hideAppPicker: Boolean = false,
 ) {
-    val resources = LocalContext.current.resources
-    var textFieldValue by remember { mutableStateOf(TextFieldValue(folderInfo.title.toString())) }
+    val resources = LocalResources.current
+    var textFieldValue by remember { mutableStateOf(TextFieldValue(initialTitle)) }
 
     ModalBottomSheetContent(
         buttons = {
@@ -270,7 +268,7 @@ fun FolderEditSheet(
             Spacer(Modifier.width(8.dp))
             Button(
                 onClick = {
-                    onRename(folderInfo, textFieldValue.text)
+                    onRename(folderId, textFieldValue.text)
                     onDismiss()
                 },
                 shapes = ButtonDefaults.shapes(),
@@ -298,14 +296,14 @@ fun FolderEditSheet(
                     label = "Manage apps",
                     subtitle = resources.getQuantityString(
                         R.plurals.apps_count,
-                        folderInfo.getContents().size,
-                        folderInfo.getContents().size,
+                        itemCount,
+                        itemCount,
                     ),
                     modifier = Modifier
                         .padding(horizontal = 8.dp),
                     colors = ListItemDefaults.colors(containerColor = Color.Transparent),
                 ) {
-                    onNavigate(folderInfo.id)
+                    onNavigate(folderId)
                 }
             }
         }
@@ -315,24 +313,28 @@ fun FolderEditSheet(
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun FolderItem(
-    folderInfo: FolderInfo,
-    onItemClick: (FolderInfo) -> Unit,
-    onItemDelete: (FolderInfo) -> Unit,
+    folderEntry: FolderEntry,
+    onItemClick: (FolderEntry) -> Unit,
+    onItemDelete: (FolderEntry) -> Unit,
     modifier: Modifier = Modifier,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     dragIndicator: @Composable () -> Unit,
 ) {
-    val resources = LocalContext.current.resources
+    val resources = LocalResources.current
     PreferenceTemplate(
         title = {
             Text(
-                text = folderInfo.title.toString(),
+                text = folderEntry.title,
             )
         },
         modifier = modifier,
         description = {
             Text(
-                text = resources.getQuantityString(R.plurals.apps_count, folderInfo.getContents().size, folderInfo.getContents().size),
+                text = resources.getQuantityString(
+                    R.plurals.apps_count,
+                    folderEntry.itemComponentKeys.size,
+                    folderEntry.itemComponentKeys.size,
+                ),
             )
         },
         startWidget = {
@@ -342,16 +344,21 @@ fun FolderItem(
             Row {
                 IconButton(
                     onClick = {
-                        onItemDelete(folderInfo)
+                        onItemDelete(folderEntry)
                     },
                     shapes = IconButtonDefaults.shapes(),
                 ) {
-                    Icon(Icons.Rounded.Delete, contentDescription = "Delete", tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Icon(
+                        Icons.Rounded.Delete,
+                        contentDescription = "Delete",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
                 }
             }
         },
         onClick = {
-            onItemClick(folderInfo)
+            onItemClick(folderEntry)
         },
+        interactionSource = interactionSource,
     )
 }

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/AppDrawerFoldersPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/AppDrawerFoldersPreference.kt
@@ -104,7 +104,7 @@ fun AppDrawerFoldersPreference(
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun AppDrawerFoldersPreference(
-    folders: List<FolderEntry>,
+    folders: List<FolderEntry>?,
     onCreateFolder: (String) -> Unit,
     onEditFolderItems: (Int) -> Unit,
     onRenameFolder: (Int, String) -> Unit,
@@ -118,8 +118,8 @@ fun AppDrawerFoldersPreference(
     val folderOrderString by folderOrderAdapter.state
 
     var sortedDisplayList = remember(folders, folderOrderString) {
-        Log.d("AppDrawerFolders", "Recalculating sortedDisplayList. Folders count: ${folders.size}")
-        folders.sortedWith(
+        Log.d("AppDrawerFolders", "Recalculating sortedDisplayList. Folders count: ${folders?.size}")
+        folders?.sortedWith(
             compareBy { folderEntry ->
                 val index = FolderOrderUtils
                     .stringToIntList(folderOrderString)
@@ -131,14 +131,11 @@ fun AppDrawerFoldersPreference(
                     index
                 }
             },
-        )
+        ) ?: emptyList()
     }
 
-    // proxy for detecting if all apps have been loaded, todo change
-    val apps by appsState()
-
     LoadingScreen(
-        isLoading = apps.isEmpty(),
+        isLoading = folders == null,
         modifier = modifier.fillMaxWidth(),
     ) {
         PreferenceLayout(

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/SelectAppsForDrawerFolder.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/SelectAppsForDrawerFolder.kt
@@ -77,16 +77,18 @@ fun SelectAppsForDrawerFolder(
     }
 
     LaunchedEffect(folders) {
-        allFolderPackages = folders.flatMap { it.itemComponentKeys }
-            .map { key -> key.substringBefore("/") }
-            .toSet()
+        folders?.let {
+            allFolderPackages = it.flatMap { folder -> folder.itemComponentKeys }
+                .map { key -> key.substringBefore("/") }
+                .toSet()
+        }
     }
 
     LaunchedEffect(folderInfoId) {
         viewModel.setFolderEntry(folderInfoId)
     }
 
-    val loading = folderEntry == null && apps.isEmpty()
+    val loading = folderEntry == null || apps.isEmpty()
 
     PreferenceScaffold(
         label = if (loading) {

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/SelectAppsForDrawerFolder.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/SelectAppsForDrawerFolder.kt
@@ -1,6 +1,5 @@
 ﻿package app.lawnchair.ui.preferences.destinations
 
-import android.content.Context
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.layout.PaddingValues
@@ -19,7 +18,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -38,7 +36,6 @@ import app.lawnchair.ui.preferences.components.reorderable.PositionalReorderer
 import app.lawnchair.util.App
 import app.lawnchair.util.appsState
 import com.android.launcher3.R
-import com.android.launcher3.util.ComponentKey
 
 @Composable
 fun SelectAppsForDrawerFolder(
@@ -52,16 +49,15 @@ fun SelectAppsForDrawerFolder(
         return
     }
 
-    val context = LocalContext.current
     val apps by appsState()
     val folders by viewModel.folders.collectAsStateWithLifecycle()
-    val folderInfo by viewModel.folderInfo.collectAsStateWithLifecycle()
+    val folderEntry by viewModel.folderEntry.collectAsStateWithLifecycle()
 
     var allFolderPackages by remember { mutableStateOf(emptySet<String>()) }
     var filterNonUniqueItems by remember { mutableStateOf(true) }
 
-    val activeIds = remember(folderInfo) {
-        folderInfo?.getContents()?.map { ComponentKey(it.targetComponent, it.user).toString() } ?: emptyList()
+    val activeIds = remember(folderEntry) {
+        folderEntry?.itemComponentKeys ?: emptyList()
     }
 
     val (positionalItems, activeCount) = remember(apps, activeIds, filterNonUniqueItems, allFolderPackages) {
@@ -81,22 +77,22 @@ fun SelectAppsForDrawerFolder(
     }
 
     LaunchedEffect(folders) {
-        allFolderPackages = folders.flatMap { it.getContents() }
-            .mapNotNull { it.targetPackage }
+        allFolderPackages = folders.flatMap { it.itemComponentKeys }
+            .map { key -> key.substringBefore("/") }
             .toSet()
     }
 
     LaunchedEffect(folderInfoId) {
-        viewModel.setFolderInfo(folderInfoId, false)
+        viewModel.setFolderEntry(folderInfoId)
     }
 
-    val loading = folderInfo == null && apps.isEmpty()
+    val loading = folderEntry == null && apps.isEmpty()
 
     PreferenceScaffold(
         label = if (loading) {
             stringResource(R.string.loading)
         } else {
-            stringResource(R.string.x_with_y_count, folderInfo?.title.toString(), activeCount)
+            stringResource(R.string.x_with_y_count, folderEntry?.title.toString(), activeCount)
         },
         modifier = modifier,
         actions = {
@@ -106,7 +102,7 @@ fun SelectAppsForDrawerFolder(
                     activeCount = activeCount,
                     onUpdate = { newList, newCount ->
                         val sorted = PositionalMapper.sortInactiveItems(newList, newCount) { it.label }
-                        updateViewModel(sorted, newCount, apps, context, viewModel, folderInfoId, folderInfo?.title.toString())
+                        updateViewModel(sorted, newCount, viewModel, folderInfoId, folderEntry?.title.toString())
                     },
                     labelSelector = { it.label },
                     additionalContent = { hideMenu ->
@@ -144,7 +140,7 @@ fun SelectAppsForDrawerFolder(
                     activeCount = activeCount,
                     onOrderChange = { newList, newCount ->
                         val sorted = PositionalMapper.sortInactiveItems(newList, newCount) { it.label }
-                        updateViewModel(sorted, newCount, apps, context, viewModel, folderInfoId, folderInfo?.title.toString())
+                        updateViewModel(sorted, newCount, viewModel, folderInfoId, folderEntry?.title.toString())
                     },
                     contentPadding = it,
                 )
@@ -182,20 +178,10 @@ private fun PositionalAppListPreference(
 private fun updateViewModel(
     newList: List<PositionalListItem<App>>,
     newCount: Int,
-    apps: List<App>,
-    context: Context,
     viewModel: FolderViewModel,
     folderId: Int,
     title: String,
 ) {
-    val activePackageNames = PositionalMapper.getEnabledKeys(newList, newCount).toSet()
-
-    val newSelection = activePackageNames.mapNotNull { keyString ->
-        val app = apps.find { it.key.toString() == keyString }
-        app?.toAppInfo(context)?.apply {
-            rank = activePackageNames.indexOf(keyString)
-        }
-    }
-
-    viewModel.updateFolderItems(folderId, title, newSelection)
+    val activeKeys = PositionalMapper.getEnabledKeys(newList, newCount)
+    viewModel.updateFolderItems(folderId, title, activeKeys)
 }

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/SelectAppsForDrawerFolder.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/SelectAppsForDrawerFolder.kt
@@ -12,7 +12,6 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -22,6 +21,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import app.lawnchair.data.folder.FolderEntry
 import app.lawnchair.data.folder.model.FolderViewModel
 import app.lawnchair.ui.preferences.LocalIsExpandedScreen
 import app.lawnchair.ui.preferences.components.AppItem
@@ -50,10 +50,28 @@ fun SelectAppsForDrawerFolder(
     }
 
     val apps by appsState()
-    val folders by viewModel.folders.collectAsStateWithLifecycle()
-    val folderEntry by viewModel.folderEntry.collectAsStateWithLifecycle()
+    val folderEntry by viewModel.getFolderFlowForId(folderInfoId).collectAsStateWithLifecycle(null)
+    val allFolderPackages by viewModel.allFolderPackages.collectAsStateWithLifecycle()
 
-    var allFolderPackages by remember { mutableStateOf(emptySet<String>()) }
+    SelectAppsForDrawerFolder(
+        folderEntry = folderEntry,
+        apps = apps,
+        allFolderPackages = allFolderPackages,
+        onUpdate = { title, componentKeys ->
+            viewModel.updateFolderItems(folderInfoId, title, componentKeys)
+        },
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun SelectAppsForDrawerFolder(
+    folderEntry: FolderEntry?,
+    apps: List<App>,
+    allFolderPackages: Set<String>?,
+    onUpdate: (title: String, componentKeys: List<String>) -> Unit,
+    modifier: Modifier = Modifier,
+) {
     var filterNonUniqueItems by remember { mutableStateOf(true) }
 
     val activeIds = remember(folderEntry) {
@@ -63,7 +81,8 @@ fun SelectAppsForDrawerFolder(
     val (positionalItems, activeCount) = remember(apps, activeIds, filterNonUniqueItems, allFolderPackages) {
         val filtered = apps.filter { app ->
             if (filterNonUniqueItems) {
-                !allFolderPackages.contains(app.key.componentName.packageName) ||
+                val packages = allFolderPackages ?: emptySet()
+                !packages.contains(app.key.componentName.packageName) ||
                     activeIds.contains(app.key.toString())
             } else {
                 true
@@ -76,25 +95,13 @@ fun SelectAppsForDrawerFolder(
         )
     }
 
-    LaunchedEffect(folders) {
-        folders?.let {
-            allFolderPackages = it.flatMap { folder -> folder.itemComponentKeys }
-                .map { key -> key.substringBefore("/") }
-                .toSet()
-        }
-    }
-
-    LaunchedEffect(folderInfoId) {
-        viewModel.setFolderEntry(folderInfoId)
-    }
-
     val loading = folderEntry == null || apps.isEmpty()
 
     PreferenceScaffold(
         label = if (loading) {
             stringResource(R.string.loading)
         } else {
-            stringResource(R.string.x_with_y_count, folderEntry?.title.toString(), activeCount)
+            stringResource(R.string.x_with_y_count, folderEntry.title, activeCount)
         },
         modifier = modifier,
         actions = {
@@ -104,7 +111,8 @@ fun SelectAppsForDrawerFolder(
                     activeCount = activeCount,
                     onUpdate = { newList, newCount ->
                         val sorted = PositionalMapper.sortInactiveItems(newList, newCount) { it.label }
-                        updateViewModel(sorted, newCount, viewModel, folderInfoId, folderEntry?.title.toString())
+                        val activeKeys = PositionalMapper.getEnabledKeys(sorted, newCount)
+                        onUpdate(folderEntry.title, activeKeys)
                     },
                     labelSelector = { it.label },
                     additionalContent = { hideMenu ->
@@ -123,10 +131,10 @@ fun SelectAppsForDrawerFolder(
             }
         },
         isExpandedScreen = LocalIsExpandedScreen.current,
-    ) {
+    ) { contentPadding ->
         Crossfade(targetState = loading, label = "") { isLoading ->
             if (isLoading) {
-                PreferenceLazyColumn(it, enabled = false, state = rememberLazyListState()) {
+                PreferenceLazyColumn(contentPadding, enabled = false, state = rememberLazyListState()) {
                     preferenceGroupItems(
                         count = 20,
                         isFirstChild = true,
@@ -142,9 +150,10 @@ fun SelectAppsForDrawerFolder(
                     activeCount = activeCount,
                     onOrderChange = { newList, newCount ->
                         val sorted = PositionalMapper.sortInactiveItems(newList, newCount) { it.label }
-                        updateViewModel(sorted, newCount, viewModel, folderInfoId, folderEntry?.title.toString())
+                        val activeKeys = PositionalMapper.getEnabledKeys(sorted, newCount)
+                        onUpdate(folderEntry?.title.toString(), activeKeys)
                     },
-                    contentPadding = it,
+                    contentPadding = contentPadding,
                 )
             }
         }
@@ -175,15 +184,4 @@ private fun PositionalAppListPreference(
         contentPadding = contentPadding,
         modifier = modifier,
     )
-}
-
-private fun updateViewModel(
-    newList: List<PositionalListItem<App>>,
-    newCount: Int,
-    viewModel: FolderViewModel,
-    folderId: Int,
-    title: String,
-) {
-    val activeKeys = PositionalMapper.getEnabledKeys(newList, newCount)
-    viewModel.updateFolderItems(folderId, title, activeKeys)
 }


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

This PR aims to improve the loading performance of `AppDrawerFoldersPreference` and `SelectAppsForDrawerFolder` via the following changes:

- Use a new data class `FolderEntry` to not rely unnecessarily on Launcher3's heavy models
- Remove unnecessary state duplication
- Simplify state management for the details screen: actually use the nav argument on the destination screen rather than managing a state variable in the viewmodel.
- Simplify the CRUD system of the viewmodel to improve maintainability and performance
- Simplify `SelectAppsForDrawerFolder` to use callbacks and delegate on the viewmodel  when possible

A good next PR would be to migrate the string-based approach for "sorting" items to the rank-based approach, and to improve the UX of the current system (which is half-baked).

Addresses task of #6442.

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->
Mostly do this to address technical debt. The main thing here is that by not using `FolderInfo`s until necessary, we can use standard Kotlin data classes (which should be faster).

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

1. Install many apps
2. Go to Home settings > App drawer > App drawer folders
3. See that the list loads almost instantly
4. Create a folder, then change items inside
5. See that the waiting times become significantly faster

Have tested this on my real device with ~150 apps, and it cut the loading times from ~10-20s to just ~1s, even on a debug build.

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

:white_check_mark: **Performance** (A code change that improves performance)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved drawer folder management and app selection using more reliable folder item data.
  * Folder contents preserve their configured order when viewing or editing.
  * Folder editing, renaming, and item updates now refresh more consistently after changes.
  * App selection now reflects the folder’s configured apps and helps prevent duplicate package selections across folders.
  * Folder screens display loading states and titles more consistently while data is being retrieved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->