### PR TITLE
fix: allapps tab search focus

### DIFF
--- a/lawnchair/src/app/lawnchair/allapps/FallbackSearchInputView.kt
+++ b/lawnchair/src/app/lawnchair/allapps/FallbackSearchInputView.kt
@@ -28,7 +28,17 @@ class FallbackSearchInputView(context: Context, attrs: AttributeSet?) : Extended
 
     override fun hideKeyboard() {
         super.hideKeyboard()
-        this.appsView?.requestFocus()
+        // Prefer the active apps list over appsView itself. appsView has
+        // focusable=false and its search container is focusedByDefault, so
+        // requestFocus() on appsView would re-focus the search field (e.g. when
+        // switching Personal/Work tabs triggers resetSearch).
+        val appsView = this.appsView
+        val activeList = appsView?.activeRecyclerView
+        if (activeList != null) {
+            activeList.requestFocus()
+        } else {
+            appsView?.requestFocus()
+        }
     }
 
     override fun onAttachedToWindow() {


### PR DESCRIPTION
### Description

Prevent the All Apps search bar from becoming active when switching between Personal and Work tabs. Tab switches call `resetSearch` → `hideKeyboard`, which requested focus on `appsView` and landed back on the focused-by-default search field.

### Reasoning

`appsView` is not focusable, while the search container is marked `focusedByDefault`. Requesting focus on `appsView` therefore re-selected search and showed the hint without user input. Focus the active apps list instead so tab switches leave search inactive.

### Testing

1. Open All Apps with Personal/Work tabs visible.
2. Confirm the search bar is inactive (no hint/placeholder, no keyboard).
3. Switch between Personal and Work several times.
4. Confirm search stays inactive after each switch.
5. Tap search and confirm focus, hint, and keyboard still work normally.

### Type of change
:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
:x: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard dismissal and focus restoration when leaving search.
  * Focus now returns to the active apps list, preventing the search field from being unintentionally reselected during tab switching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->