### PR TITLE
fix: Clear stuck workspace blur after drawer/folder close

### DIFF
--- a/quickstep/src/com/android/launcher3/statehandlers/DepthController.java
+++ b/quickstep/src/com/android/launcher3/statehandlers/DepthController.java
@@ -184,6 +184,11 @@ public class DepthController extends BaseDepthController implements StateHandler
         if (toState == LauncherState.BACKGROUND_APP) {
             addOnDrawListener();
         }
+        // Re-apply even when depth is already 0 so an interrupted All Apps / depth transition
+        // cannot leave workspace RenderEffect or surface blur stuck until the next resume.
+        if (toState == LauncherState.NORMAL) {
+            applyDepthAndBlur();
+        }
     }
 
     @Override

--- a/quickstep/src/com/android/quickstep/util/BaseDepthController.java
+++ b/quickstep/src/com/android/quickstep/util/BaseDepthController.java
@@ -201,8 +201,7 @@ public class BaseDepthController {
             boolean applyImmediately, boolean skipSimilarBlur) {
         float depth = mDepth;
         IBinder windowToken = mLauncher.getRootView().getWindowToken();
-        if (windowToken != null) {
-            if (!Utilities.ATLEAST_R) return;
+        if (windowToken != null && Utilities.ATLEAST_R) {
             if (enableScalingRevealHomeAnimation()) {
                 mWallpaperManager.setWallpaperZoomOut(windowToken, depth);
             } else {
@@ -212,6 +211,32 @@ public class BaseDepthController {
                 // Launcher's concept of full depth unchanged, we divide the depth by 3 here.
                 mWallpaperManager.setWallpaperZoomOut(windowToken, depth / 3);
             }
+        }
+
+        boolean hasOpaqueBg = mLauncher.getScrimView().isFullyOpaque();
+        boolean isSurfaceOpaque = !mHasContentBehindLauncher && hasOpaqueBg && !mPauseBlurs;
+
+        float blurAmount;
+        if (enableScalingRevealHomeAnimation()) {
+            blurAmount = mapDepthToBlur(depth);
+        } else {
+            blurAmount = depth;
+        }
+
+        int previousBlur = mCurrentBlur;
+        int newBlur = BlurUtils.supportsBlursOnWindows() && mCrossWindowBlursEnabled
+                && !hasOpaqueBg && !mPauseBlurs
+                ? (int) (blurAmount * mMaxBlurRadius) : 0;
+        int delta = Math.abs(newBlur - previousBlur);
+        boolean skipUpdate = skipSimilarBlur && delta < Utilities.dpToPx(1) && newBlur != 0
+                && previousBlur != 0 && blurAmount != 1f;
+
+        // Always keep mCurrentBlur and workspace RenderEffects in sync with depth, even when the
+        // SurfaceControl is temporarily unavailable. Otherwise setDepth(0) can early-return later
+        // (same depth) and leave workspace/hotseat stuck blurred until the activity restarts.
+        if (!skipUpdate) {
+            mCurrentBlur = newBlur;
+            blurWorkspaceDepthTargets();
         }
 
         if (!BlurUtils.supportsBlursOnWindows()) {
@@ -228,44 +253,29 @@ public class BaseDepthController {
             return;
         }
         mWaitingOnSurfaceValidity = false;
-        boolean hasOpaqueBg = mLauncher.getScrimView().isFullyOpaque();
-        boolean isSurfaceOpaque = !mHasContentBehindLauncher && hasOpaqueBg && !mPauseBlurs;
 
-        float blurAmount;
-        if (enableScalingRevealHomeAnimation()) {
-            blurAmount = mapDepthToBlur(depth);
-        } else {
-            blurAmount = depth;
-        }
         SurfaceControl blurSurface =
                 enableOverviewBackgroundWallpaperBlur() && mBlurSurface != null ? mBlurSurface
                         : mBaseSurface;
 
-        int previousBlur = mCurrentBlur;
-        int newBlur = mCrossWindowBlursEnabled && !hasOpaqueBg && !mPauseBlurs ? (int) (blurAmount
-                * mMaxBlurRadius) : 0;
-        int delta = Math.abs(newBlur - previousBlur);
-        if (skipSimilarBlur && delta < Utilities.dpToPx(1) && newBlur != 0 && previousBlur != 0
-                && blurAmount != 1f) {
+        if (skipUpdate) {
             Log.d(TAG, "Skipping small blur delta. newBlur: " + newBlur + " previousBlur: "
                     + previousBlur + " delta: " + delta + " surface: " + blurSurface);
             return;
         }
-        mCurrentBlur = newBlur;
+
         Log.v(TAG, "Applying blur: " + mCurrentBlur + " to " + blurSurface);
 
         final SurfaceControl.Transaction finalTransaction =
                 transaction == null ? createTransaction() : transaction;
-        
+
         // LC: Fix blur effect on Android 12.1/12.0
         try (finalTransaction) {
-            if (blurSurface != null && blurSurface.isValid()) {
-                finalTransaction.setBackgroundBlurRadius(blurSurface, mCurrentBlur)
-                        .setOpaque(blurSurface, isSurfaceOpaque);
-            } else {
-                // GRASP
+            if (blurSurface == null || !blurSurface.isValid()) {
                 return;
             }
+            finalTransaction.setBackgroundBlurRadius(blurSurface, mCurrentBlur)
+                    .setOpaque(blurSurface, isSurfaceOpaque);
 
             boolean wantsEarlyWakeUp = blurAmount > 0 && blurAmount < 1;
             if (wantsEarlyWakeUp && !mInEarlyWakeUp) {
@@ -285,8 +295,6 @@ public class BaseDepthController {
             // LC: Always apply immediately.
             finalTransaction.apply();
         }
-
-        blurWorkspaceDepthTargets();
     }
 
     /**
@@ -329,6 +337,8 @@ public class BaseDepthController {
     @VisibleForTesting
     public boolean blurWorkspaceDepthTargets() {
         if (!Flags.allAppsBlur()) {
+            // Still clear any leftover effect if the flag flips or blur was applied earlier.
+            mLauncher.getDepthBlurTargets().forEach(target -> target.setRenderEffect(null));
             return false;
         }
         StateManager<LauncherState, Launcher> stateManager = mLauncher.getStateManager();
@@ -361,6 +371,11 @@ public class BaseDepthController {
             depthF = depthI / 256f;
         }
         if (Float.compare(mDepth, depthF) == 0) {
+            // Depth is unchanged, but a previous apply may have returned early (invalid surface)
+            // leaving blur stuck. Force a re-apply when clearing.
+            if (depthF == 0f && mCurrentBlur != 0) {
+                applyDepthAndBlur();
+            }
             return;
         }
         mDepth = depthF;

--- a/quickstep/src/com/android/quickstep/util/BaseDepthController.java
+++ b/quickstep/src/com/android/quickstep/util/BaseDepthController.java
@@ -336,6 +336,10 @@ public class BaseDepthController {
     /** @return {@code true} if the workspace should be blurred. */
     @VisibleForTesting
     public boolean blurWorkspaceDepthTargets() {
+        // RenderEffect / createBlurEffect require API 31+.
+        if (!Utilities.ATLEAST_S) {
+            return false;
+        }
         if (!Flags.allAppsBlur()) {
             // Still clear any leftover effect if the flag flips or blur was applied earlier.
             mLauncher.getDepthBlurTargets().forEach(target -> target.setRenderEffect(null));

--- a/src/com/android/launcher3/folder/Folder.java
+++ b/src/com/android/launcher3/folder/Folder.java
@@ -1147,6 +1147,14 @@ public class Folder extends AbstractFloatingView implements ClipPathView, DragSo
         }
         SCALE_PROPERTY.set(launcher.getWorkspace(), 1f);
         SCALE_PROPERTY.set(launcher.getHotseat(), 1f);
+        // Clear any stuck workspace/hotseat RenderEffect if we are not in a depth-blur state.
+        // Expressive folder open/close can race with All Apps depth blur and leave icons blurred.
+        if (Utilities.ATLEAST_S
+                && launcher.getStateManager().getState().getDepth(launcher) == 0f) {
+            for (View target : launcher.getDepthBlurTargets()) {
+                target.setRenderEffect(null);
+            }
+        }
     }
 
     @Override

--- a/src/com/android/launcher3/folder/FolderScrimAnimationListener.kt
+++ b/src/com/android/launcher3/folder/FolderScrimAnimationListener.kt
@@ -19,6 +19,8 @@ package com.android.launcher3.folder
 import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
 import com.android.launcher3.Launcher
+import com.android.launcher3.LauncherAnimUtils.SCALE_PROPERTY
+import com.android.launcher3.Utilities
 import com.android.launcher3.views.ScrimView
 
 /**
@@ -51,5 +53,12 @@ class FolderScrimAnimationListener(
         scrimView.setScrimColors(
             launcher.stateManager.state.getWorkspaceScrimColor(launcher),
         )
+        // Also reset scale here: close animations can be cancelled without going through
+        // Folder.closeComplete's restore path, leaving workspace/hotseat visually dimmed/scaled.
+        SCALE_PROPERTY.set(launcher.workspace, 1f)
+        SCALE_PROPERTY.set(launcher.hotseat, 1f)
+        if (Utilities.ATLEAST_S && launcher.stateManager.state.getDepth(launcher) == 0f) {
+            launcher.depthBlurTargets.forEach { it.setRenderEffect(null) }
+        }
     }
 }


### PR DESCRIPTION
Depth blur could leave RenderEffect on workspace/hotseat when SurfaceControl apply returned early, then setDepth(0) skipped re-apply. Always sync view blur with depth and force re-apply when settling to NORMAL; also clear leftover effects on folder dismiss.

### Description

Fixes stuck home-screen blur after closing the app drawer or a folder: workspace/hotseat could keep a `RenderEffect` (and surface blur) if depth was cleared while `SurfaceControl` apply failed, then `setDepth(0)` skipped a re-apply. Blur now stays synced with depth even without a valid surface, is forced on settle to `NORMAL`, and leftover effects are cleared on folder dismiss.

Fixes #6389 <!-- related: stuck dim/blur after folder; also covers drawer close case -->

### Reasoning

With `all_apps_blur` / wallpaper depth enabled, closing All Apps animates depth to `0`. If `applyDepthAndBlur` returned early (null/invalid surface) *after* depth was already stored as `0`, workspace/hotseat stayed blurred. The next `setDepth(0)` saw no change and did nothing, so only lock/unlock (surface recreation) cleared it. The same leftover blur could race with expressive folder dismiss. Sync view blur with depth independently of surface validity, and force a clear when entering `NORMAL`.

### Testing

1. Enable **Wallpaper depth effect** (Home settings).
2. Open and close the app drawer repeatedly — home should never stay black/blurred; dock icons must stay sharp.
3. Open and close a home folder (expressive expansion on if available) — scrim, scale, and blur should reset.
4. Launch an app from a folder (skip folder close animation) — home should not stay dimmed/scaled/blurred.
5. Lock and unlock the device once — still recovers cleanly; opening All Apps still shows blur as expected.

### Type of change

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
:x: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cases where workspace blur/render effects could get stuck after interrupted All Apps/depth transitions.
  * Prevented lingering depth-blur effects after closing folders by clearing relevant render effects when depth is reset.
  * Improved depth/blur synchronization to avoid stale visuals and no-op updates, including safer handling of blur surface selection.
  * Added Android-version safeguards for wallpaper zoom-out and ensured correct behavior when depth blur is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->