### PR TITLE
fix: Don't leave drawer folders open after closing All Apps

### DIFF
--- a/src/com/android/launcher3/touch/WorkspaceTouchListener.java
+++ b/src/com/android/launcher3/touch/WorkspaceTouchListener.java
@@ -198,6 +198,10 @@ public class WorkspaceTouchListener extends GestureDetector.SimpleOnGestureListe
             cancelLongPress();
         }
         if (action == ACTION_UP && isInAllAppsBottomSheet) {
+            // NORMAL has no FLAG_CLOSE_POPUPS, so drawer folders (Lawnchair) would stay open
+            // on the workspace after dismissing All Apps via the sheet's upper edge.
+            AbstractFloatingView.closeOpenViews(
+                    mLauncher, true /* animate */, AbstractFloatingView.TYPE_FOLDER);
             mLauncher.getStateManager().goToState(NORMAL);
             mLauncher.getStatsLogManager().logger()
                     .withSrcState(ALL_APPS.statsLogOrdinal)


### PR DESCRIPTION
### Description

Closes open app drawer folders when dismissing All Apps by tapping the upper edge of the bottom sheet. Previously the drawer closed but the folder stayed open on the workspace.

### Reasoning

Tapping outside the All Apps sheet (its upper edge) goes to `NORMAL` via `WorkspaceTouchListener`. Unlike `ALL_APPS` / `OVERVIEW`, `NORMAL` does not have `FLAG_CLOSE_POPUPS`, so folders opened from the drawer (attached to `DragLayer`) were never closed. Explicitly close `TYPE_FOLDER` before the state transition.

### Testing

1. Open the app drawer
2. Open any folder (category / manual drawer folder)
3. Tap the upper edge of the All Apps sheet (above the list)
4. Confirm both the drawer and the folder close; the folder should not remain on the home screen

### Type of change

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
:x: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Open folders now close correctly when dismissing the All Apps panel by tapping outside it.
  * Launcher state transitions remain consistent after closing the panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->