### PR TITLE
refactor: rewrite PositionalList component to use state

### DIFF
--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -155,6 +155,8 @@
     <string name="advanced">Advanced</string>
 
     <!-- Draggable -->
+    <string name="reorderable_move_up">Move up</string>
+    <string name="reorderable_move_down">Move down</string>
     <string name="reorderable_active_items">Active items</string>
     <string name="reorderable_disabled_items">Other items</string>
     <string name="reorderable_disabled_hint">Disabled items will appear here</string>

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/reorderable/PositionalList.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/reorderable/PositionalList.kt
@@ -18,7 +18,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -56,104 +58,125 @@ import sh.calvin.reorderable.rememberReorderableLazyListState
  * @property data The underlying data object being displayed.
  * @property id The unique key used to track this item's identity during reordering and animations.
  */
+@Immutable
 data class PositionalListItem<T, K>(
     val data: T,
     val id: K,
 )
 
-object PositionalListMapper {
+/**
+ * This class handles the logic for reordering items in [PositionalList] component via drag-and-drop,
+ * toggling items, between sections, and bulk operations like sorting or swapping categories.
+ *
+ * @param T The type of the actual data object.
+ * @param K The type of the unique identifier for the item.
+ * @param initialItems The initial list of items.
+ * @param initialActiveCount The initial number of items at the start of the list considered "Enabled".
+ * @param onOrderChange Callback triggered when the list order or the active count changes.
+ * @param labelSelector Function used to retrieve a string label from the data for alphabetical sorting.
+ * @param haptic Provider for haptic feedback during reorder operations.
+ */
+@Stable
+class PositionalListState<T, K>(
+    initialItems: List<PositionalListItem<T, K>>,
+    initialActiveCount: Int,
+    internal val onOrderChange: (newList: List<PositionalListItem<T, K>>, newEnabledCount: Int) -> Unit,
+    internal val labelSelector: (T) -> String,
+    private val haptic: ReorderHapticFeedback,
+) {
     /**
-     * Converts raw data into a single list for the Reorderable UI.
-     * @param allItems All available items
-     * @param enabledIds IDs of items that are currently "Enabled"
+     * The flat list of items, partitioned by [activeCount] into enabled and disabled sections.
      */
-    fun <T, K> prepareCategorizedItems(
-        allItems: List<T>,
-        enabledIds: List<K>,
-        idSelector: (T) -> K,
-    ): Pair<List<PositionalListItem<T, K>>, Int> {
-        val enabledItems = allItems.filter { idSelector(it) in enabledIds }
-            // Ensure enabled items follow the order defined in enabledIds
-            .sortedBy { enabledIds.indexOf(idSelector(it)) }
-            .map { PositionalListItem(it, idSelector(it)) }
+    var items by mutableStateOf(initialItems)
+        internal set
 
-        val disabledItems = allItems.filter { idSelector(it) !in enabledIds }
-            .map { PositionalListItem(it, idSelector(it)) }
+    /**
+     * The number of [items] at the start of the list that are currently enabled.
+     */
+    var activeCount by mutableIntStateOf(initialActiveCount)
+        internal set
 
-        return (enabledItems + disabledItems) to enabledItems.size
+    /**
+     * Swaps the positions of the active and inactive sections.
+     */
+    fun swapCategories() {
+        val newActive = items.drop(activeCount)
+        val newInactive = items.take(activeCount)
+        notifyChange(newActive + newInactive, newActive.size)
     }
 
     /**
-     * Converts the UI state back to the enabled IDs list for saving.
+     * Toggles between selecting all items and deselecting all items.
      */
-    fun <T, K> getEnabledKeys(
-        uiItems: List<PositionalListItem<T, K>>,
-        enabledCount: Int,
-    ): List<K> {
-        return uiItems.take(enabledCount).map { it.id }
-    }
-
-    /**
-     * Re-sorts the disabled section alphabetically while maintaining the active section's order.
-     */
-    fun <T, K> sortInactiveItems(
-        items: List<PositionalListItem<T, K>>,
-        activeCount: Int,
-        labelSelector: (T) -> String,
-    ): List<PositionalListItem<T, K>> {
-        val active = items.take(activeCount)
-        val inactive = items.drop(activeCount).sortedBy { labelSelector(it.data) }
-        return active + inactive
+    fun toggleSelectAll() {
+        val allSelected = activeCount == items.size
+        val newCount = if (allSelected) 0 else items.size
+        notifyChange(items, newCount)
     }
 
     /**
      * Re-sorts the active section alphabetically while maintaining the inactive section's order.
      */
-    fun <T, K> sortActiveItems(
-        items: List<PositionalListItem<T, K>>,
-        activeCount: Int,
-        labelSelector: (T) -> String,
-    ): List<PositionalListItem<T, K>> {
+    fun sortActiveItems() {
         val active = items.take(activeCount).sortedBy { labelSelector(it.data) }
         val inactive = items.drop(activeCount)
-        return active + inactive
+        notifyChange(active + inactive, activeCount)
     }
 
     /**
-     * Swaps the positions of the active and inactive sections.
+     * Resets the list by deselecting all items.
      */
-    fun <T, K> swapCategories(
-        items: List<PositionalListItem<T, K>>,
-        activeCount: Int,
-    ): Pair<List<PositionalListItem<T, K>>, Int> {
-        val newActive = items.drop(activeCount)
-        val newInactive = items.take(activeCount)
-        return (newActive + newInactive) to newActive.size
+    fun reset() {
+        notifyChange(items, 0)
     }
 
     /**
-     * Toggles the status of an item between active (enabled) and inactive (disabled).
+     * Moves the item at [index] up by one position.
      *
-     * When an item is made active, it is moved to the top of the active list (index 0).
-     * When an item is made inactive, it is moved to the inactive section and the section is re-sorted
-     * alphabetically using the provided [labelSelector].
+     * If an item moves from the start of the disabled section into the enabled section,
+     * the [activeCount] is incremented.
+     *
+     * @return `true` if the move was performed, `false` if already at the top.
      */
-    internal fun <T, K> toggleItemStatus(
-        items: List<PositionalListItem<T, K>>,
-        activeCount: Int,
-        itemId: K,
-        makeActive: Boolean,
-        labelSelector: (T) -> String,
-    ): Pair<List<PositionalListItem<T, K>>, Int> {
+    fun moveUp(index: Int): Boolean {
+        if (index <= 0) return false
+        val newList = items.toMutableList().apply { add(index - 1, removeAt(index)) }
+        val newCount = if (index == activeCount) activeCount + 1 else activeCount
+        notifyChange(newList, newCount)
+        return true
+    }
+
+    /**
+     * Moves the item at [index] down by one position.
+     *
+     * If an item moves from the end of the enabled section into the disabled section,
+     * the [activeCount] is decremented.
+     *
+     * @return `true` if the move was performed, `false` if already at the bottom.
+     */
+    fun moveDown(index: Int): Boolean {
+        if (index >= items.size - 1) return false
+        val newList = items.toMutableList().apply { add(index + 1, removeAt(index)) }
+        val newCount = if (index == activeCount - 1) activeCount - 1 else activeCount
+        notifyChange(newList, newCount)
+        return true
+    }
+
+    internal fun update(newList: List<PositionalListItem<T, K>>, newCount: Int) {
+        items = newList
+        activeCount = newCount
+    }
+
+    internal fun toggleItemStatus(itemId: K, makeActive: Boolean) {
         val currentIndex = items.indexOfFirst { it.id == itemId }
-        if (currentIndex == -1) return items to activeCount
+        if (currentIndex == -1) return
 
         val mutable = items.toMutableList()
         val item = mutable.removeAt(currentIndex)
 
-        return if (makeActive) {
+        if (makeActive) {
             mutable.add(0, item)
-            mutable to activeCount + 1
+            notifyChange(mutable, activeCount + 1)
         } else {
             mutable.add(item)
             val newActiveCount = activeCount - 1
@@ -162,57 +185,20 @@ object PositionalListMapper {
                 newActiveCount,
                 labelSelector,
             )
-            result to newActiveCount
+            notifyChange(result, newActiveCount)
         }
     }
 
-    /**
-     * Calculates the mapping of item keys to their visual UI indices, including ghost/hint items.
-     *
-     * Ghost items are inserted when a section (active or disabled) is empty to provide
-     * a visual drop target or hint.
-     */
-    internal fun <K> calculateIndices(
-        items: List<PositionalListItem<*, K>>,
-        activeCount: Int,
-    ): Map<Any, Int> = buildMap {
-        var uiIndex = 0
-        if (activeCount == 0) put("ghost_active", uiIndex++)
+    internal fun reorder(fromKey: Any, toKey: Any): Boolean {
+        // Early exits for safety
+        if (fromKey == "ghost_active" || fromKey == "ghost_disabled") return false
+        if (toKey == "header_enabled" || toKey == "header_disabled") return false
 
-        items.forEach { item ->
-            put(item.id as Any, uiIndex++)
-        }
+        val fromUiIndex = itemIndices[fromKey] ?: return false
+        val toUiIndex = itemIndices[toKey] ?: return false
+        if (fromUiIndex == toUiIndex) return false
 
-        if (activeCount == items.size) {
-            put("ghost_disabled", uiIndex)
-        }
-    }
-
-    /**
-     * Computes the new state of the list and active count after a reorder drag-and-drop event.
-     *
-     * This logic handles the transformation from UI-level indices (which may include ghost/header items)
-     * back to data-level indices, and updates [activeCount] if an item is dragged across the
-     * boundary between the active and inactive sections.
-     *
-     * @return A [Pair] containing the updated list and the new active count, or `null` if the move is invalid.
-     */
-    internal fun <T, K> calculateReorder(
-        items: List<PositionalListItem<T, K>>,
-        activeCount: Int,
-        fromKey: Any,
-        toKey: Any,
-        itemIndices: Map<Any, Int>,
-    ): Pair<List<PositionalListItem<T, K>>, Int>? {
-        // 1. Safety early exits
-        if (fromKey == "ghost_active" || fromKey == "ghost_disabled") return null
-        if (toKey == "header_enabled" || toKey == "header_disabled") return null
-
-        val fromUiIndex = itemIndices[fromKey] ?: return null
-        val toUiIndex = itemIndices[toKey] ?: return null
-        if (fromUiIndex == toUiIndex) return null
-
-        // 2. Map UI indices back to Data indices correctly
+        // Map UI indices back to data indices correctly
         val fromDataIndex = if (activeCount == 0) {
             fromUiIndex - 1
         } else {
@@ -221,20 +207,22 @@ object PositionalListMapper {
 
         val toDataIndex = when (toKey) {
             "ghost_active" -> 0
+
             "ghost_disabled" -> items.size - 1
+
             else -> {
                 if (activeCount == 0) (toUiIndex - 1) else toUiIndex
             }
         }.coerceIn(0, items.size - 1)
 
-        // 3. Perform the Move
+        // Perform move
         val newList = items.toMutableList().apply {
             if (fromDataIndex in indices) {
                 add(toDataIndex, removeAt(fromDataIndex))
             }
         }
 
-        // 4. Boundary Logic
+        // Boundary logic
         val uiThreshold = if (activeCount == 0) 1 else activeCount
 
         var newCount = activeCount
@@ -243,8 +231,114 @@ object PositionalListMapper {
         } else if (uiThreshold in (toUiIndex + 1)..fromUiIndex) {
             newCount++
         }
-        return newList to newCount.coerceIn(0, newList.size)
+        notifyChange(newList, newCount.coerceIn(0, newList.size))
+        return true
     }
+
+    private val itemIndices by derivedStateOf {
+        buildMap {
+            var uiIndex = 0
+            if (activeCount == 0) put("ghost_active", uiIndex++)
+
+            items.forEach { item ->
+                put(item.id as Any, uiIndex++)
+            }
+
+            if (activeCount == items.size) {
+                put("ghost_disabled", uiIndex)
+            }
+        }
+    }
+
+    private fun notifyChange(newList: List<PositionalListItem<T, K>>, newCount: Int) {
+        items = newList
+        activeCount = newCount
+        onOrderChange(newList, newCount)
+        haptic.performHapticFeedback(ReorderHapticFeedbackType.MOVE)
+    }
+
+    companion object {
+        /**
+         * Converts raw data into a single list for the Reorderable UI.
+         * @param allItems All available items
+         * @param enabledIds IDs of items that are currently "Enabled"
+         */
+        fun <T, K> prepareCategorizedItems(
+            allItems: List<T>,
+            enabledIds: List<K>,
+            idSelector: (T) -> K,
+        ): Pair<List<PositionalListItem<T, K>>, Int> {
+            val enabledItems = allItems.filter { idSelector(it) in enabledIds }
+                // Ensure enabled items follow the order defined in enabledIds
+                .sortedBy { enabledIds.indexOf(idSelector(it)) }
+                .map { PositionalListItem(it, idSelector(it)) }
+
+            val disabledItems = allItems.filter { idSelector(it) !in enabledIds }
+                .map { PositionalListItem(it, idSelector(it)) }
+
+            return (enabledItems + disabledItems) to enabledItems.size
+        }
+
+        /**
+         * Converts the UI state back to the enabled IDs list for saving.
+         */
+        fun <T, K> getEnabledKeys(
+            uiItems: List<PositionalListItem<T, K>>,
+            enabledCount: Int,
+        ): List<K> {
+            return uiItems.take(enabledCount).map { it.id }
+        }
+
+        /**
+         * Re-sorts the disabled section alphabetically while maintaining the active section's order.
+         */
+        fun <T, K> sortInactiveItems(
+            items: List<PositionalListItem<T, K>>,
+            activeCount: Int,
+            labelSelector: (T) -> String,
+        ): List<PositionalListItem<T, K>> {
+            val active = items.take(activeCount)
+            val inactive = items.drop(activeCount).sortedBy { labelSelector(it.data) }
+            return active + inactive
+        }
+    }
+}
+
+/**
+ * Creates and remembers a [PositionalListState] to manage the state of a reorderable list
+ * with active and inactive sections.
+ *
+ * @param T The type of the data object.
+ * @param K The type of the unique identifier for the item.
+ * @param items The initial list of items to display.
+ * @param activeCount The number of items starting from the top of the list that are considered active.
+ * @param onOrderChange Callback invoked when the order or the active status of items changes.
+ * @param labelSelector A function to extract a display string from the data, used for sorting.
+ * @return A remembered [PositionalListState] instance.
+ */
+@Composable
+fun <T, K> rememberPositionalListState(
+    items: List<PositionalListItem<T, K>>,
+    activeCount: Int,
+    onOrderChange: (newList: List<PositionalListItem<T, K>>, newEnabledCount: Int) -> Unit,
+    labelSelector: (T) -> String,
+): PositionalListState<T, K> {
+    val haptic = rememberReorderHapticFeedback()
+    val state = remember {
+        PositionalListState(
+            initialItems = items,
+            initialActiveCount = activeCount,
+            onOrderChange = onOrderChange,
+            labelSelector = labelSelector,
+            haptic = haptic,
+        )
+    }
+
+    LaunchedEffect(items, activeCount) {
+        state.update(items, activeCount)
+    }
+
+    return state
 }
 
 object PositionalListDefaults {
@@ -264,7 +358,6 @@ object PositionalListDefaults {
     }
 }
 
-
 /**
  * A UI component for managing a list of items toggled between "Enabled" and "Disabled" states.
  * Uses a single flat list to prevent animation jumping during state transitions.
@@ -272,64 +365,28 @@ object PositionalListDefaults {
  * - Indices `< activeCount` represent "Enabled" items.
  * - Indices `>= activeCount` represent "Disabled" items.
  *
- * Moving an item across this boundary updates [activeCount] and changes the item's status.
+ * Moving an item across this boundary updates activeCount and changes the item's status.
  *
- * @param items The flattened list of items, with enabled items positioned first.
- * @param activeCount The number of enabled items at the start of the list.
- * @param onOrderChange Callback triggered on item move or toggle. Returns the updated list and active count.
+ * @param state The state object managing the list's items and their enabled status.
  * @param itemContent The UI builder for an individual item, exposing a drag handle and status toggle.
- * @param labelSelector Property selector used to sort the inactive section alphabetically.
  * @param contentPadding Padding applied to the underlying scrollable container.
+ * @param modifier The modifier to be applied to the container.
  */
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun <T, K> PositionalList(
-    items: List<PositionalListItem<T, K>>,
-    activeCount: Int,
-    onOrderChange: (newList: List<PositionalListItem<T, K>>, newEnabledCount: Int) -> Unit,
+    state: PositionalListState<T, K>,
     itemContent: @Composable ReorderableCollectionItemScope.(
         item: T,
         dragHandle: @Composable () -> Unit,
         toggle: @Composable () -> Unit,
     ) -> Unit,
-    labelSelector: (T) -> String,
     contentPadding: PaddingValues,
     modifier: Modifier = Modifier,
 ) {
-    var localItems by remember { mutableStateOf(items) }
-    var localActiveCount by remember { mutableIntStateOf(activeCount) }
-
-    val itemIndices by remember {
-        derivedStateOf {
-            PositionalListMapper.calculateIndices(localItems, localActiveCount)
-        }
-    }
-
-    LaunchedEffect(items, activeCount) {
-        localItems = items
-        localActiveCount = activeCount
-    }
-
     val lazyListState = rememberLazyListState()
-    val haptic = rememberReorderHapticFeedback()
-
-    val updateState: (List<PositionalListItem<T, K>>, Int) -> Unit = { list, count ->
-        localItems = list
-        localActiveCount = count
-        onOrderChange(list, count)
-        haptic.performHapticFeedback(ReorderHapticFeedbackType.MOVE)
-    }
-
     val reorderableState = rememberReorderableLazyListState(lazyListState) { from, to ->
-        PositionalListMapper.calculateReorder(
-            localItems,
-            localActiveCount,
-            from.key,
-            to.key,
-            itemIndices,
-        )?.let { (newList, newCount) ->
-            updateState(newList, newCount)
-        }
+        state.reorder(from.key, to.key)
     }
 
     PreferenceLazyColumn(
@@ -341,7 +398,7 @@ fun <T, K> PositionalList(
             PreferenceGroupHeading(heading = stringResource(R.string.reorderable_active_items))
         }
 
-        if (localActiveCount == 0) {
+        if (state.activeCount == 0) {
             item(key = "ghost_active") {
                 // We treat this hint as a REORDERABLE ITEM so it can be swapped with
                 ReorderableItem(reorderableState, key = "ghost_active") {
@@ -354,12 +411,12 @@ fun <T, K> PositionalList(
         }
 
         itemsIndexed(
-            items = localItems,
+            items = state.items,
             key = { _, item -> item.id as Any },
         ) { index, item ->
-            val isActive = index < localActiveCount
+            val isActive = index < state.activeCount
 
-            ExpandAndShrink(visible = index == localActiveCount) {
+            ExpandAndShrink(visible = index == state.activeCount) {
                 PreferenceGroupHeading(
                     stringResource(R.string.reorderable_disabled_items),
                 )
@@ -368,23 +425,16 @@ fun <T, K> PositionalList(
             ReorderableItem(
                 state = reorderableState,
                 key = item.id as Any,
-                modifier = Modifier.semanticReorderActions(index, localItems, localActiveCount, onOrderChange),
+                modifier = Modifier.semanticReorderActions(index, state),
             ) {
                 ReorderableItemContainer(
                     item = item,
                     active = isActive,
                     onActiveChange = { makeActive ->
-                        val (newList, newCount) = PositionalListMapper.toggleItemStatus(
-                            localItems,
-                            localActiveCount,
-                            item.id,
-                            makeActive,
-                            labelSelector,
-                        )
-                        onOrderChange(newList, newCount)
+                        state.toggleItemStatus(item.id, makeActive)
                     },
-                    isFirst = index == if (isActive) 0 else localActiveCount,
-                    isLast = index == (if (isActive) localActiveCount else localItems.size) - 1,
+                    isFirst = index == if (isActive) 0 else state.activeCount,
+                    isLast = index == (if (isActive) state.activeCount else state.items.size) - 1,
                     isAnyDragging = reorderableState.isAnyItemDragging,
                     content = itemContent,
                 )
@@ -392,7 +442,7 @@ fun <T, K> PositionalList(
         }
 
         // Handle trailing header if all items are enabled
-        if (localActiveCount == localItems.size) {
+        if (state.activeCount == state.items.size) {
             item(key = "ghost_disabled") {
                 ReorderableItem(reorderableState, key = "ghost_disabled") {
                     PreferenceGroup(heading = stringResource(R.string.reorderable_disabled_items)) {
@@ -406,31 +456,19 @@ fun <T, K> PositionalList(
 
 private fun <T, K> Modifier.semanticReorderActions(
     index: Int,
-    items: List<PositionalListItem<T, K>>,
-    activeCount: Int,
-    onUpdate: (newList: List<PositionalListItem<T, K>>, newEnabledCount: Int) -> Unit,
+    state: PositionalListState<T, K>,
 ) = this.semantics {
     customActions = listOfNotNull(
         if (index > 0) {
             CustomAccessibilityAction("Move up") {
-                val newList =
-                    items.toMutableList().apply { add(index - 1, removeAt(index)) }
-                // If it was the first disabled item moving up, it becomes enabled
-                val newCount = if (index == activeCount) activeCount + 1 else activeCount
-                onUpdate(newList, newCount)
-                true
+                state.moveUp(index)
             }
         } else {
             null
         },
-        if (index < items.size - 1) {
+        if (index < state.items.size - 1) {
             CustomAccessibilityAction("Move down") {
-                val newList =
-                    items.toMutableList().apply { add(index + 1, removeAt(index)) }
-                // If it was the last enabled item moving down, it becomes disabled
-                val newCount = if (index == activeCount - 1) activeCount - 1 else activeCount
-                onUpdate(newList, newCount)
-                true
+                state.moveDown(index)
             }
         } else {
             null
@@ -493,11 +531,8 @@ private fun <T, K> ReorderableCollectionItemScope.ReorderableItemContainer(
 }
 
 @Composable
-fun <T, K> PositionalListOveflowMenu(
-    items: List<PositionalListItem<T, K>>,
-    activeCount: Int,
-    onUpdate: (newList: List<PositionalListItem<T, K>>, newCount: Int) -> Unit,
-    labelSelector: (T) -> String,
+fun <T, K> PositionalListOverflowMenu(
+    state: PositionalListState<T, K>,
     modifier: Modifier = Modifier,
     extraItems: @Composable OverflowMenuScope.(hideMenu: () -> Unit) -> Unit = {},
 ) {
@@ -505,20 +540,18 @@ fun <T, K> PositionalListOveflowMenu(
         DropdownMenuItem(
             text = { Text(stringResource(R.string.inverse_selection)) },
             onClick = {
-                val (newList, newCount) = PositionalListMapper.swapCategories(items, activeCount)
-                onUpdate(newList, newCount)
+                state.swapCategories()
                 hideMenu()
             },
         )
 
-        val allSelected = activeCount == items.size
+        val allSelected = state.activeCount == state.items.size
         DropdownMenuItem(
             text = {
                 Text(stringResource(if (allSelected) R.string.deselect_all else R.string.select_all))
             },
             onClick = {
-                val newCount = if (allSelected) 0 else items.size
-                onUpdate(items, newCount)
+                state.toggleSelectAll()
                 hideMenu()
             },
         )
@@ -526,8 +559,7 @@ fun <T, K> PositionalListOveflowMenu(
         DropdownMenuItem(
             text = { Text(stringResource(R.string.sort_active_items_action)) },
             onClick = {
-                val newList = PositionalListMapper.sortActiveItems(items, activeCount, labelSelector)
-                onUpdate(newList, activeCount)
+                state.sortActiveItems()
                 hideMenu()
             },
         )
@@ -539,7 +571,7 @@ fun <T, K> PositionalListOveflowMenu(
         DropdownMenuItem(
             text = { Text(stringResource(R.string.action_reset)) },
             onClick = {
-                onUpdate(items, 0)
+                state.reset()
                 hideMenu()
             },
         )

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/reorderable/PositionalList.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/reorderable/PositionalList.kt
@@ -27,6 +27,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.CustomAccessibilityAction
 import androidx.compose.ui.semantics.customActions
@@ -46,22 +48,30 @@ import sh.calvin.reorderable.ReorderableCollectionItemScope
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
 
-data class PositionalListItem<T>(
+/**
+ * A wrapper class used by [PositionalList] to represent an item in a reorderable list.
+ *
+ * @param T The type of the actual data object.
+ * @param K The type of the unique identifier for the item.
+ * @property data The underlying data object being displayed.
+ * @property id The unique key used to track this item's identity during reordering and animations.
+ */
+data class PositionalListItem<T, K>(
     val data: T,
-    val id: String,
+    val id: K,
 )
 
-object PositionalMapper {
+object PositionalListMapper {
     /**
      * Converts raw data into a single list for the Reorderable UI.
-     * @param allItems All available items (e.g., all apps)
+     * @param allItems All available items
      * @param enabledIds IDs of items that are currently "Enabled"
      */
-    fun <T> prepareCategorizedItems(
+    fun <T, K> prepareCategorizedItems(
         allItems: List<T>,
-        enabledIds: List<String>,
-        idSelector: (T) -> String,
-    ): Pair<List<PositionalListItem<T>>, Int> {
+        enabledIds: List<K>,
+        idSelector: (T) -> K,
+    ): Pair<List<PositionalListItem<T, K>>, Int> {
         val enabledItems = allItems.filter { idSelector(it) in enabledIds }
             // Ensure enabled items follow the order defined in enabledIds
             .sortedBy { enabledIds.indexOf(idSelector(it)) }
@@ -76,21 +86,21 @@ object PositionalMapper {
     /**
      * Converts the UI state back to the enabled IDs list for saving.
      */
-    fun <T> getEnabledKeys(
-        uiItems: List<PositionalListItem<T>>,
+    fun <T, K> getEnabledKeys(
+        uiItems: List<PositionalListItem<T, K>>,
         enabledCount: Int,
-    ): List<String> {
+    ): List<K> {
         return uiItems.take(enabledCount).map { it.id }
     }
 
     /**
      * Re-sorts the disabled section alphabetically while maintaining the active section's order.
      */
-    fun <T> sortInactiveItems(
-        items: List<PositionalListItem<T>>,
+    fun <T, K> sortInactiveItems(
+        items: List<PositionalListItem<T, K>>,
         activeCount: Int,
         labelSelector: (T) -> String,
-    ): List<PositionalListItem<T>> {
+    ): List<PositionalListItem<T, K>> {
         val active = items.take(activeCount)
         val inactive = items.drop(activeCount).sortedBy { labelSelector(it.data) }
         return active + inactive
@@ -99,32 +109,42 @@ object PositionalMapper {
     /**
      * Re-sorts the active section alphabetically while maintaining the inactive section's order.
      */
-    fun <T> sortActiveItems(
-        items: List<PositionalListItem<T>>,
+    fun <T, K> sortActiveItems(
+        items: List<PositionalListItem<T, K>>,
         activeCount: Int,
         labelSelector: (T) -> String,
-    ): List<PositionalListItem<T>> {
+    ): List<PositionalListItem<T, K>> {
         val active = items.take(activeCount).sortedBy { labelSelector(it.data) }
         val inactive = items.drop(activeCount)
         return active + inactive
     }
 
-    fun <T> swapCategories(
-        items: List<PositionalListItem<T>>,
+    /**
+     * Swaps the positions of the active and inactive sections.
+     */
+    fun <T, K> swapCategories(
+        items: List<PositionalListItem<T, K>>,
         activeCount: Int,
-    ): Pair<List<PositionalListItem<T>>, Int> {
+    ): Pair<List<PositionalListItem<T, K>>, Int> {
         val newActive = items.drop(activeCount)
         val newInactive = items.take(activeCount)
         return (newActive + newInactive) to newActive.size
     }
 
-    fun <T> toggleItemStatus(
-        items: List<PositionalListItem<T>>,
+    /**
+     * Toggles the status of an item between active (enabled) and inactive (disabled).
+     *
+     * When an item is made active, it is moved to the top of the active list (index 0).
+     * When an item is made inactive, it is moved to the inactive section and the section is re-sorted
+     * alphabetically using the provided [labelSelector].
+     */
+    internal fun <T, K> toggleItemStatus(
+        items: List<PositionalListItem<T, K>>,
         activeCount: Int,
-        itemId: String,
+        itemId: K,
         makeActive: Boolean,
         labelSelector: (T) -> String,
-    ): Pair<List<PositionalListItem<T>>, Int> {
+    ): Pair<List<PositionalListItem<T, K>>, Int> {
         val currentIndex = items.indexOfFirst { it.id == itemId }
         if (currentIndex == -1) return items to activeCount
 
@@ -132,7 +152,6 @@ object PositionalMapper {
         val item = mutable.removeAt(currentIndex)
 
         return if (makeActive) {
-            // Move to the very top of the active list
             mutable.add(0, item)
             mutable to activeCount + 1
         } else {
@@ -146,37 +165,128 @@ object PositionalMapper {
             result to newActiveCount
         }
     }
+
+    /**
+     * Calculates the mapping of item keys to their visual UI indices, including ghost/hint items.
+     *
+     * Ghost items are inserted when a section (active or disabled) is empty to provide
+     * a visual drop target or hint.
+     */
+    internal fun <K> calculateIndices(
+        items: List<PositionalListItem<*, K>>,
+        activeCount: Int,
+    ): Map<Any, Int> = buildMap {
+        var uiIndex = 0
+        if (activeCount == 0) put("ghost_active", uiIndex++)
+
+        items.forEach { item ->
+            put(item.id as Any, uiIndex++)
+        }
+
+        if (activeCount == items.size) {
+            put("ghost_disabled", uiIndex)
+        }
+    }
+
+    /**
+     * Computes the new state of the list and active count after a reorder drag-and-drop event.
+     *
+     * This logic handles the transformation from UI-level indices (which may include ghost/header items)
+     * back to data-level indices, and updates [activeCount] if an item is dragged across the
+     * boundary between the active and inactive sections.
+     *
+     * @return A [Pair] containing the updated list and the new active count, or `null` if the move is invalid.
+     */
+    internal fun <T, K> calculateReorder(
+        items: List<PositionalListItem<T, K>>,
+        activeCount: Int,
+        fromKey: Any,
+        toKey: Any,
+        itemIndices: Map<Any, Int>,
+    ): Pair<List<PositionalListItem<T, K>>, Int>? {
+        // 1. Safety early exits
+        if (fromKey == "ghost_active" || fromKey == "ghost_disabled") return null
+        if (toKey == "header_enabled" || toKey == "header_disabled") return null
+
+        val fromUiIndex = itemIndices[fromKey] ?: return null
+        val toUiIndex = itemIndices[toKey] ?: return null
+        if (fromUiIndex == toUiIndex) return null
+
+        // 2. Map UI indices back to Data indices correctly
+        val fromDataIndex = if (activeCount == 0) {
+            fromUiIndex - 1
+        } else {
+            fromUiIndex
+        }
+
+        val toDataIndex = when (toKey) {
+            "ghost_active" -> 0
+            "ghost_disabled" -> items.size - 1
+            else -> {
+                if (activeCount == 0) (toUiIndex - 1) else toUiIndex
+            }
+        }.coerceIn(0, items.size - 1)
+
+        // 3. Perform the Move
+        val newList = items.toMutableList().apply {
+            if (fromDataIndex in indices) {
+                add(toDataIndex, removeAt(fromDataIndex))
+            }
+        }
+
+        // 4. Boundary Logic
+        val uiThreshold = if (activeCount == 0) 1 else activeCount
+
+        var newCount = activeCount
+        if (uiThreshold in (fromUiIndex + 1)..toUiIndex) {
+            newCount--
+        } else if (uiThreshold in (toUiIndex + 1)..fromUiIndex) {
+            newCount++
+        }
+        return newList to newCount.coerceIn(0, newList.size)
+    }
 }
 
+object PositionalListDefaults {
+    @Composable
+    fun containerColor(isSelfDragging: Boolean, isAnyDragging: Boolean): Color {
+        return when {
+            isSelfDragging -> MaterialTheme.colorScheme.surfaceContainer
+            isAnyDragging -> MaterialTheme.colorScheme.surface
+            else -> preferenceGroupColor()
+        }
+    }
+
+    fun containerShape(isFirst: Boolean, isLast: Boolean, isSelfDragging: Boolean): Shape {
+        val top = if (!isFirst) 0.dp else 12.dp
+        val bottom = if (!isLast) 0.dp else 12.dp
+        return if (isSelfDragging) RoundedCornerShape(12.dp) else RoundedCornerShape(top, top, bottom, bottom)
+    }
+}
+
+
 /**
- * A UI component for managing a list where items can be toggled between "Enabled" and "Disabled"
- * and reordered via drag-and-drop within and across those categories.
+ * A UI component for managing a list of items toggled between "Enabled" and "Disabled" states.
+ * Uses a single flat list to prevent animation jumping during state transitions.
  *
- * Instead of using two separate lists (which causes "jumping" animations when moving items),
- * this component treats all items as a single flat list. A "divider" is virtually placed
- * at the index defined by [activeCount].
- * - Indices `< activeCount`: "Enabled" items (e.g., Apps in folder).
- * - Indices `>= activeCount`: "Disabled" items (e.g., Other apps).
+ * - Indices `< activeCount` represent "Enabled" items.
+ * - Indices `>= activeCount` represent "Disabled" items.
  *
- * Moving an item across this boundary automatically increments or decrements the [activeCount],
- * effectively changing the item's status while maintaining a smooth animation.
+ * Moving an item across this boundary updates [activeCount] and changes the item's status.
  *
- * @param T The type of data being displayed.
- * @param items The flattened list of items, where enabled items must come first.
- * @param activeCount The number of items at the start of the list that are considered "active/enabled".
- * @param onOrderChange Callback triggered when an item is moved or toggled. Provides the new
- * full list and the updated count of active items.
- * @param itemContent The UI for an individual item. Provides a `dragHandle` for reordering
- * and a `toggle` for switching status without dragging.
- * @param labelSelector Used to sort the inactive section alphabetically when an item is disabled.
- * @param contentPadding Padding applied to the inner [PreferenceLazyColumn].
+ * @param items The flattened list of items, with enabled items positioned first.
+ * @param activeCount The number of enabled items at the start of the list.
+ * @param onOrderChange Callback triggered on item move or toggle. Returns the updated list and active count.
+ * @param itemContent The UI builder for an individual item, exposing a drag handle and status toggle.
+ * @param labelSelector Property selector used to sort the inactive section alphabetically.
+ * @param contentPadding Padding applied to the underlying scrollable container.
  */
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-fun <T> PositionalReorderer(
-    items: List<PositionalListItem<T>>,
+fun <T, K> PositionalList(
+    items: List<PositionalListItem<T, K>>,
     activeCount: Int,
-    onOrderChange: (newList: List<PositionalListItem<T>>, newEnabledCount: Int) -> Unit,
+    onOrderChange: (newList: List<PositionalListItem<T, K>>, newEnabledCount: Int) -> Unit,
     itemContent: @Composable ReorderableCollectionItemScope.(
         item: T,
         dragHandle: @Composable () -> Unit,
@@ -191,18 +301,7 @@ fun <T> PositionalReorderer(
 
     val itemIndices by remember {
         derivedStateOf {
-            buildMap {
-                var uiIndex = 0
-                if (localActiveCount == 0) put("ghost_active", uiIndex++)
-
-                localItems.forEachIndexed { _, item ->
-                    put(item.id, uiIndex++)
-                }
-
-                if (localActiveCount == localItems.size) {
-                    put("ghost_disabled", uiIndex)
-                }
-            }
+            PositionalListMapper.calculateIndices(localItems, localActiveCount)
         }
     }
 
@@ -214,7 +313,7 @@ fun <T> PositionalReorderer(
     val lazyListState = rememberLazyListState()
     val haptic = rememberReorderHapticFeedback()
 
-    val updateState: (List<PositionalListItem<T>>, Int) -> Unit = { list, count ->
+    val updateState: (List<PositionalListItem<T, K>>, Int) -> Unit = { list, count ->
         localItems = list
         localActiveCount = count
         onOrderChange(list, count)
@@ -222,55 +321,15 @@ fun <T> PositionalReorderer(
     }
 
     val reorderableState = rememberReorderableLazyListState(lazyListState) { from, to ->
-        val fromKey = from.key as String
-        val toKey = to.key as String
-
-        // 1. Safety early exits
-        if (fromKey == "ghost_active" || fromKey == "ghost_disabled") return@rememberReorderableLazyListState
-        if (toKey == "header_enabled" || toKey == "header_disabled") return@rememberReorderableLazyListState
-
-        val fromUiIndex = itemIndices[fromKey] ?: return@rememberReorderableLazyListState
-        val toUiIndex = itemIndices[toKey] ?: return@rememberReorderableLazyListState
-        if (fromUiIndex == toUiIndex) return@rememberReorderableLazyListState
-
-        // 2. Map UI indices back to Data indices correctly
-        // We subtract 1 ONLY if the item we are looking at is AFTER the active ghost
-        val fromDataIndex = if (localActiveCount == 0) {
-            fromUiIndex - 1
-        } else {
-            fromUiIndex
+        PositionalListMapper.calculateReorder(
+            localItems,
+            localActiveCount,
+            from.key,
+            to.key,
+            itemIndices,
+        )?.let { (newList, newCount) ->
+            updateState(newList, newCount)
         }
-
-        val toDataIndex = when (toKey) {
-            "ghost_active" -> 0
-
-            "ghost_disabled" -> localItems.size - 1
-
-            else -> {
-                // If there's an active ghost at the start, all real items are shifted by 1
-                if (localActiveCount == 0) (toUiIndex - 1) else toUiIndex
-            }
-        }.coerceIn(0, localItems.size - 1)
-
-        // 3. Perform the Move
-        val newList = localItems.toMutableList().apply {
-            if (fromDataIndex in indices) {
-                add(toDataIndex, removeAt(fromDataIndex))
-            }
-        }
-
-        // 4. Boundary Logic
-        // The threshold is the physical boundary in the UI list
-        val uiThreshold = if (localActiveCount == 0) 1 else localActiveCount
-
-        var newCount = localActiveCount
-        if (uiThreshold in (fromUiIndex + 1)..toUiIndex) {
-            newCount--
-        } else if (uiThreshold in (toUiIndex + 1)..fromUiIndex) {
-            newCount++
-        }
-
-        updateState(newList, newCount.coerceIn(0, newList.size))
     }
 
     PreferenceLazyColumn(
@@ -296,7 +355,7 @@ fun <T> PositionalReorderer(
 
         itemsIndexed(
             items = localItems,
-            key = { _, item -> item.id },
+            key = { _, item -> item.id as Any },
         ) { index, item ->
             val isActive = index < localActiveCount
 
@@ -308,14 +367,14 @@ fun <T> PositionalReorderer(
 
             ReorderableItem(
                 state = reorderableState,
-                key = item.id,
+                key = item.id as Any,
                 modifier = Modifier.semanticReorderActions(index, localItems, localActiveCount, onOrderChange),
             ) {
                 ReorderableItemContainer(
                     item = item,
                     active = isActive,
                     onActiveChange = { makeActive ->
-                        val (newList, newCount) = PositionalMapper.toggleItemStatus(
+                        val (newList, newCount) = PositionalListMapper.toggleItemStatus(
                             localItems,
                             localActiveCount,
                             item.id,
@@ -332,7 +391,7 @@ fun <T> PositionalReorderer(
             }
         }
 
-        // Handle trailing header if all apps are enabled
+        // Handle trailing header if all items are enabled
         if (localActiveCount == localItems.size) {
             item(key = "ghost_disabled") {
                 ReorderableItem(reorderableState, key = "ghost_disabled") {
@@ -345,11 +404,11 @@ fun <T> PositionalReorderer(
     }
 }
 
-private fun <T> Modifier.semanticReorderActions(
+private fun <T, K> Modifier.semanticReorderActions(
     index: Int,
-    items: List<PositionalListItem<T>>,
+    items: List<PositionalListItem<T, K>>,
     activeCount: Int,
-    onUpdate: (newList: List<PositionalListItem<T>>, newEnabledCount: Int) -> Unit,
+    onUpdate: (newList: List<PositionalListItem<T, K>>, newEnabledCount: Int) -> Unit,
 ) = this.semantics {
     customActions = listOfNotNull(
         if (index > 0) {
@@ -380,8 +439,8 @@ private fun <T> Modifier.semanticReorderActions(
 }
 
 @Composable
-private fun <T> ReorderableCollectionItemScope.ReorderableItemContainer(
-    item: PositionalListItem<T>,
+private fun <T, K> ReorderableCollectionItemScope.ReorderableItemContainer(
+    item: PositionalListItem<T, K>,
     active: Boolean,
     onActiveChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
@@ -396,18 +455,9 @@ private fun <T> ReorderableCollectionItemScope.ReorderableItemContainer(
 ) {
     var isSelfDragging by remember { mutableStateOf(false) }
 
-    val shape = remember(isFirst, isLast) {
-        val top = if (!isFirst) 0.dp else 12.dp
-        val bottom = if (!isLast) 0.dp else 12.dp
-        if (isSelfDragging) RoundedCornerShape(12.dp) else RoundedCornerShape(top, top, bottom, bottom)
-    }
-
+    val shape = PositionalListDefaults.containerShape(isFirst, isLast, isSelfDragging)
     val color by animateColorAsState(
-        when {
-            isSelfDragging -> MaterialTheme.colorScheme.surfaceContainer
-            isAnyDragging -> MaterialTheme.colorScheme.surface
-            else -> preferenceGroupColor()
-        },
+        PositionalListDefaults.containerColor(isSelfDragging, isAnyDragging),
     )
 
     Surface(
@@ -443,26 +493,24 @@ private fun <T> ReorderableCollectionItemScope.ReorderableItemContainer(
 }
 
 @Composable
-fun <T> PositionalOrderMenu(
-    items: List<PositionalListItem<T>>,
+fun <T, K> PositionalListOveflowMenu(
+    items: List<PositionalListItem<T, K>>,
     activeCount: Int,
-    onUpdate: (newList: List<PositionalListItem<T>>, newCount: Int) -> Unit,
+    onUpdate: (newList: List<PositionalListItem<T, K>>, newCount: Int) -> Unit,
     labelSelector: (T) -> String,
     modifier: Modifier = Modifier,
-    additionalContent: @Composable OverflowMenuScope.(hideMenu: () -> Unit) -> Unit = {},
+    extraItems: @Composable OverflowMenuScope.(hideMenu: () -> Unit) -> Unit = {},
 ) {
     OverflowMenu(modifier) {
-        // Inverse Selection
         DropdownMenuItem(
             text = { Text(stringResource(R.string.inverse_selection)) },
             onClick = {
-                val (newList, newCount) = PositionalMapper.swapCategories(items, activeCount)
+                val (newList, newCount) = PositionalListMapper.swapCategories(items, activeCount)
                 onUpdate(newList, newCount)
                 hideMenu()
             },
         )
 
-        // Select / Deselect All
         val allSelected = activeCount == items.size
         DropdownMenuItem(
             text = {
@@ -475,22 +523,19 @@ fun <T> PositionalOrderMenu(
             },
         )
 
-        // Sort Active Items alphabetically
         DropdownMenuItem(
             text = { Text(stringResource(R.string.sort_active_items_action)) },
             onClick = {
-                val newList = PositionalMapper.sortActiveItems(items, activeCount, labelSelector)
+                val newList = PositionalListMapper.sortActiveItems(items, activeCount, labelSelector)
                 onUpdate(newList, activeCount)
                 hideMenu()
             },
         )
 
-        // Custom Slots (e.g., Filter Duplicates toggle)
-        additionalContent(::hideMenu)
+        extraItems(::hideMenu)
 
         PreferenceDivider(modifier = Modifier.padding(vertical = 8.dp))
 
-        // Reset (Same as Deselect All in this context)
         DropdownMenuItem(
             text = { Text(stringResource(R.string.action_reset)) },
             onClick = {

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/reorderable/PositionalList.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/reorderable/PositionalList.kt
@@ -59,7 +59,7 @@ import sh.calvin.reorderable.rememberReorderableLazyListState
  * @property id The unique key used to track this item's identity during reordering and animations.
  */
 @Immutable
-data class PositionalListItem<T, K>(
+data class PositionalListItem<T, K : Any>(
     val data: T,
     val id: K,
 )
@@ -77,7 +77,7 @@ data class PositionalListItem<T, K>(
  * @param haptic Provider for haptic feedback during reorder operations.
  */
 @Stable
-class PositionalListState<T, K>(
+class PositionalListState<T, K : Any>(
     initialItems: List<PositionalListItem<T, K>>,
     initialActiveCount: Int,
     internal val onOrderChange: (newList: List<PositionalListItem<T, K>>, newEnabledCount: Int) -> Unit,
@@ -191,8 +191,8 @@ class PositionalListState<T, K>(
 
     internal fun reorder(fromKey: Any, toKey: Any): Boolean {
         // Early exits for safety
-        if (fromKey == "ghost_active" || fromKey == "ghost_disabled") return false
-        if (toKey == "header_enabled" || toKey == "header_disabled") return false
+        if (fromKey == ReorderableKey.GHOST_ACTIVE || fromKey == ReorderableKey.GHOST_DISABLED) return false
+        if (toKey == ReorderableKey.HEADER_ENABLED || toKey == ReorderableKey.HEADER_DISABLED) return false
 
         val fromUiIndex = itemIndices[fromKey] ?: return false
         val toUiIndex = itemIndices[toKey] ?: return false
@@ -206,9 +206,9 @@ class PositionalListState<T, K>(
         }
 
         val toDataIndex = when (toKey) {
-            "ghost_active" -> 0
+            ReorderableKey.GHOST_ACTIVE -> 0
 
-            "ghost_disabled" -> items.size - 1
+            ReorderableKey.GHOST_DISABLED -> items.size - 1
 
             else -> {
                 if (activeCount == 0) (toUiIndex - 1) else toUiIndex
@@ -232,20 +232,21 @@ class PositionalListState<T, K>(
             newCount++
         }
         notifyChange(newList, newCount.coerceIn(0, newList.size))
+        haptic.performHapticFeedback(ReorderHapticFeedbackType.MOVE)
         return true
     }
 
     private val itemIndices by derivedStateOf {
         buildMap {
             var uiIndex = 0
-            if (activeCount == 0) put("ghost_active", uiIndex++)
+            if (activeCount == 0) put(ReorderableKey.GHOST_ACTIVE, uiIndex++)
 
             items.forEach { item ->
                 put(item.id as Any, uiIndex++)
             }
 
             if (activeCount == items.size) {
-                put("ghost_disabled", uiIndex)
+                put(ReorderableKey.GHOST_DISABLED, uiIndex)
             }
         }
     }
@@ -254,7 +255,6 @@ class PositionalListState<T, K>(
         items = newList
         activeCount = newCount
         onOrderChange(newList, newCount)
-        haptic.performHapticFeedback(ReorderHapticFeedbackType.MOVE)
     }
 
     companion object {
@@ -263,7 +263,7 @@ class PositionalListState<T, K>(
          * @param allItems All available items
          * @param enabledIds IDs of items that are currently "Enabled"
          */
-        fun <T, K> prepareCategorizedItems(
+        fun <T, K : Any> prepareCategorizedItems(
             allItems: List<T>,
             enabledIds: List<K>,
             idSelector: (T) -> K,
@@ -282,7 +282,7 @@ class PositionalListState<T, K>(
         /**
          * Converts the UI state back to the enabled IDs list for saving.
          */
-        fun <T, K> getEnabledKeys(
+        fun <T, K : Any> getEnabledKeys(
             uiItems: List<PositionalListItem<T, K>>,
             enabledCount: Int,
         ): List<K> {
@@ -292,7 +292,7 @@ class PositionalListState<T, K>(
         /**
          * Re-sorts the disabled section alphabetically while maintaining the active section's order.
          */
-        fun <T, K> sortInactiveItems(
+        fun <T, K : Any> sortInactiveItems(
             items: List<PositionalListItem<T, K>>,
             activeCount: Int,
             labelSelector: (T) -> String,
@@ -317,7 +317,7 @@ class PositionalListState<T, K>(
  * @return A remembered [PositionalListState] instance.
  */
 @Composable
-fun <T, K> rememberPositionalListState(
+fun <T, K : Any> rememberPositionalListState(
     items: List<PositionalListItem<T, K>>,
     activeCount: Int,
     onOrderChange: (newList: List<PositionalListItem<T, K>>, newEnabledCount: Int) -> Unit,
@@ -339,6 +339,13 @@ fun <T, K> rememberPositionalListState(
     }
 
     return state
+}
+
+enum class ReorderableKey {
+    GHOST_ACTIVE,
+    GHOST_DISABLED,
+    HEADER_ENABLED,
+    HEADER_DISABLED,
 }
 
 object PositionalListDefaults {
@@ -374,7 +381,7 @@ object PositionalListDefaults {
  */
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-fun <T, K> PositionalList(
+fun <T, K : Any> PositionalList(
     state: PositionalListState<T, K>,
     itemContent: @Composable ReorderableCollectionItemScope.(
         item: T,
@@ -394,14 +401,14 @@ fun <T, K> PositionalList(
         contentPadding = contentPadding,
         modifier = modifier,
     ) {
-        item(key = "header_enabled") {
+        item(key = ReorderableKey.HEADER_ENABLED) {
             PreferenceGroupHeading(heading = stringResource(R.string.reorderable_active_items))
         }
 
         if (state.activeCount == 0) {
-            item(key = "ghost_active") {
+            item(key = ReorderableKey.GHOST_ACTIVE) {
                 // We treat this hint as a REORDERABLE ITEM so it can be swapped with
-                ReorderableItem(reorderableState, key = "ghost_active") {
+                ReorderableItem(reorderableState, key = ReorderableKey.GHOST_ACTIVE) {
                     PreferenceTemplate(
                         title = { Text(text = stringResource(R.string.reorderable_add_hint_items)) },
                         modifier = Modifier.padding(horizontal = 16.dp),
@@ -424,8 +431,13 @@ fun <T, K> PositionalList(
 
             ReorderableItem(
                 state = reorderableState,
-                key = item.id as Any,
-                modifier = Modifier.semanticReorderActions(index, state),
+                key = item.id,
+                modifier = Modifier.semanticReorderActions(
+                    index,
+                    state,
+                    stringResource(R.string.reorderable_move_up),
+                    stringResource(R.string.reorderable_move_down),
+                ),
             ) {
                 ReorderableItemContainer(
                     item = item,
@@ -443,8 +455,8 @@ fun <T, K> PositionalList(
 
         // Handle trailing header if all items are enabled
         if (state.activeCount == state.items.size) {
-            item(key = "ghost_disabled") {
-                ReorderableItem(reorderableState, key = "ghost_disabled") {
+            item(key = ReorderableKey.GHOST_DISABLED) {
+                ReorderableItem(reorderableState, key = ReorderableKey.GHOST_DISABLED) {
                     PreferenceGroup(heading = stringResource(R.string.reorderable_disabled_items)) {
                         PreferenceTemplate(title = { Text(text = stringResource(R.string.reorderable_disabled_hint)) })
                     }
@@ -454,20 +466,22 @@ fun <T, K> PositionalList(
     }
 }
 
-private fun <T, K> Modifier.semanticReorderActions(
+private fun <T, K : Any> Modifier.semanticReorderActions(
     index: Int,
     state: PositionalListState<T, K>,
+    moveUpLabel: String,
+    moveDownLabel: String,
 ) = this.semantics {
     customActions = listOfNotNull(
         if (index > 0) {
-            CustomAccessibilityAction("Move up") {
+            CustomAccessibilityAction(moveUpLabel) {
                 state.moveUp(index)
             }
         } else {
             null
         },
         if (index < state.items.size - 1) {
-            CustomAccessibilityAction("Move down") {
+            CustomAccessibilityAction(moveDownLabel) {
                 state.moveDown(index)
             }
         } else {
@@ -477,7 +491,7 @@ private fun <T, K> Modifier.semanticReorderActions(
 }
 
 @Composable
-private fun <T, K> ReorderableCollectionItemScope.ReorderableItemContainer(
+private fun <T, K : Any> ReorderableCollectionItemScope.ReorderableItemContainer(
     item: PositionalListItem<T, K>,
     active: Boolean,
     onActiveChange: (Boolean) -> Unit,
@@ -531,7 +545,7 @@ private fun <T, K> ReorderableCollectionItemScope.ReorderableItemContainer(
 }
 
 @Composable
-fun <T, K> PositionalListOverflowMenu(
+fun <T, K : Any> PositionalListOverflowMenu(
     state: PositionalListState<T, K>,
     modifier: Modifier = Modifier,
     extraItems: @Composable OverflowMenuScope.(hideMenu: () -> Unit) -> Unit = {},

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/SelectAppsForDrawerFolder.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/SelectAppsForDrawerFolder.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -29,10 +30,10 @@ import app.lawnchair.ui.preferences.components.AppItemPlaceholder
 import app.lawnchair.ui.preferences.components.layout.PreferenceLazyColumn
 import app.lawnchair.ui.preferences.components.layout.PreferenceScaffold
 import app.lawnchair.ui.preferences.components.layout.preferenceGroupItems
-import app.lawnchair.ui.preferences.components.reorderable.PositionalListItem
-import app.lawnchair.ui.preferences.components.reorderable.PositionalListMapper
-import app.lawnchair.ui.preferences.components.reorderable.PositionalListOveflowMenu
 import app.lawnchair.ui.preferences.components.reorderable.PositionalList
+import app.lawnchair.ui.preferences.components.reorderable.PositionalListOverflowMenu
+import app.lawnchair.ui.preferences.components.reorderable.PositionalListState
+import app.lawnchair.ui.preferences.components.reorderable.rememberPositionalListState
 import app.lawnchair.util.App
 import app.lawnchair.util.appsState
 import com.android.launcher3.R
@@ -88,7 +89,7 @@ fun SelectAppsForDrawerFolder(
                 true
             }
         }
-        PositionalListMapper.prepareCategorizedItems(
+        PositionalListState.prepareCategorizedItems(
             allItems = filtered,
             enabledIds = activeIds,
             idSelector = { it.key.toString() },
@@ -97,24 +98,30 @@ fun SelectAppsForDrawerFolder(
 
     val loading = folderEntry == null || apps.isEmpty()
 
+    val state = key(loading) {
+        rememberPositionalListState(
+            items = positionalItems,
+            activeCount = activeCount,
+            onOrderChange = { newList, newCount ->
+                val sorted = PositionalListState.sortInactiveItems(newList, newCount) { it.label }
+                val activeKeys = PositionalListState.getEnabledKeys(sorted, newCount)
+                onUpdate(folderEntry?.title.toString(), activeKeys)
+            },
+            labelSelector = { it.label },
+        )
+    }
+
     PreferenceScaffold(
         label = if (loading) {
             stringResource(R.string.loading)
         } else {
-            stringResource(R.string.x_with_y_count, folderEntry.title, activeCount)
+            stringResource(R.string.x_with_y_count, folderEntry.title, state.activeCount)
         },
         modifier = modifier,
         actions = {
             if (!loading) {
-                PositionalListOveflowMenu(
-                    items = positionalItems,
-                    activeCount = activeCount,
-                    onUpdate = { newList, newCount ->
-                        val sorted = PositionalListMapper.sortInactiveItems(newList, newCount) { it.label }
-                        val activeKeys = PositionalListMapper.getEnabledKeys(sorted, newCount)
-                        onUpdate(folderEntry.title, activeKeys)
-                    },
-                    labelSelector = { it.label },
+                PositionalListOverflowMenu(
+                    state = state,
                 ) { hideMenu ->
                     DropdownMenuItem(
                         onClick = {
@@ -145,13 +152,7 @@ fun SelectAppsForDrawerFolder(
                 }
             } else {
                 PositionalAppListPreference(
-                    items = positionalItems,
-                    activeCount = activeCount,
-                    onOrderChange = { newList, newCount ->
-                        val sorted = PositionalListMapper.sortInactiveItems(newList, newCount) { it.label }
-                        val activeKeys = PositionalListMapper.getEnabledKeys(sorted, newCount)
-                        onUpdate(folderEntry?.title.toString(), activeKeys)
-                    },
+                    state = state,
                     contentPadding = contentPadding,
                 )
             }
@@ -161,16 +162,12 @@ fun SelectAppsForDrawerFolder(
 
 @Composable
 private fun PositionalAppListPreference(
-    items: List<PositionalListItem<App, String>>,
-    activeCount: Int,
-    onOrderChange: (newList: List<PositionalListItem<App, String>>, newEnabledCount: Int) -> Unit,
+    state: PositionalListState<App, String>,
     contentPadding: PaddingValues,
     modifier: Modifier = Modifier,
 ) {
     PositionalList(
-        items = items,
-        activeCount = activeCount,
-        onOrderChange = onOrderChange,
+        state = state,
         itemContent = { app, dragHandle, toggle ->
             AppItem(
                 app = app,
@@ -179,7 +176,6 @@ private fun PositionalAppListPreference(
                 endWidget = toggle,
             )
         },
-        labelSelector = { it.label },
         contentPadding = contentPadding,
         modifier = modifier,
     )

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/SelectAppsForDrawerFolder.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/SelectAppsForDrawerFolder.kt
@@ -30,9 +30,9 @@ import app.lawnchair.ui.preferences.components.layout.PreferenceLazyColumn
 import app.lawnchair.ui.preferences.components.layout.PreferenceScaffold
 import app.lawnchair.ui.preferences.components.layout.preferenceGroupItems
 import app.lawnchair.ui.preferences.components.reorderable.PositionalListItem
-import app.lawnchair.ui.preferences.components.reorderable.PositionalMapper
-import app.lawnchair.ui.preferences.components.reorderable.PositionalOrderMenu
-import app.lawnchair.ui.preferences.components.reorderable.PositionalReorderer
+import app.lawnchair.ui.preferences.components.reorderable.PositionalListMapper
+import app.lawnchair.ui.preferences.components.reorderable.PositionalListOveflowMenu
+import app.lawnchair.ui.preferences.components.reorderable.PositionalList
 import app.lawnchair.util.App
 import app.lawnchair.util.appsState
 import com.android.launcher3.R
@@ -88,7 +88,7 @@ fun SelectAppsForDrawerFolder(
                 true
             }
         }
-        PositionalMapper.prepareCategorizedItems(
+        PositionalListMapper.prepareCategorizedItems(
             allItems = filtered,
             enabledIds = activeIds,
             idSelector = { it.key.toString() },
@@ -106,28 +106,27 @@ fun SelectAppsForDrawerFolder(
         modifier = modifier,
         actions = {
             if (!loading) {
-                PositionalOrderMenu(
+                PositionalListOveflowMenu(
                     items = positionalItems,
                     activeCount = activeCount,
                     onUpdate = { newList, newCount ->
-                        val sorted = PositionalMapper.sortInactiveItems(newList, newCount) { it.label }
-                        val activeKeys = PositionalMapper.getEnabledKeys(sorted, newCount)
+                        val sorted = PositionalListMapper.sortInactiveItems(newList, newCount) { it.label }
+                        val activeKeys = PositionalListMapper.getEnabledKeys(sorted, newCount)
                         onUpdate(folderEntry.title, activeKeys)
                     },
                     labelSelector = { it.label },
-                    additionalContent = { hideMenu ->
-                        DropdownMenuItem(
-                            onClick = {
-                                filterNonUniqueItems = !filterNonUniqueItems
-                                hideMenu()
-                            },
-                            trailingIcon = {
-                                if (filterNonUniqueItems) Icon(Icons.Rounded.Check, null)
-                            },
-                            text = { Text(stringResource(R.string.folders_filter_duplicates)) },
-                        )
-                    },
-                )
+                ) { hideMenu ->
+                    DropdownMenuItem(
+                        onClick = {
+                            filterNonUniqueItems = !filterNonUniqueItems
+                            hideMenu()
+                        },
+                        trailingIcon = {
+                            if (filterNonUniqueItems) Icon(Icons.Rounded.Check, null)
+                        },
+                        text = { Text(stringResource(R.string.folders_filter_duplicates)) },
+                    )
+                }
             }
         },
         isExpandedScreen = LocalIsExpandedScreen.current,
@@ -149,8 +148,8 @@ fun SelectAppsForDrawerFolder(
                     items = positionalItems,
                     activeCount = activeCount,
                     onOrderChange = { newList, newCount ->
-                        val sorted = PositionalMapper.sortInactiveItems(newList, newCount) { it.label }
-                        val activeKeys = PositionalMapper.getEnabledKeys(sorted, newCount)
+                        val sorted = PositionalListMapper.sortInactiveItems(newList, newCount) { it.label }
+                        val activeKeys = PositionalListMapper.getEnabledKeys(sorted, newCount)
                         onUpdate(folderEntry?.title.toString(), activeKeys)
                     },
                     contentPadding = contentPadding,
@@ -162,13 +161,13 @@ fun SelectAppsForDrawerFolder(
 
 @Composable
 private fun PositionalAppListPreference(
-    items: List<PositionalListItem<App>>,
+    items: List<PositionalListItem<App, String>>,
     activeCount: Int,
-    onOrderChange: (newList: List<PositionalListItem<App>>, newEnabledCount: Int) -> Unit,
+    onOrderChange: (newList: List<PositionalListItem<App, String>>, newEnabledCount: Int) -> Unit,
     contentPadding: PaddingValues,
     modifier: Modifier = Modifier,
 ) {
-    PositionalReorderer(
+    PositionalList(
         items = items,
         activeCount = activeCount,
         onOrderChange = onOrderChange,


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Rewrite `PositionalReorder` to `PositionalList`, and change implementation to be state based. This should improve maintainability and pave way for this component to be used by other items, such as the upcoming multiple icons system.

Addresses task of #6442.

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->
1. Go to Home settings > App drawer > App drawer folders
2. Create a folder or update a folder's items
3. Do the following:
  - Drag an item to the top/bottom
  - Press the add or remove actions
  - Tap the overflow item actions
  - See the list change real time
4. Go to app drawer to see the changes reflected

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

:white_check_mark: **Refactor** (A code change that neither fixes a bug nor adds a feature)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reorderable list UI for managing items in separate Enabled and Disabled sections.
  * Supports drag-and-drop reordering across sections, with “move up/down” accessibility actions, haptic feedback, and visual drag hints.
  * Includes item activation toggles plus bulk actions: select/deselect all, swap categories, sort, and reset.
* **Improvements**
  * Updated drawer folder app selection to use the new list experience and refreshed overflow actions, while keeping duplicate-filter controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->