### PR TITLE
feat: add "Customize" shortcut to dock QSB

### DIFF
--- a/lawnchair/src/app/lawnchair/allapps/AllAppsSearchInput.kt
+++ b/lawnchair/src/app/lawnchair/allapps/AllAppsSearchInput.kt
@@ -175,7 +175,6 @@ class AllAppsSearchInput(context: Context, attrs: AttributeSet?) :
                         input.requestFocus()
                         input.showKeyboard()
                     },
-                    onQsbLongClick = {},
                     onStartIconClick = if (shouldShowIcons) {
                         {
                             val launcher = context.launcher

--- a/lawnchair/src/app/lawnchair/allapps/AllAppsSearchInput.kt
+++ b/lawnchair/src/app/lawnchair/allapps/AllAppsSearchInput.kt
@@ -175,6 +175,7 @@ class AllAppsSearchInput(context: Context, attrs: AttributeSet?) :
                         input.requestFocus()
                         input.showKeyboard()
                     },
+                    onQsbLongClick = {},
                     onStartIconClick = if (shouldShowIcons) {
                         {
                             val launcher = context.launcher

--- a/lawnchair/src/app/lawnchair/qsb/LawnQsbLayout.kt
+++ b/lawnchair/src/app/lawnchair/qsb/LawnQsbLayout.kt
@@ -3,6 +3,8 @@ package app.lawnchair.qsb
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.graphics.Rect
+import android.graphics.RectF
 import android.util.AttributeSet
 import android.widget.FrameLayout
 import androidx.compose.runtime.getValue
@@ -12,6 +14,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.view.children
 import androidx.lifecycle.lifecycleScope
+import app.lawnchair.LawnchairLauncher
 import app.lawnchair.animateToAllApps
 import app.lawnchair.launcher
 import app.lawnchair.preferences.observeAsState
@@ -23,13 +26,17 @@ import app.lawnchair.qsb.providers.AppSearch
 import app.lawnchair.qsb.providers.Google
 import app.lawnchair.qsb.providers.PixelSearch
 import app.lawnchair.qsb.providers.QsbSearchProvider
+import app.lawnchair.ui.preferences.PreferenceActivity
+import app.lawnchair.ui.preferences.navigation.Search
 import app.lawnchair.ui.theme.LawnchairTheme
 import app.lawnchair.util.ProvideLifecycleState
 import app.lawnchair.util.repeatOnAttached
 import com.android.launcher3.BaseActivity
 import com.android.launcher3.DeviceProfile
+import com.android.launcher3.R
+import com.android.launcher3.logging.StatsLogManager
 import com.android.launcher3.views.ActivityContext
-import com.patrykmichalik.opto.core.firstBlocking
+import com.android.launcher3.views.OptionsPopupView
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flatMapLatest
@@ -105,6 +112,7 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
                                     }
                                 }
                             },
+                            onQsbLongClick = ::openOptions,
                             onStartIconClick = null,
                             onEndIconClick = { id ->
                                 runCatching {
@@ -142,6 +150,23 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
                     .collect()
             }
         }
+    }
+
+    private fun openOptions() {
+        val launcher = context.launcher
+        val pos = Rect()
+        launcher.dragLayer.getDescendantRectRelativeToSelf(composeView, pos)
+        OptionsPopupView.show<LawnchairLauncher>(launcher, RectF(pos), listOf(getCustomizeOption()), true)
+    }
+
+    private fun getCustomizeOption() = OptionsPopupView.OptionItem(
+        context,
+        R.string.action_customize,
+        R.drawable.ic_setting,
+        StatsLogManager.LauncherEvent.IGNORE,
+    ) {
+        context.startActivity(PreferenceActivity.createIntent(context, Search()))
+        true
     }
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {

--- a/lawnchair/src/app/lawnchair/qsb/LawnQsbUi.kt
+++ b/lawnchair/src/app/lawnchair/qsb/LawnQsbUi.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -127,6 +128,7 @@ data class QsbState(
 @Immutable
 data class QsbActions(
     val onQsbClick: () -> Unit,
+    val onQsbLongClick: () -> Unit,
     val onStartIconClick: (() -> Unit)? = null,
     val onEndIconClick: ((id: QsbIconId) -> Unit),
 )
@@ -342,8 +344,9 @@ fun LawnQsbUi(
         .semantics { contentDescription = state.contentDescription }
         .clip(shape)
         .background(ComposeColor(style.backgroundColor).copy(alpha = style.backgroundAlpha), shape)
-        .clickable(
+        .combinedClickable(
             onClick = actions.onQsbClick,
+            onLongClick = actions.onQsbLongClick,
             interactionSource = remember { MutableInteractionSource() },
             indication = ripple(
                 color = MaterialTheme.colorScheme.onSurface,
@@ -506,6 +509,7 @@ private fun LawnQsbUiPreview() {
             ),
             actions = QsbActions(
                 onQsbClick = {},
+                onQsbLongClick = {},
                 onStartIconClick = {},
                 onEndIconClick = {},
             ),

--- a/lawnchair/src/app/lawnchair/qsb/LawnQsbUi.kt
+++ b/lawnchair/src/app/lawnchair/qsb/LawnQsbUi.kt
@@ -121,6 +121,7 @@ data class QsbState(
  * Defines the click handlers for the various interactive elements within the Quick Search Bar (QSB).
  *
  * @property onQsbClick Callback invoked when the main body of the search bar is clicked.
+ * @property onQsbLongClick Callback invoked when the main body of the search bar is long clicked.
  * @property onStartIconClick Optional callback invoked when the leading icon (e.g., search provider logo) is clicked.
  * @property onEndIconClick Callback invoked when one of the trailing icons (e.g., Mic, Lens, or Clear) is clicked,
  * passing the specific [QsbIconId] of the clicked icon.

--- a/lawnchair/src/app/lawnchair/qsb/LawnQsbUi.kt
+++ b/lawnchair/src/app/lawnchair/qsb/LawnQsbUi.kt
@@ -129,7 +129,7 @@ data class QsbState(
 @Immutable
 data class QsbActions(
     val onQsbClick: () -> Unit,
-    val onQsbLongClick: () -> Unit,
+    val onQsbLongClick: (() -> Unit)? = null,
     val onStartIconClick: (() -> Unit)? = null,
     val onEndIconClick: ((id: QsbIconId) -> Unit),
 )
@@ -510,7 +510,6 @@ private fun LawnQsbUiPreview() {
             ),
             actions = QsbActions(
                 onQsbClick = {},
-                onQsbLongClick = {},
                 onStartIconClick = {},
                 onEndIconClick = {},
             ),

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/search/DockSearchPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/search/DockSearchPreferences.kt
@@ -1,7 +1,6 @@
 package app.lawnchair.ui.preferences.components.search
 
 import androidx.compose.animation.Crossfade
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -219,6 +218,7 @@ private fun DockSearchBarPreview(
                 ),
                 actions = QsbActions(
                     onQsbClick = {},
+                    onQsbLongClick = {},
                     onEndIconClick = {},
                 ),
                 modifier = Modifier.height(48.dp),

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/search/DockSearchPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/search/DockSearchPreferences.kt
@@ -218,7 +218,6 @@ private fun DockSearchBarPreview(
                 ),
                 actions = QsbActions(
                     onQsbClick = {},
-                    onQsbLongClick = {},
                     onEndIconClick = {},
                 ),
                 modifier = Modifier.height(48.dp),


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->
This PR adds a "Customize" pop-up option when long-pressing the dock search bar.

<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/10a38809-f2b8-4911-a057-0b45c115aa3c" />

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->
1. Open Lawnchair
2. Long press on the dock search bar
3. Tap Customize
4. See that the Dock settings page shows up


### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

:white_check_mark: **New feature** (A non-breaking change that adds functionality)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added long-press support to the home screen search bar.
  * Long-pressing the search bar now opens customization options, including access to search preferences.

* **Bug Fixes**
  * Improved search bar interaction handling for click and long-press actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->