### PR TITLE
fix: guard QSB ComposeView measurement in launcher preview to prevent crash

### DIFF
--- a/lawnchair/src/app/lawnchair/qsb/LawnQsbLayout.kt
+++ b/lawnchair/src/app/lawnchair/qsb/LawnQsbLayout.kt
@@ -174,6 +174,11 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
         // Unlike Phone, for Foldable/Tablet we let the original onMeasure do that instead since it
         // matched what we need. It perfectly fit the QSB with the grid.
         if (!dp.deviceProperties.isPhone) {
+            if (!composeView.isAttachedToWindow) {
+                setMeasuredDimension(MeasureSpec.getSize(widthMeasureSpec), MeasureSpec.getSize(heightMeasureSpec))
+                return
+            }
+
             super.onMeasure(widthMeasureSpec, heightMeasureSpec)
             return
         }


### PR DESCRIPTION
### Description

`LawnQsbLayout` embeds a `ComposeView` (added as a child in `onFinishInflate`, composition strategy `DisposeOnDetachedFromWindow`). Its `onMeasure` already guards the phone path with `if (!composeView.isAttachedToWindow) return` to "prevent crash on preview contexts", but the Foldable/Tablet branch (`if (!dp.deviceProperties.isPhone)`) delegates straight to `super.onMeasure(...)` (FrameLayout.onMeasure), which measures the `ComposeView` unconditionally and triggers the recomposer crash in the detached preview. The fix mirrors the existing guard: in the non-phone branch, when `composeView` is not attached to a window, call `setMeasuredDimension(MeasureSpec.getSize(widthMeasureSpec), MeasureSpec.getSize(heightMeasureSpec))` and return before invoking `super.onMeasure`, so the preview skips measuring the ComposeView instead of crashing.

Fixes #6989

### Reasoning

Lawnchair (16 nightly) crashes with `java.lang.IllegalStateException: Cannot locate windowRecomposer; View androidx.compose.ui.platform.ComposeView ... is not attached to a window` when the user taps "Dock" in Settings, and identically when tapping "Create backup" in Backup and restore. Both screens render a launcher preview at the top via `com.android.launcher3.preview.LauncherPreviewRenderer`, which measures/lays out a detached root view that is never attached to a real window. The stack trace runs `LauncherPreviewRenderer.measureAndLayoutRootView -> Hotseat.onMeasure -> LawnQsbLayout.onMeasure -> FrameLayout.onMeasure -> measureChildWithMargins -> ComposeView.onMeasure`, where the embedded `ComposeView` tries to create its composition on first measure and fails to locate a window recomposer.

### Testing

1. Build the 16 nightly variant.
2. Open Settings -> Dock, and Settings -> Backup and restore -> Create backup, on a foldable/tablet form factor.
3. Confirm the launcher preview renders without the `IllegalStateException: Cannot locate windowRecomposer` crash.

### Type of change

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
:x: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layout measurement behavior when the search interface is displayed in preview or detached states.
  * Prevented potential rendering or sizing issues before the interface is attached to the window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->