### PR TITLE
feat: Allow live information to be configured on/off and custom endpoint

### DIFF
--- a/lawnchair/res/values/config.xml
+++ b/lawnchair/res/values/config.xml
@@ -109,6 +109,9 @@
     <string name="pref_key_swipe_right" translatable="false">pref_swipe_right</string>
     <string name="pref_key_swipe_left" translatable="false">pref_swipe_left</string>
 
+    <!-- Live information endpoint -->
+    <string name="config_default_live_information_endpoint" translatable="false">https://lawnchair.app/live-information.json</string>
+
     <bool name="config_default_show_hotseat">true</bool>
     <bool name="config_default_always_reload_icons">true</bool>
     <bool name="config_default_dark_status_bar">false</bool>

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -672,7 +672,7 @@
     <string name="auto_updater_description">Checks for Nightly updates when opening the About screen</string>
 
     <string name="live_information_label">Live information</string>
-    <string name="live_information_description">Displays announcement, and set the default feature flags.</string>
+    <string name="live_information_description">Displays announcement, and set the default feature flags</string>
 
     <string name="wallpaper_blur">Blur wallpaper (experimental)</string>
     <string name="wallpaper_background_blur">Blur intensity</string>

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -671,6 +671,9 @@
     <string name="auto_updater_label">Automatically check for updates</string>
     <string name="auto_updater_description">Checks for Nightly updates when opening the About screen</string>
 
+    <string name="live_information_label">Live information</string>
+    <string name="live_information_description">Displays announcement, and set the default feature flags.</string>
+
     <string name="wallpaper_blur">Blur wallpaper (experimental)</string>
     <string name="wallpaper_background_blur">Blur intensity</string>
     <string name="wallpaper_background_blur_factor">Factor threshold</string>

--- a/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/LiveInformationManager.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/LiveInformationManager.kt
@@ -41,6 +41,11 @@ class LiveInformationManager@Inject constructor(
         defaultValue = context.resources.getBoolean(R.bool.config_default_live_information_enabled),
     )
 
+    val endpoint = preference(
+        key = stringPreferencesKey(name = "endpoint"),
+        defaultValue = context.resources.getString(R.string.config_default_live_information_endpoint),
+    )
+
     val showAnnouncements = preference(
         key = booleanPreferencesKey(name = "show_announcements"),
         defaultValue = context.resources.getBoolean(R.bool.config_default_live_information_show_announcements),

--- a/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/LiveInformationRequest.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/LiveInformationRequest.kt
@@ -3,12 +3,11 @@ package app.lawnchair.ui.preferences.data.liveinfo
 import android.util.Log
 import app.lawnchair.ui.preferences.data.liveinfo.model.LiveInformation
 import app.lawnchair.util.kotlinxJson
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import kotlinx.serialization.json.Json
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.ResponseBody
 import retrofit2.Response
 import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
@@ -31,12 +30,10 @@ suspend fun getLiveInformation(endpoint: String): LiveInformation? = withContext
             return@withContext null
         }
 
-        val response: Response<ResponseBody> = liveInformationService.getLiveInformation(endpoint)
+        val response: Response<LiveInformation> = liveInformationService.getLiveInformation(endpoint)
 
         if (response.isSuccessful) {
-            val responseBody = response.body()?.string() ?: return@withContext null
-
-            val liveInformation = Json.decodeFromString<LiveInformation>(responseBody)
+            val liveInformation = response.body() ?: return@withContext null
             Log.v(TAG, "getLiveInformation: $liveInformation")
 
             return@withContext liveInformation
@@ -44,6 +41,8 @@ suspend fun getLiveInformation(endpoint: String): LiveInformation? = withContext
             Log.d(TAG, "getLiveInformation: response code ${response.code()}")
             return@withContext null
         }
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         Log.e(TAG, "getLiveInformation: Error during news retrieval: ${e.message}")
         return@withContext null

--- a/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/LiveInformationRequest.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/LiveInformationRequest.kt
@@ -6,12 +6,15 @@ import app.lawnchair.util.kotlinxJson
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.ResponseBody
 import retrofit2.Response
 import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
 import retrofit2.create
+
+private const val TAG = "LiveInformationRequest"
 
 private val retrofit = Retrofit.Builder()
     .baseUrl("https://lawnchair.app/")
@@ -20,23 +23,29 @@ private val retrofit = Retrofit.Builder()
 
 val liveInformationService: LiveInformationService = retrofit.create()
 
-suspend fun getLiveInformation(): LiveInformation? = withContext(Dispatchers.IO) {
+suspend fun getLiveInformation(endpoint: String): LiveInformation? = withContext(Dispatchers.IO) {
     try {
-        val response: Response<ResponseBody> = liveInformationService.getLiveInformation()
+        val parsedEndpoint = endpoint.toHttpUrlOrNull()
+        if (parsedEndpoint == null || parsedEndpoint.scheme !in setOf("http", "https")) {
+            Log.w(TAG, "getLiveInformation: Invalid endpoint")
+            return@withContext null
+        }
+
+        val response: Response<ResponseBody> = liveInformationService.getLiveInformation(endpoint)
 
         if (response.isSuccessful) {
             val responseBody = response.body()?.string() ?: return@withContext null
 
             val liveInformation = Json.decodeFromString<LiveInformation>(responseBody)
-            Log.v("LiveInformation", "getLiveInformation: $liveInformation")
+            Log.v(TAG, "getLiveInformation: $liveInformation")
 
             return@withContext liveInformation
         } else {
-            Log.d("LiveInformation", "getLiveInformation: response code ${response.code()}")
+            Log.d(TAG, "getLiveInformation: response code ${response.code()}")
             return@withContext null
         }
     } catch (e: Exception) {
-        Log.e("LiveInformation", "getLiveInformation: Error during news retrieval: ${e.message}")
+        Log.e(TAG, "getLiveInformation: Error during news retrieval: ${e.message}")
         return@withContext null
     }
 }

--- a/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/LiveInformationService.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/LiveInformationService.kt
@@ -3,9 +3,10 @@ package app.lawnchair.ui.preferences.data.liveinfo
 import okhttp3.ResponseBody
 import retrofit2.Response
 import retrofit2.http.GET
+import retrofit2.http.Url
 
 interface LiveInformationService {
 
-    @GET("live-information.json")
-    suspend fun getLiveInformation(): Response<ResponseBody>
+    @GET
+    suspend fun getLiveInformation(@Url endpoint: String): Response<ResponseBody>
 }

--- a/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/LiveInformationService.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/LiveInformationService.kt
@@ -1,6 +1,6 @@
 package app.lawnchair.ui.preferences.data.liveinfo
 
-import okhttp3.ResponseBody
+import app.lawnchair.ui.preferences.data.liveinfo.model.LiveInformation
 import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Url
@@ -8,5 +8,5 @@ import retrofit2.http.Url
 interface LiveInformationService {
 
     @GET
-    suspend fun getLiveInformation(@Url endpoint: String): Response<ResponseBody>
+    suspend fun getLiveInformation(@Url endpoint: String): Response<LiveInformation>
 }

--- a/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/SyncLiveInformation.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/SyncLiveInformation.kt
@@ -12,13 +12,12 @@ fun SyncLiveInformation(
     liveInformationManager: LiveInformationManager = liveInformationManager(),
 ) {
     val enabled by liveInformationManager.enabled.asState()
+    val endpoint by liveInformationManager.endpoint.asState()
 
-    LaunchedEffect(enabled) {
+    LaunchedEffect(enabled, endpoint) {
         if (enabled) {
-            withContext(Dispatchers.IO) {
-                getLiveInformation()?.let { liveInformation ->
-                    liveInformationManager.liveInformation.set(liveInformation)
-                }
+            getLiveInformation(endpoint)?.let { liveInformation ->
+                liveInformationManager.liveInformation.set(liveInformation)
             }
         }
     }

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/DebugMenuPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/DebugMenuPreferences.kt
@@ -88,6 +88,14 @@ fun DebugMenuPreferences(
                     label = "Crash launcher",
                     onClick = { throw RuntimeException("User triggered crash") },
                 )
+                SwitchPreference(
+                    adapter = liveInfoManager.enabled.getAdapter(),
+                    label = "Enable live information",
+                )
+                TextPreference(
+                    adapter = liveInfoManager.endpoint.getAdapter(),
+                    label = "Live information endpoint",
+                )
                 ClickablePreference(
                     label = "Reset live information",
                     onClick = {

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/GeneralPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/GeneralPreferences.kt
@@ -99,19 +99,19 @@ fun GeneralPreferences(modifier: Modifier = Modifier) {
                 description = stringResource(id = R.string.home_screen_rotation_description),
             )
         }
-        if (BuildConfig.APPLICATION_ID.contains("nightly")) {
-            PreferenceGroup(heading = stringResource(id = R.string.updater)) {
+        PreferenceGroup(heading = stringResource(id = R.string.updater)) {
+            if (BuildConfig.APPLICATION_ID.contains("nightly")) {
                 SwitchPreference(
                     adapter = prefs2.autoUpdaterNightly.getAdapter(),
                     label = stringResource(id = R.string.auto_updater_label),
                     description = stringResource(id = R.string.auto_updater_description),
                 )
-                SwitchPreference(
-                    adapter = liveInfoManager.enabled.getAdapter(),
-                    label = stringResource(id = R.string.live_information_label),
-                    description = stringResource(id = R.string.live_information_description),
-                )
             }
+            SwitchPreference(
+                adapter = liveInfoManager.enabled.getAdapter(),
+                label = stringResource(id = R.string.live_information_label),
+                description = stringResource(id = R.string.live_information_description),
+            )
         }
         ExpandAndShrink(visible = prefs2.enableFontSelection.asState().value) {
             PreferenceGroup(heading = stringResource(id = R.string.font_label)) {

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/GeneralPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/GeneralPreferences.kt
@@ -48,6 +48,7 @@ import app.lawnchair.ui.preferences.components.layout.PreferenceGroup
 import app.lawnchair.ui.preferences.components.layout.PreferenceLayout
 import app.lawnchair.ui.preferences.components.notificationDotsEnabled
 import app.lawnchair.ui.preferences.components.notificationServiceEnabled
+import app.lawnchair.ui.preferences.data.liveinfo.liveInformationManager
 import app.lawnchair.ui.preferences.navigation.GeneralIconPack
 import app.lawnchair.ui.preferences.navigation.GeneralIconShape
 import com.android.launcher3.BuildConfig
@@ -59,6 +60,7 @@ fun GeneralPreferences(modifier: Modifier = Modifier) {
     val context = LocalContext.current
     val prefs = preferenceManager()
     val prefs2 = preferenceManager2()
+    val liveInfoManager = liveInformationManager()
     val iconPacks by LocalPreferenceInteractor.current.iconPacks.collectAsStateWithLifecycle()
     val themedIconsAdapter = prefs.themedIcons.getAdapter()
     val drawerThemedIconsAdapter = prefs.drawerThemedIcons.getAdapter()
@@ -103,6 +105,11 @@ fun GeneralPreferences(modifier: Modifier = Modifier) {
                     adapter = prefs2.autoUpdaterNightly.getAdapter(),
                     label = stringResource(id = R.string.auto_updater_label),
                     description = stringResource(id = R.string.auto_updater_description),
+                )
+                SwitchPreference(
+                    adapter = liveInfoManager.enabled.getAdapter(),
+                    label = stringResource(id = R.string.live_information_label),
+                    description = stringResource(id = R.string.live_information_description),
                 )
             }
         }


### PR DESCRIPTION


### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Allow configuration of custom endpoint (or source) for live information in debug, and present a toggle in general settings page for user to turn the feature on/off.

Fixes #5195
Fixes #6944

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Visual

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **New feature** (A non-breaking change that adds functionality)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Live Information controls to General Preferences, including an enable/disable toggle.
  * Added Live Information label/description and announcements-related messaging.
  * Added debug menu options to configure the Live Information endpoint, with a new default endpoint URL.
* **Bug Fixes**
  * Live Information fetching now safely validates the configured endpoint (only well-formed `http/https` URLs); invalid endpoints are handled gracefully without impacting the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->