### PR TITLE
fix: Lay out 3-icon folder previews on the 2x2 grid

### DIFF
--- a/lawnchair/res/values/config.xml
+++ b/lawnchair/res/values/config.xml
@@ -159,6 +159,7 @@
     <item name="config_default_home_icon_size_factor" type="dimen" format="float">1.0</item>
     <item name="config_default_folder_preview_background_opacity" type="dimen" format="float">1.0</item>
     <item name="config_default_folder_background_opacity" type="dimen" format="float">1.0</item>
+    <bool name="config_default_folder_preview_grid_for_three_items">false</bool>
     <item name="config_default_drawer_icon_size_factor" type="dimen" format="float">1.0</item>
     <item name="config_default_home_icon_label_size_factor" type="dimen" format="float">1.0</item>
     <item name="config_default_home_icon_label_folder_size_factor" type="dimen" format="float">1.0</item>

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -861,6 +861,8 @@
     <string name="folder_preview_bg_opacity_label">Icon preview background opacity</string>
     <string name="folder_bg_opacity_label">Folder background opacity</string>
     <string name="folder_preview_bg_color_label">Icon background color</string>
+    <string name="folder_preview_grid_for_three_label">2×2 preview for 3-app folders</string>
+    <string name="folder_preview_grid_for_three_description">Lay out three preview icons on a grid instead of a triangle</string>
 
     <string name="max_folder_columns">Maximum folder columns</string>
     <string name="max_folder_rows">Maximum folder rows</string>

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
@@ -479,6 +479,12 @@ class PreferenceManager2 @Inject constructor(
         onSet = { reloadHelper.reloadGrid() },
     )
 
+    val folderPreviewGridForThreeItems = preference(
+        key = booleanPreferencesKey(name = "folder_preview_grid_for_three_items"),
+        defaultValue = context.resources.getBoolean(R.bool.config_default_folder_preview_grid_for_three_items),
+        onSet = { reloadHelper.reloadGrid() },
+    )
+
     val showIconLabelsOnHomeScreen = preference(
         key = booleanPreferencesKey(name = "show_icon_labels_on_home_screen"),
         defaultValue = context.resources.getBoolean(R.bool.config_default_show_icon_labels_on_home_screen),

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/FolderPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/FolderPreferences.kt
@@ -75,6 +75,11 @@ fun FolderPreferences(
                 valueRange = 0F..1F,
                 showAsPercentage = true,
             )
+            SwitchPreference(
+                adapter = prefs2.folderPreviewGridForThreeItems.getAdapter(),
+                label = stringResource(id = R.string.folder_preview_grid_for_three_label),
+                description = stringResource(id = R.string.folder_preview_grid_for_three_description),
+            )
         }
         PreferenceGroup(heading = stringResource(id = R.string.grid)) {
             SliderPreference(

--- a/src/com/android/launcher3/folder/ClippedFolderIconLayoutRule.java
+++ b/src/com/android/launcher3/folder/ClippedFolderIconLayoutRule.java
@@ -28,12 +28,24 @@ public class ClippedFolderIconLayoutRule {
     private boolean mIsRtl;
     private float mBaselineIconScale;
     private int mNumFolderColumns;
+    // LC-Note: Optional 2x2 grid for 3-item previews; default keeps Launcher3 triangle.
+    private boolean mUseGridForThreeItems;
 
     /**
      * initialize the layout rule
      */
     public void init(int availableSpace, float intrinsicIconSize, boolean rtl,
             int numFolderColumns) {
+        init(availableSpace, intrinsicIconSize, rtl, numFolderColumns, false);
+    }
+
+    /**
+     * initialize the layout rule
+     *
+     * @param useGridForThreeItems LC-Note: when true, 3-item previews use the 2x2 grid
+     */
+    public void init(int availableSpace, float intrinsicIconSize, boolean rtl,
+            int numFolderColumns, boolean useGridForThreeItems) {
         mAvailableSpace = availableSpace;
         mRadius = (
                 Flags.enableLauncherIconShapes()
@@ -43,6 +55,12 @@ public class ClippedFolderIconLayoutRule {
         mIsRtl = rtl;
         mBaselineIconScale = availableSpace / intrinsicIconSize;
         mNumFolderColumns = numFolderColumns;
+        mUseGridForThreeItems = useGridForThreeItems;
+    }
+
+    /** LC-Note: Whether 3-item previews currently use the 2x2 grid. */
+    public boolean useGridForThreeItems() {
+        return mUseGridForThreeItems;
     }
 
     /**
@@ -141,11 +159,10 @@ public class ClippedFolderIconLayoutRule {
         // The case of two items is homomorphic to the case of one.
         curNumItems = Math.max(curNumItems, 2);
 
-        // Lay out 3 items on the same 2x2 grid used by 4-item previews, filling
-        // left-to-right / top-to-bottom (and mirrored for RTL):
+        // LC-Note: Optional 2x2 grid for 3-item previews (default: circular triangle):
         // 0 1
         // 2
-        if (curNumItems == 3) {
+        if (curNumItems == 3 && mUseGridForThreeItems) {
             getGridPosition(index / 2, index % 2, result);
             return;
         }
@@ -158,12 +175,14 @@ public class ClippedFolderIconLayoutRule {
         int direction = mIsRtl ? 1 : -1;
 
         double thetaShift = 0;
-        if (curNumItems == 4) {
+        if (curNumItems == 3) {
+            thetaShift = Math.PI / 2;
+        } else if (curNumItems == 4) {
             thetaShift = Math.PI / 4;
         }
         theta0 += direction * thetaShift;
 
-        // We want the items to appear in reading order. For the case of 1 and 2 items, this
+        // We want the items to appear in reading order. For the case of 1, 2 and 3 items, this
         // is natural for the circular model. With 4 items, however, we need to swap the 3rd and
         // 4th indices to achieve reading order.
         if (curNumItems == 4 && index == 3) {
@@ -207,7 +226,7 @@ public class ClippedFolderIconLayoutRule {
         if (page > 0) {
             scale = MIN_SCALE;
         } else if (numItems <= 2) {
-            // 1–2 items stay larger; 3+ share the 2x2 preview grid and use the smaller scale.
+            // LC-Note: Match 3-item preview icon scale to 4-item folders (was MAX_SCALE for <= 3).
             scale = MAX_SCALE;
         } else {
             scale = MIN_SCALE;
@@ -216,7 +235,9 @@ public class ClippedFolderIconLayoutRule {
     }
 
     private float radiusDilationForItems(int numItems) {
-        if (numItems == MAX_NUM_ITEMS_IN_PREVIEW) {
+        if (numItems == 3) {
+            return 0.15f;
+        } else if (numItems == MAX_NUM_ITEMS_IN_PREVIEW) {
             return 0.12f;
         } else {
             return 0;

--- a/src/com/android/launcher3/folder/ClippedFolderIconLayoutRule.java
+++ b/src/com/android/launcher3/folder/ClippedFolderIconLayoutRule.java
@@ -216,9 +216,7 @@ public class ClippedFolderIconLayoutRule {
     }
 
     private float radiusDilationForItems(int numItems) {
-        if (numItems == 3) {
-            return 0.15f;
-        } else if (numItems == MAX_NUM_ITEMS_IN_PREVIEW) {
+        if (numItems == MAX_NUM_ITEMS_IN_PREVIEW) {
             return 0.12f;
         } else {
             return 0;

--- a/src/com/android/launcher3/folder/ClippedFolderIconLayoutRule.java
+++ b/src/com/android/launcher3/folder/ClippedFolderIconLayoutRule.java
@@ -141,6 +141,15 @@ public class ClippedFolderIconLayoutRule {
         // The case of two items is homomorphic to the case of one.
         curNumItems = Math.max(curNumItems, 2);
 
+        // Lay out 3 items on the same 2x2 grid used by 4-item previews, filling
+        // left-to-right / top-to-bottom (and mirrored for RTL):
+        // 0 1
+        // 2
+        if (curNumItems == 3) {
+            getGridPosition(index / 2, index % 2, result);
+            return;
+        }
+
         // We model the preview as a circle of items starting in the appropriate piece of the
         // upper left quadrant (to achieve horizontal and vertical symmetry).
         double theta0 = mIsRtl ? 0 : Math.PI;
@@ -149,14 +158,12 @@ public class ClippedFolderIconLayoutRule {
         int direction = mIsRtl ? 1 : -1;
 
         double thetaShift = 0;
-        if (curNumItems == 3) {
-            thetaShift = Math.PI / 2;
-        } else if (curNumItems == 4) {
+        if (curNumItems == 4) {
             thetaShift = Math.PI / 4;
         }
         theta0 += direction * thetaShift;
 
-        // We want the items to appear in reading order. For the case of 1, 2 and 3 items, this
+        // We want the items to appear in reading order. For the case of 1 and 2 items, this
         // is natural for the circular model. With 4 items, however, we need to swap the 3rd and
         // 4th indices to achieve reading order.
         if (curNumItems == 4 && index == 3) {
@@ -199,7 +206,8 @@ public class ClippedFolderIconLayoutRule {
         float scale;
         if (page > 0) {
             scale = MIN_SCALE;
-        } else if (numItems <= 3) {
+        } else if (numItems <= 2) {
+            // 1–2 items stay larger; 3+ share the 2x2 preview grid and use the smaller scale.
             scale = MAX_SCALE;
         } else {
             scale = MIN_SCALE;

--- a/src/com/android/launcher3/folder/PreviewItemManager.java
+++ b/src/com/android/launcher3/folder/PreviewItemManager.java
@@ -57,6 +57,8 @@ import java.util.List;
 import java.util.function.Predicate;
 
 import app.lawnchair.preferences.PreferenceManager;
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
+import app.lawnchair.preferences2.PreferenceManager2;
 
 /**
  * Manages the drawing and animations of {@link PreviewItemDrawingParams} for a
@@ -124,8 +126,13 @@ public class PreviewItemManager {
     }
 
     private void computePreviewDrawingParams(int drawableSize, int totalSize) {
+        // LC-Note: Optional 2x2 grid for 3-item folder previews (Folders > General).
+        boolean useGridForThreeItems = PreferenceCacheExtensionsKt.firstCached(
+                PreferenceManager2.INSTANCE.get(mIcon.getContext())
+                        .getFolderPreviewGridForThreeItems());
         if (mIntrinsicIconSize != drawableSize || mTotalWidth != totalSize ||
-                mPrevTopPadding != mIcon.getPaddingTop()) {
+                mPrevTopPadding != mIcon.getPaddingTop() ||
+                mIcon.mPreviewLayoutRule.useGridForThreeItems() != useGridForThreeItems) {
             mIntrinsicIconSize = drawableSize;
             mTotalWidth = totalSize;
             mPrevTopPadding = mIcon.getPaddingTop();
@@ -135,7 +142,8 @@ public class PreviewItemManager {
             mIcon.mPreviewLayoutRule.init(
                     mIcon.mBackground.previewSize, mIntrinsicIconSize,
                     Utilities.isRtl(mIcon.getResources()),
-                    mIcon.mActivity.getDeviceProfile().numFolderColumns
+                    mIcon.mActivity.getDeviceProfile().numFolderColumns,
+                    useGridForThreeItems
             );
             updatePreviewItems(false);
         }


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

Lay out 3-app folder previews on the same 2×2 grid used by 4-app folders (left-to-right, top-to-bottom) instead of the triangular circular arrangement, and match their icon scale to 4-item previews.

### Reasoning

Folder preview icons used a circular layout. With exactly three apps that produced a centered triangle, which looked inconsistent next to 2×2 folders. Filling the existing grid slots (`OO` / `O`) keeps reading order and visual alignment with other folder previews.

<img width="960"  alt="group" src="https://github.com/user-attachments/assets/1ae0070a-ab76-4ba8-9b48-f30dc1cc000c" />

### Testing

1. Find or create a folder with exactly 3 apps.
2. Confirm the preview shows two icons on the top row and one on the bottom-left (bottom-right empty), not a triangle.
3. Compare with a 4-app folder: icon size and cell alignment should match.
4. (RTL) If available, confirm the third icon sits on the bottom-right (start side).

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
:white_check_mark: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an optional 2×2 grid preview layout for three-app folders, instead of the previous triangular arrangement.

* **Bug Fixes**
  * Improved three-item folder preview positioning and balancing.
  * Refined related spacing/placement behavior to keep four-item folder previews consistent.

* **Settings**
  * Introduced a new folder preview toggle to enable/disable the 2×2 grid for three-item folders (default: off).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->