### PR TITLE
feat: Add 2x2/3x3 folder preview grid setting

### DIFF
--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -861,6 +861,9 @@
     <string name="folder_preview_bg_opacity_label">Icon preview background opacity</string>
     <string name="folder_bg_opacity_label">Folder background opacity</string>
     <string name="folder_preview_bg_color_label">Icon background color</string>
+    <string name="folder_preview_grid_label">Preview icons</string>
+    <string name="folder_preview_grid_2x2">2×2 (4 icons)</string>
+    <string name="folder_preview_grid_3x3">3×3 (9 icons)</string>
 
     <string name="max_folder_columns">Maximum folder columns</string>
     <string name="max_folder_rows">Maximum folder rows</string>

--- a/lawnchair/src/app/lawnchair/folder/FolderPreviewConfig.kt
+++ b/lawnchair/src/app/lawnchair/folder/FolderPreviewConfig.kt
@@ -27,12 +27,10 @@ import com.android.launcher3.util.Executors
 object FolderPreviewConfig {
 
     @JvmStatic
-    fun getActiveItemCount(context: Context): Int =
-        PreferenceManager2.getInstance(context).folderPreviewGridSize.firstCached().itemCount
+    fun getActiveItemCount(context: Context): Int = PreferenceManager2.getInstance(context).folderPreviewGridSize.firstCached().itemCount
 
     @JvmStatic
-    fun getGridSide(context: Context): Int =
-        PreferenceManager2.getInstance(context).folderPreviewGridSize.firstCached().sideLength
+    fun getGridSide(context: Context): Int = PreferenceManager2.getInstance(context).folderPreviewGridSize.firstCached().sideLength
 
     /**
      * Reapplies the preview grid on workspace/hotseat folder icons and rebinds the app drawer

--- a/lawnchair/src/app/lawnchair/folder/FolderPreviewConfig.kt
+++ b/lawnchair/src/app/lawnchair/folder/FolderPreviewConfig.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026, Lawnchair
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.lawnchair.folder
+
+import android.content.Context
+import app.lawnchair.LawnchairApp
+import app.lawnchair.preferences2.PreferenceManager2
+import app.lawnchair.preferences2.firstCached
+import com.android.launcher3.folder.FolderIcon
+import com.android.launcher3.util.Executors
+
+/** Reads the active closed-folder preview grid preference for AOSP callers. */
+object FolderPreviewConfig {
+
+    @JvmStatic
+    fun getActiveItemCount(context: Context): Int =
+        PreferenceManager2.getInstance(context).folderPreviewGridSize.firstCached().itemCount
+
+    @JvmStatic
+    fun getGridSide(context: Context): Int =
+        PreferenceManager2.getInstance(context).folderPreviewGridSize.firstCached().sideLength
+
+    /**
+     * Reapplies the preview grid on workspace/hotseat folder icons and rebinds the app drawer
+     * so folder previews update without restarting the launcher.
+     */
+    @JvmStatic
+    fun refreshAllFolderIcons(context: Context) {
+        Executors.MAIN_EXECUTOR.execute {
+            val launcher = LawnchairApp.launcher ?: return@execute
+            launcher.workspace.mapOverItems { _, view ->
+                if (view is FolderIcon) {
+                    view.refreshPreviewGrid()
+                }
+                false
+            }
+            launcher.appsView?.rebindAdaptersForFolderPreviewChange()
+        }
+    }
+}

--- a/lawnchair/src/app/lawnchair/folder/FolderPreviewGrid.kt
+++ b/lawnchair/src/app/lawnchair/folder/FolderPreviewGrid.kt
@@ -39,12 +39,9 @@ enum class FolderPreviewGrid(
     ;
 
     companion object {
-        fun valuesList() = entries.toList()
+        fun fromString(value: String?): FolderPreviewGrid = entries.firstOrNull { it.name == value } ?: TWO_BY_TWO
 
-        fun fromString(value: String?): FolderPreviewGrid =
-            valuesList().firstOrNull { it.name == value } ?: TWO_BY_TWO
-
-        fun preferenceEntries(): List<ListPreferenceEntry<FolderPreviewGrid>> = valuesList().map {
+        fun preferenceEntries(): List<ListPreferenceEntry<FolderPreviewGrid>> = entries.map {
             ListPreferenceEntry(value = it) { stringResource(id = it.labelResourceId) }
         }
     }

--- a/lawnchair/src/app/lawnchair/folder/FolderPreviewGrid.kt
+++ b/lawnchair/src/app/lawnchair/folder/FolderPreviewGrid.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026, Lawnchair
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.lawnchair.folder
+
+import androidx.annotation.StringRes
+import androidx.compose.ui.res.stringResource
+import app.lawnchair.ui.preferences.components.controls.ListPreferenceEntry
+import com.android.launcher3.R
+
+enum class FolderPreviewGrid(
+    val itemCount: Int,
+    val sideLength: Int,
+    @StringRes val labelResourceId: Int,
+) {
+    TWO_BY_TWO(
+        itemCount = 4,
+        sideLength = 2,
+        labelResourceId = R.string.folder_preview_grid_2x2,
+    ),
+    THREE_BY_THREE(
+        itemCount = 9,
+        sideLength = 3,
+        labelResourceId = R.string.folder_preview_grid_3x3,
+    ),
+    ;
+
+    companion object {
+        fun valuesList() = entries.toList()
+
+        fun fromString(value: String?): FolderPreviewGrid =
+            valuesList().firstOrNull { it.name == value } ?: TWO_BY_TWO
+
+        fun preferenceEntries(): List<ListPreferenceEntry<FolderPreviewGrid>> = valuesList().map {
+            ListPreferenceEntry(value = it) { stringResource(id = it.labelResourceId) }
+        }
+    }
+}

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
@@ -29,6 +29,8 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import app.lawnchair.data.Converters
+import app.lawnchair.folder.FolderPreviewConfig
+import app.lawnchair.folder.FolderPreviewGrid
 import app.lawnchair.font.FontCache
 import app.lawnchair.gestures.config.GestureHandlerConfig
 import app.lawnchair.gestures.handlers.SleepMode
@@ -471,6 +473,14 @@ class PreferenceManager2 @Inject constructor(
         key = floatPreferencesKey(name = "folder_preview_background_opacity"),
         defaultValue = resourceProvider.getFloat(R.dimen.config_default_folder_preview_background_opacity),
         onSet = { reloadHelper.reloadGrid() },
+    )
+
+    val folderPreviewGridSize = preference(
+        key = stringPreferencesKey(name = "folder_preview_grid_size"),
+        defaultValue = FolderPreviewGrid.TWO_BY_TWO,
+        parse = { FolderPreviewGrid.fromString(it) },
+        save = { it.name },
+        onSet = { FolderPreviewConfig.refreshAllFolderIcons(context) },
     )
 
     val folderBackgroundOpacity = preference(

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/FolderPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/FolderPreferences.kt
@@ -20,12 +20,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import app.lawnchair.folder.FolderPreviewGrid
 import app.lawnchair.preferences.getAdapter
 import app.lawnchair.preferences.preferenceManager
 import app.lawnchair.preferences2.preferenceManager2
 import app.lawnchair.ui.preferences.LocalIsExpandedScreen
 import app.lawnchair.ui.preferences.components.NavigationActionPreference
 import app.lawnchair.ui.preferences.components.colorpreference.ColorPreference
+import app.lawnchair.ui.preferences.components.controls.ListPreference
 import app.lawnchair.ui.preferences.components.controls.SliderPreference
 import app.lawnchair.ui.preferences.components.controls.SwitchPreference
 import app.lawnchair.ui.preferences.components.layout.ExpandAndShrink
@@ -61,6 +63,11 @@ fun FolderPreferences(
                 },
             )
             ColorPreference(preference = prefs2.folderColor)
+            ListPreference(
+                adapter = prefs2.folderPreviewGridSize.getAdapter(),
+                entries = FolderPreviewGrid.preferenceEntries(),
+                label = stringResource(id = R.string.folder_preview_grid_label),
+            )
             SliderPreference(
                 label = stringResource(id = R.string.folder_preview_bg_opacity_label),
                 adapter = prefs2.folderPreviewBackgroundOpacity.getAdapter(),

--- a/src/com/android/launcher3/allapps/ActivityAllAppsContainerView.java
+++ b/src/com/android/launcher3/allapps/ActivityAllAppsContainerView.java
@@ -1298,6 +1298,15 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
         }
     }
 
+    /** Rebinds all-apps lists so folder preview icons pick up preference changes. */
+    public void rebindAdaptersForFolderPreviewChange() {
+        forAllRecyclerViews(rv -> {
+            if (rv.getAdapter() != null) {
+                rv.getAdapter().notifyDataSetChanged();
+            }
+        });
+    }
+
     /** The current focus change listener in the search container. */
     public OnFocusChangeListener getSearchFocusChangeListener() {
         return mAH.get(AdapterHolder.SEARCH).mOnFocusChangeListener;

--- a/src/com/android/launcher3/folder/ClippedFolderIconLayoutRule.java
+++ b/src/com/android/launcher3/folder/ClippedFolderIconLayoutRule.java
@@ -1,48 +1,76 @@
 package com.android.launcher3.folder;
 
-import com.android.launcher3.Flags;
-
+/**
+ * Layout rule for icons shown on a closed folder preview.
+ *
+ * {@link #MAX_NUM_ITEMS_IN_PREVIEW} is the absolute ceiling (3×3). The active preview count
+ * (4 or 9) comes from the user preference and is applied via {@link #init}.
+ */
 public class ClippedFolderIconLayoutRule {
 
-    public static final int MAX_NUM_ITEMS_IN_PREVIEW = 4;
-    private static final int MIN_NUM_ITEMS_IN_PREVIEW = 2;
+    /** Absolute maximum icons that can appear in a folder preview (3×3). */
+    public static final int MAX_NUM_ITEMS_IN_PREVIEW = 9;
+    /** Default preview count when no preference is available (2×2). */
+    public static final int DEFAULT_NUM_ITEMS_IN_PREVIEW = 4;
+    public static final int DEFAULT_PREVIEW_GRID_SIDE = 2;
+
+    private static final int MIN_NUM_ITEMS_FOR_SCALE = 2;
 
     public static final float MIN_SCALE = 0.44f;
     public static final float MAX_SCALE = 0.51f;
+    /** Scale used when the preview grid is 3×3 so nine icons fit without overlap. */
+    public static final float GRID_3X3_SCALE = 0.31f;
 
-    // TODO: figure out exact radius for different icons
     private static final float MAX_RADIUS_DILATION = 0.25f;
     // The max amount of overlap the preview items can go outside of the background bounds.
     public static final float ICON_OVERLAP_FACTOR = 1 + (MAX_RADIUS_DILATION / 2f);
-    private static final float ITEM_RADIUS_SCALE_FACTOR = 1.15f;
-    private static final float ITEM_RADIUS_SCALE_FACTOR_SHAPES = 1.2f;
 
     public static final int EXIT_INDEX = -2;
     public static final int ENTER_INDEX = -3;
 
-    private float[] mTmpPoint = new float[2];
+    private final float[] mTmpPoint = new float[2];
 
     private float mAvailableSpace;
-    private float mRadius;
     private float mIconSize;
     private boolean mIsRtl;
     private float mBaselineIconScale;
-    private int mNumFolderColumns;
+    private int mActivePreviewCount = DEFAULT_NUM_ITEMS_IN_PREVIEW;
+    private int mPreviewGridSide = DEFAULT_PREVIEW_GRID_SIDE;
 
     /**
-     * initialize the layout rule
+     * Initialize the layout rule.
      */
     public void init(int availableSpace, float intrinsicIconSize, boolean rtl,
             int numFolderColumns) {
+        init(availableSpace, intrinsicIconSize, rtl, numFolderColumns,
+                DEFAULT_NUM_ITEMS_IN_PREVIEW, DEFAULT_PREVIEW_GRID_SIDE);
+    }
+
+    /**
+     * Initialize the layout rule with an active preview grid from preferences.
+     *
+     * @param activePreviewCount number of icons shown on the closed folder (4 or 9)
+     * @param previewGridSide    grid side length (2 or 3)
+     */
+    public void init(int availableSpace, float intrinsicIconSize, boolean rtl,
+            int numFolderColumns, int activePreviewCount, int previewGridSide) {
         mAvailableSpace = availableSpace;
-        mRadius = (
-                Flags.enableLauncherIconShapes()
-                        ? ITEM_RADIUS_SCALE_FACTOR_SHAPES
-                        : ITEM_RADIUS_SCALE_FACTOR) * availableSpace / 2f;
         mIconSize = intrinsicIconSize;
         mIsRtl = rtl;
         mBaselineIconScale = availableSpace / intrinsicIconSize;
-        mNumFolderColumns = numFolderColumns;
+        mActivePreviewCount = Math.min(Math.max(activePreviewCount, MIN_NUM_ITEMS_FOR_SCALE),
+                MAX_NUM_ITEMS_IN_PREVIEW);
+        mPreviewGridSide = Math.max(previewGridSide, DEFAULT_PREVIEW_GRID_SIDE);
+    }
+
+    /** Active number of icons shown in the closed-folder preview. */
+    public int getActivePreviewItemCount() {
+        return mActivePreviewCount;
+    }
+
+    /** Side length of the active preview grid (2 or 3). */
+    public int getPreviewGridSide() {
+        return mPreviewGridSide;
     }
 
     /**
@@ -59,18 +87,16 @@ public class ClippedFolderIconLayoutRule {
         float transY;
 
         if (index == EXIT_INDEX) {
-            // 0 1 * <-- Exit position (row 0, col 2)
-            // 2 3
-            getGridPosition(0, 2, mTmpPoint);
+            // Past the trailing column on the top row.
+            getGridPosition(0, mPreviewGridSide, totalScale, mTmpPoint);
         } else if (index == ENTER_INDEX) {
-            // 0 1
-            // 2 3 * <-- Enter position (row 1, col 2)
-            getGridPosition(1, 2, mTmpPoint);
-        } else if (index >= MAX_NUM_ITEMS_IN_PREVIEW) {
+            // Past the trailing column on the bottom preview row.
+            getGridPosition(mPreviewGridSide - 1, mPreviewGridSide, totalScale, mTmpPoint);
+        } else if (index >= mActivePreviewCount) {
             // Items beyond those displayed in the preview are animated to the center
             mTmpPoint[0] = mTmpPoint[1] = mAvailableSpace / 2 - (mIconSize * totalScale) / 2;
         } else {
-            getPosition(index, curNumItems, mTmpPoint);
+            getPosition(index, totalScale, mTmpPoint);
         }
 
         transX = mTmpPoint[0];
@@ -85,23 +111,21 @@ public class ClippedFolderIconLayoutRule {
     }
 
     /**
-     * Computes positions for icons in folder as part of spring animation. Here both preview icons
-     * and the rest of the content icons are animated along the same grid.
-     *
-     * @param index          index of icon in folder
-     * @param numItemsInPage current number of items in page
-     * @param params         params to update for icon
+     * Computes positions for icons in folder as part of spring animation.
+     * Indices below the active preview count use the closed-folder preview grid (reading order);
+     * higher indices collapse to the preview center.
      */
     public PreviewItemDrawingParams computeSpringAnimationItemParams(int index, int numItemsInPage,
             int page, PreviewItemDrawingParams params) {
-        float totalScale = scaleForItem(numItemsInPage, page);
+        int previewCount = Math.min(Math.max(numItemsInPage, 1), mActivePreviewCount);
+        float totalScale = scaleForItem(previewCount, 0);
         float transX;
         float transY;
 
-        if (numItemsInPage <= MAX_NUM_ITEMS_IN_PREVIEW) {
-            getPosition(index, numItemsInPage, mTmpPoint);
+        if (index < mActivePreviewCount) {
+            getPosition(index, totalScale, mTmpPoint);
         } else {
-            getGridPosition(index / mNumFolderColumns, index % mNumFolderColumns, mTmpPoint);
+            mTmpPoint[0] = mTmpPoint[1] = mAvailableSpace / 2 - (mIconSize * totalScale) / 2;
         }
 
         transX = mTmpPoint[0];
@@ -115,78 +139,23 @@ public class ClippedFolderIconLayoutRule {
         return params;
     }
 
-
     /**
-     * Builds a grid based on the positioning of the items when there are
-     * {@link #MAX_NUM_ITEMS_IN_PREVIEW} in the preview.
+     * Places an icon in the preview (or extended) grid.
      *
-     * Positions in the grid: 0 1  // 0 is row 0, col 1
-     * 2 3  // 3 is row 1, col 1`
+     * Columns past {@link #mPreviewGridSide} are used for ENTER/EXIT animations.
+     * RTL mirrors columns so reading order stays start-to-end.
      */
-    private void getGridPosition(int row, int col, float[] result) {
-        // We use position 0 and 3 to calculate the x and y distances between items.
-        getPosition(0, 4, result);
-        float left = result[0];
-        float top = result[1];
-
-        getPosition(3, 4, result);
-        float dx = result[0] - left;
-        float dy = result[1] - top;
-
-        result[0] = left + (col * dx);
-        result[1] = top + (row * dy);
+    private void getGridPosition(int row, int col, float iconScale, float[] result) {
+        float iconSize = mIconSize * iconScale;
+        float cell = mAvailableSpace / (float) mPreviewGridSide;
+        int visualCol = mIsRtl ? (mPreviewGridSide - 1 - col) : col;
+        result[0] = visualCol * cell + (cell - iconSize) / 2f;
+        result[1] = row * cell + (cell - iconSize) / 2f;
     }
 
-    private void getPosition(int index, int curNumItems, float[] result) {
-        // The case of two items is homomorphic to the case of one.
-        curNumItems = Math.max(curNumItems, 2);
-
-        // We model the preview as a circle of items starting in the appropriate piece of the
-        // upper left quadrant (to achieve horizontal and vertical symmetry).
-        double theta0 = mIsRtl ? 0 : Math.PI;
-
-        // In RTL we go counterclockwise
-        int direction = mIsRtl ? 1 : -1;
-
-        double thetaShift = 0;
-        if (curNumItems == 3) {
-            thetaShift = Math.PI / 2;
-        } else if (curNumItems == 4) {
-            thetaShift = Math.PI / 4;
-        }
-        theta0 += direction * thetaShift;
-
-        // We want the items to appear in reading order. For the case of 1, 2 and 3 items, this
-        // is natural for the circular model. With 4 items, however, we need to swap the 3rd and
-        // 4th indices to achieve reading order.
-        if (curNumItems == 4 && index == 3) {
-            index = 2;
-        } else if (curNumItems == 4 && index == 2) {
-            index = 3;
-        }
-
-        float radius = getRadius(curNumItems);
-        double theta = theta0 + index * (2 * Math.PI / curNumItems) * direction;
-        float halfIconSize = (mIconSize * scaleForItem(curNumItems, 0)) / 2;
-
-        // Map the location along the circle, and offset the coordinates to represent the center
-        // of the icon, and to be based from the top / left of the preview area. The y component
-        // is inverted to match the coordinate system.
-        result[0] = mAvailableSpace / 2 + (float) (radius * Math.cos(theta) / 2) - halfIconSize;
-        result[1] = mAvailableSpace / 2 + (float) (-radius * Math.sin(theta) / 2) - halfIconSize;
-    }
-
-    private float getRadius(int numItems) {
-        float radiusDilation = Flags.enableLauncherIconShapes() ? radiusDilationForItems(numItems)
-                : MAX_RADIUS_DILATION;
-        if (Flags.enableLauncherIconShapes()) {
-            // Just give custom radius weights for each # of icons.
-            return mRadius * (1 + radiusDilation);
-        } else {
-            // Increase radius from 0 up to MAX_RADIUS_DILATION as the number of items increases.
-            return mRadius * (1 + radiusDilation * (numItems - MIN_NUM_ITEMS_IN_PREVIEW)
-                    / (MAX_NUM_ITEMS_IN_PREVIEW - MIN_NUM_ITEMS_IN_PREVIEW));
-        }
+    /** Fills the active preview grid left-to-right / top-to-bottom. */
+    private void getPosition(int index, float iconScale, float[] result) {
+        getGridPosition(index / mPreviewGridSide, index % mPreviewGridSide, iconScale, result);
     }
 
     /**
@@ -197,24 +166,17 @@ public class ClippedFolderIconLayoutRule {
      */
     public float scaleForItem(int numItems, int page) {
         float scale;
-        if (page > 0) {
+        if (mPreviewGridSide >= 3) {
+            // Keep single/dual icons a bit larger; everything else uses the tight 3×3 scale.
+            scale = numItems <= 2 ? MAX_SCALE : GRID_3X3_SCALE;
+        } else if (page > 0) {
             scale = MIN_SCALE;
-        } else if (numItems <= 3) {
+        } else if (numItems <= 2) {
             scale = MAX_SCALE;
         } else {
             scale = MIN_SCALE;
         }
         return scale * mBaselineIconScale;
-    }
-
-    private float radiusDilationForItems(int numItems) {
-        if (numItems == 3) {
-            return 0.15f;
-        } else if (numItems == MAX_NUM_ITEMS_IN_PREVIEW) {
-            return 0.12f;
-        } else {
-            return 0;
-        }
     }
 
     public float getIconSize() {

--- a/src/com/android/launcher3/folder/Folder.java
+++ b/src/com/android/launcher3/folder/Folder.java
@@ -1363,6 +1363,7 @@ public class Folder extends AbstractFloatingView implements ClipPathView, DragSo
 
     private void updateItemLocationsInDatabaseBatch(boolean isBind) {
         FolderGridOrganizer verifier = createFolderGridOrganizer(
+                mActivityContext.asContext(),
                 mActivityContext.getDeviceProfile()
         ).setFolderInfo(mInfo);
 
@@ -1703,6 +1704,7 @@ public class Folder extends AbstractFloatingView implements ClipPathView, DragSo
 
         if (!mSuppressContentUpdate) {
             FolderGridOrganizer verifier = createFolderGridOrganizer(
+                    mActivityContext.asContext(),
                     mActivityContext.getDeviceProfile()).setFolderInfo(mInfo);
             verifier.updateRankAndPos(item, rank);
             mActivityContext.getModelWriter().addOrMoveItemInDatabase(item, mInfo.id, 0,

--- a/src/com/android/launcher3/folder/FolderAnimationManager.java
+++ b/src/com/android/launcher3/folder/FolderAnimationManager.java
@@ -20,7 +20,6 @@ import static android.view.View.ALPHA;
 
 import static com.android.launcher3.BubbleTextView.TEXT_ALPHA_PROPERTY;
 import static com.android.launcher3.LauncherAnimUtils.SCALE_PROPERTY;
-import static com.android.launcher3.folder.ClippedFolderIconLayoutRule.MAX_NUM_ITEMS_IN_PREVIEW;
 import static com.android.launcher3.folder.FolderGridOrganizer.createFolderGridOrganizer;
 
 import android.animation.Animator;
@@ -105,7 +104,7 @@ public class FolderAnimationManager implements FolderAnimationCreator {
 
         mContext = folder.getContext();
         mDeviceProfile = folder.mActivityContext.getDeviceProfile();
-        mPreviewVerifier = createFolderGridOrganizer(mDeviceProfile);
+        mPreviewVerifier = createFolderGridOrganizer(mContext, mDeviceProfile);
 
         mIsOpening = true;
 
@@ -377,7 +376,7 @@ public class FolderAnimationManager implements FolderAnimationCreator {
                 isOnFirstPage ? 0 : mFolder.mContent.getCurrentPage());
         final int numItemsInPreview = itemsInPreview.size();
         final int numItemsInFirstPagePreview = isOnFirstPage
-                ? numItemsInPreview : MAX_NUM_ITEMS_IN_PREVIEW;
+                ? numItemsInPreview : mPreviewVerifier.getPreviewMaxItems();
 
         TimeInterpolator previewItemInterpolator = getPreviewItemInterpolator();
 
@@ -429,7 +428,7 @@ public class FolderAnimationManager implements FolderAnimationCreator {
             scaleAnimator.setInterpolator(previewItemInterpolator);
             play(animatorSet, scaleAnimator);
 
-            if (mFolder.getItemCount() > MAX_NUM_ITEMS_IN_PREVIEW) {
+            if (mFolder.getItemCount() > mPreviewVerifier.getPreviewMaxItems()) {
                 // These delays allows the preview items to move as part of the Folder's motion,
                 // and its only necessary for large folders because of differing interpolators.
                 int delay = mIsOpening ? mDelay : mDelay * 2;
@@ -479,7 +478,7 @@ public class FolderAnimationManager implements FolderAnimationCreator {
     }
 
     private boolean isLargeFolder() {
-        return mFolder.getItemCount() > MAX_NUM_ITEMS_IN_PREVIEW;
+        return mFolder.getItemCount() > mPreviewVerifier.getPreviewMaxItems();
     }
 
     private Interpolator getPreviewItemInterpolator() {

--- a/src/com/android/launcher3/folder/FolderAnimationSpringBuilderManager.kt
+++ b/src/com/android/launcher3/folder/FolderAnimationSpringBuilderManager.kt
@@ -74,7 +74,10 @@ class FolderAnimationSpringBuilderManager(
     companion object {
         /** Returns the list of "preview items" on {@param page}. */
         fun getPreviewIconsOnPage(folder: Folder, page: Int): List<View> {
-            return createFolderGridOrganizer(folder.mActivityContext.deviceProfile)
+            return createFolderGridOrganizer(
+                    folder.mActivityContext.asContext(),
+                    folder.mActivityContext.deviceProfile,
+                )
                 .setFolderInfo(folder.mInfo)
                 .previewItemsForPage(page, folder.iconsInReadingOrder)
         }

--- a/src/com/android/launcher3/folder/FolderGridOrganizer.java
+++ b/src/com/android/launcher3/folder/FolderGridOrganizer.java
@@ -16,8 +16,9 @@
 
 package com.android.launcher3.folder;
 
-import static com.android.launcher3.folder.ClippedFolderIconLayoutRule.MAX_NUM_ITEMS_IN_PREVIEW;
+import static com.android.launcher3.folder.ClippedFolderIconLayoutRule.DEFAULT_NUM_ITEMS_IN_PREVIEW;
 
+import android.content.Context;
 import android.graphics.Point;
 import android.util.Log;
 
@@ -28,6 +29,8 @@ import com.android.launcher3.model.data.ItemInfo;
 import java.util.ArrayList;
 import java.util.List;
 
+import app.lawnchair.folder.FolderPreviewConfig;
+
 /**
  * Utility class for managing item positions in a folder based on rank
  */
@@ -37,28 +40,48 @@ public class FolderGridOrganizer {
     private final int mMaxCountX;
     private final int mMaxCountY;
     private final int mMaxItemsPerPage;
+    private final int mPreviewMaxItems;
 
     private int mNumItemsInFolder;
     private int mCountX;
     private int mCountY;
-    private boolean mDisplayingUpperLeftQuadrant = false;
-    private static final int PREVIEW_MAX_ROWS = 2;
-    private static final int PREVIEW_MAX_COLUMNS = 2;
 
     /**
      * Note: must call {@link #setFolderInfo(FolderInfo)} manually for verifier to work.
      */
     public FolderGridOrganizer(int maxCountX, int maxCountY) {
-        mMaxCountX = maxCountX;
-        mMaxCountY = maxCountY;
-        mMaxItemsPerPage = mMaxCountX * mMaxCountY;
+        this(maxCountX, maxCountY, DEFAULT_NUM_ITEMS_IN_PREVIEW);
     }
 
     /**
-     * Creates a FolderGridOrganizer for the given DeviceProfile
+     * Creates an organizer with an explicit closed-folder preview item count.
+     */
+    public FolderGridOrganizer(int maxCountX, int maxCountY, int previewMaxItems) {
+        mMaxCountX = maxCountX;
+        mMaxCountY = maxCountY;
+        mMaxItemsPerPage = mMaxCountX * mMaxCountY;
+        mPreviewMaxItems = previewMaxItems;
+    }
+
+    /**
+     * Creates a FolderGridOrganizer for the given DeviceProfile using the default 2×2 preview.
      */
     public static FolderGridOrganizer createFolderGridOrganizer(DeviceProfile profile) {
         return new FolderGridOrganizer(profile.numFolderColumns, profile.numFolderRows);
+    }
+
+    /**
+     * Creates a FolderGridOrganizer using the user's folder preview grid preference.
+     */
+    public static FolderGridOrganizer createFolderGridOrganizer(Context context,
+            DeviceProfile profile) {
+        return new FolderGridOrganizer(profile.numFolderColumns, profile.numFolderRows,
+                FolderPreviewConfig.getActiveItemCount(context));
+    }
+
+    /** Active number of icons shown in the closed-folder preview. */
+    public int getPreviewMaxItems() {
+        return mPreviewMaxItems;
     }
 
     /**
@@ -74,8 +97,6 @@ public class FolderGridOrganizer {
     public FolderGridOrganizer setContentSize(int contentSize) {
         if (contentSize != mNumItemsInFolder) {
             calculateGridSize(contentSize);
-
-            mDisplayingUpperLeftQuadrant = contentSize > MAX_NUM_ITEMS_IN_PREVIEW;
             mNumItemsInFolder = contentSize;
         }
         return this;
@@ -164,22 +185,18 @@ public class FolderGridOrganizer {
     }
 
     /**
-     * Returns the preview items for the provided pageNo using the full list of contents
+     * Returns the preview items for the provided pageNo using the full list of contents.
+     * Contents are expected in reading order (rank / cellY / cellX); the first
+     * {@link #mPreviewMaxItems} items on the page are shown.
      */
     public <T, R extends T> ArrayList<R> previewItemsForPage(int page, List<T> contents) {
         ArrayList<R> result = new ArrayList<>();
-        int itemsPerPage = mCountX * mCountY;
+        int itemsPerPage = Math.max(mCountX * mCountY, 1);
         int start = itemsPerPage * page;
         int end = Math.min(start + itemsPerPage, contents.size());
 
-        for (int i = start, rank = 0; i < end; i++, rank++) {
-            if (isItemInPreview(page, rank)) {
-                result.add((R) contents.get(i));
-            }
-
-            if (result.size() == MAX_NUM_ITEMS_IN_PREVIEW) {
-                break;
-            }
+        for (int i = start; i < end && result.size() < mPreviewMaxItems; i++) {
+            result.add((R) contents.get(i));
         }
 
         if (result.isEmpty()) {
@@ -200,19 +217,15 @@ public class FolderGridOrganizer {
     }
 
     /**
-     * @param page The page the item is on.
-     * @param rank The rank of the item.
-     * @return True iff the icon is in the 2x2 upper left quadrant of the Folder.
+     * @param page The page the item is on (unused; preview always follows reading order).
+     * @param rank The rank of the item within the page.
+     * @return True iff the icon is among the first {@link #mPreviewMaxItems} in reading order.
      */
     public boolean isItemInPreview(int page, int rank) {
-        // First page items are laid out such that the first 4 items are always in the upper
-        // left quadrant. For all other pages, we need to check the row and col.
-        if (page > 0 || mDisplayingUpperLeftQuadrant) {
-            int col = rank % mCountX;
-            int row = rank / mCountX;
-            return col < PREVIEW_MAX_COLUMNS && row < PREVIEW_MAX_ROWS;
-        }
-        // If we have less than 4 items do this
-        return rank < MAX_NUM_ITEMS_IN_PREVIEW;
+        // Match closed-folder preview to folder contents order (left-to-right, top-to-bottom
+        // by rank), not the upper-left corner of the opened folder grid. Otherwise a 4-column
+        // folder with a 3×3 preview would skip the 4th icon on each row (e.g. Gemini after
+        // YouTube).
+        return rank < mPreviewMaxItems;
     }
 }

--- a/src/com/android/launcher3/folder/FolderIcon.java
+++ b/src/com/android/launcher3/folder/FolderIcon.java
@@ -810,7 +810,10 @@ public class FolderIcon extends FrameLayout implements FloatingIconViewCompanion
             title = getContext().getString(R.string.unnamed_folder);
         }
         int size = mInfo.getContents().size();
-        int activePreviewCount = mPreviewLayoutRule.getActivePreviewItemCount();
+        // Prefer the preference over mPreviewLayoutRule: title can be set during inflation
+        // before the layout rule is initialized.
+        int activePreviewCount =
+                app.lawnchair.folder.FolderPreviewConfig.getActiveItemCount(getContext());
         if (size < activePreviewCount) {
             return getContext().getString(R.string.folder_name_format_exact, title, size);
         } else {

--- a/src/com/android/launcher3/folder/FolderIcon.java
+++ b/src/com/android/launcher3/folder/FolderIcon.java
@@ -20,7 +20,6 @@ package com.android.launcher3.folder;
 
 import static com.android.launcher3.Flags.enableCursorHoverStates;
 import static com.android.launcher3.folder.ClippedFolderIconLayoutRule.ICON_OVERLAP_FACTOR;
-import static com.android.launcher3.folder.ClippedFolderIconLayoutRule.MAX_NUM_ITEMS_IN_PREVIEW;
 import static com.android.launcher3.folder.FolderGridOrganizer.createFolderGridOrganizer;
 import static com.android.launcher3.folder.PreviewItemManager.INITIAL_ITEM_ANIMATION_DURATION;
 import static com.android.launcher3.logging.StatsLogManager.LauncherEvent.LAUNCHER_FOLDER_AUTO_LABELED;
@@ -89,6 +88,7 @@ import com.android.launcher3.views.FloatingIconViewCompanion;
 import com.android.launcher3.widget.PendingAddShortcutInfo;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -228,7 +228,10 @@ public class FolderIcon extends FrameLayout implements FloatingIconViewCompanion
 
         icon.setAccessibilityDelegate(activity.getAccessibilityDelegate());
 
-        icon.mPreviewVerifier = createFolderGridOrganizer(activity.getDeviceProfile());
+        Context host = activity instanceof Context c
+                ? c
+                : activity.getDragLayer().getContext();
+        icon.mPreviewVerifier = createFolderGridOrganizer(host, activity.getDeviceProfile());
         icon.mPreviewVerifier.setFolderInfo(folderInfo);
         icon.updatePreviewItems(false);
 
@@ -350,9 +353,10 @@ public class FolderIcon extends FrameLayout implements FloatingIconViewCompanion
                 workspace.resetTransitionTransform();
             }
 
-            int numItemsInPreview = Math.min(MAX_NUM_ITEMS_IN_PREVIEW, index + 1);
+            int activePreviewCount = mPreviewLayoutRule.getActivePreviewItemCount();
+            int numItemsInPreview = Math.min(activePreviewCount, index + 1);
             boolean itemAdded = false;
-            if (itemReturnedOnFailedDrop || index >= MAX_NUM_ITEMS_IN_PREVIEW) {
+            if (itemReturnedOnFailedDrop || index >= activePreviewCount) {
                 List<ItemInfo> oldPreviewItems = new ArrayList<>(mCurrentPreviewItems);
                 getFolder().addFolderContent(item, index, false);
                 mCurrentPreviewItems.clear();
@@ -388,7 +392,7 @@ public class FolderIcon extends FrameLayout implements FloatingIconViewCompanion
                 to.offset(center[0] - animateView.getMeasuredWidth() / 2,
                         center[1] - animateView.getMeasuredHeight() / 2);
 
-                float finalAlpha = index < MAX_NUM_ITEMS_IN_PREVIEW ? 1f : 0f;
+                float finalAlpha = index < activePreviewCount ? 1f : 0f;
 
                 float finalScale = scale * scaleRelativeToDragLayer;
 
@@ -555,7 +559,8 @@ public class FolderIcon extends FrameLayout implements FloatingIconViewCompanion
 
     private float getLocalCenterForIndex(int index, int curNumItems, int[] center) {
         mTmpParams = mPreviewItemManager.computePreviewItemDrawingParams(
-                Math.min(MAX_NUM_ITEMS_IN_PREVIEW, index), curNumItems, mTmpParams);
+                Math.min(mPreviewLayoutRule.getActivePreviewItemCount(), index), curNumItems,
+                mTmpParams);
 
         mTmpParams.transX += mBackground.basePreviewOffsetX;
         mTmpParams.transY += mBackground.basePreviewOffsetY;
@@ -666,7 +671,23 @@ public class FolderIcon extends FrameLayout implements FloatingIconViewCompanion
      * Returns the list of items which should be visible in the preview
      */
     public List<ItemInfo> getPreviewItemsOnPage(int page) {
-        return mPreviewVerifier.setFolderInfo(mInfo).previewItemsForPage(page, mInfo.getContents());
+        // getContents() is unsorted; preview must follow the same order as the opened folder.
+        ArrayList<ItemInfo> sorted = new ArrayList<>(mInfo.getContents());
+        Collections.sort(sorted, Folder.ITEM_POS_COMPARATOR);
+        return mPreviewVerifier.setFolderInfo(mInfo).previewItemsForPage(page, sorted);
+    }
+
+    /**
+     * Applies the current folder-preview grid preference and redraws this icon.
+     */
+    public void refreshPreviewGrid() {
+        Context host = getContext();
+        mPreviewVerifier = createFolderGridOrganizer(host, mActivity.getDeviceProfile());
+        mPreviewVerifier.setFolderInfo(mInfo);
+        mPreviewItemManager.reapplyPreviewGrid();
+        updatePreviewItems(false);
+        setContentDescription(getAccessiblityTitle(mInfo.title));
+        invalidate();
     }
 
     @Override
@@ -789,11 +810,12 @@ public class FolderIcon extends FrameLayout implements FloatingIconViewCompanion
             title = getContext().getString(R.string.unnamed_folder);
         }
         int size = mInfo.getContents().size();
-        if (size < MAX_NUM_ITEMS_IN_PREVIEW) {
+        int activePreviewCount = mPreviewLayoutRule.getActivePreviewItemCount();
+        if (size < activePreviewCount) {
             return getContext().getString(R.string.folder_name_format_exact, title, size);
         } else {
             return getContext().getString(R.string.folder_name_format_overflow, title,
-                    MAX_NUM_ITEMS_IN_PREVIEW);
+                    activePreviewCount);
         }
     }
 

--- a/src/com/android/launcher3/folder/FolderPagedView.java
+++ b/src/com/android/launcher3/folder/FolderPagedView.java
@@ -111,7 +111,9 @@ public class FolderPagedView extends PagedView<PageIndicatorDots> implements Cli
         this(
                 context,
                 attrs,
-                createFolderGridOrganizer(ActivityContext.lookupContext(context).getDeviceProfile())
+                createFolderGridOrganizer(
+                    context,
+                    ActivityContext.lookupContext(context).getDeviceProfile())
         );
     }
 

--- a/src/com/android/launcher3/folder/FolderSpringAnimatorSet.kt
+++ b/src/com/android/launcher3/folder/FolderSpringAnimatorSet.kt
@@ -36,7 +36,6 @@ import com.android.launcher3.LauncherState
 import com.android.launcher3.Utilities.isDarkTheme
 import com.android.launcher3.anim.SpringAnimationBuilder
 import com.android.launcher3.apppairs.AppPairIcon
-import com.android.launcher3.folder.ClippedFolderIconLayoutRule.MAX_NUM_ITEMS_IN_PREVIEW
 
 /** Holder for Animators created from [FolderAnimationSpringBuilderManager] */
 class FolderSpringAnimatorSet(val animatorSet: AnimatorSet) {
@@ -250,7 +249,8 @@ class FolderSpringAnimatorSet(val animatorSet: AnimatorSet) {
 
                 val footerAlphaDuration: Int
                 var footerStartDelay = 0
-                val isLargeFolder = folder.itemCount > MAX_NUM_ITEMS_IN_PREVIEW
+                val isLargeFolder =
+                    folder.itemCount > folder.folderIcon.layoutRule.activePreviewItemCount
                 if (isLargeFolder) {
                     if (isOpening) {
                         folder.mFooter.alpha = 0f

--- a/src/com/android/launcher3/folder/IconAnimationData.kt
+++ b/src/com/android/launcher3/folder/IconAnimationData.kt
@@ -18,7 +18,6 @@ package com.android.launcher3.folder
 
 import android.view.View
 import com.android.launcher3.celllayout.CellLayoutLayoutParams
-import com.android.launcher3.folder.ClippedFolderIconLayoutRule.MAX_NUM_ITEMS_IN_PREVIEW
 import com.android.launcher3.folder.FolderAnimationSpringBuilderManager.Companion.getBubbleTextView
 import com.android.launcher3.folder.FolderAnimationSpringBuilderManager.Companion.getPreviewIconsOnPage
 
@@ -73,8 +72,12 @@ data class IconAnimationData(
                 iconLayoutParams.isLockedToGrid = true
                 shortcutsAndWidgets?.setupLp(currentIcon)
 
-                // Match scale of icons in the preview of the items on the first page.
-                val previewIconScale = layoutRule.scaleForItem(numItemsOnPage, page)
+                // Match scale/positions to the closed-folder preview (reading order), not the
+                // opened folder's cell grid — otherwise close anim "reassembles" into the wrong
+                // slots when folder columns differ from the preview grid (e.g. 4 cols vs 3×3).
+                val previewCount =
+                    minOf(itemsInPreview.size, layoutRule.activePreviewItemCount).coerceAtLeast(1)
+                val previewIconScale = layoutRule.scaleForItem(previewCount, 0)
                 val previewIconSize = layoutRule.iconSize * previewIconScale
                 val baseIconSize = getBubbleTextView(currentIcon).iconSize.toFloat()
                 val iconScale = previewIconSize / baseIconSize
@@ -88,16 +91,17 @@ data class IconAnimationData(
                 currentIcon.scaleX = startScale
                 currentIcon.scaleY = startScale
 
-                val pageLayoutCount =
-                    if (numItemsOnPage < MAX_NUM_ITEMS_IN_PREVIEW && page > 0) {
-                        // If not on first page, we don't want preview items to position in a
-                        // circle.
-                        MAX_NUM_ITEMS_IN_PREVIEW
-                    } else {
-                        numItemsOnPage
-                    }
-                // Match positions of the icons in the folder with their positions in the preview
-                layoutRule.computeSpringAnimationItemParams(i, pageLayoutCount, page, mTmpParams)
+                val previewIndex = itemsInPreview.indexOf(currentIcon)
+                if (previewIndex >= 0) {
+                    layoutRule.computePreviewItemDrawingParams(previewIndex, previewCount, mTmpParams)
+                } else {
+                    // Non-preview icons collapse toward the preview center.
+                    layoutRule.computePreviewItemDrawingParams(
+                        layoutRule.activePreviewItemCount,
+                        previewCount,
+                        mTmpParams,
+                    )
+                }
 
                 // The PreviewLayoutRule assumes that the icon size takes up the entire width so we
                 // offset by the actual size.

--- a/src/com/android/launcher3/folder/PreviewItemManager.java
+++ b/src/com/android/launcher3/folder/PreviewItemManager.java
@@ -20,7 +20,6 @@ import static com.android.launcher3.BubbleTextView.DISPLAY_FOLDER;
 import static com.android.launcher3.LauncherSettings.Favorites.DESKTOP_ICON_FLAG;
 import static com.android.launcher3.folder.ClippedFolderIconLayoutRule.ENTER_INDEX;
 import static com.android.launcher3.folder.ClippedFolderIconLayoutRule.EXIT_INDEX;
-import static com.android.launcher3.folder.ClippedFolderIconLayoutRule.MAX_NUM_ITEMS_IN_PREVIEW;
 import static com.android.launcher3.folder.FolderIcon.DROP_IN_ANIMATION_DURATION;
 import static com.android.launcher3.graphics.PreloadIconDrawable.newPendingIcon;
 import static com.android.launcher3.icons.BitmapInfo.FLAG_THEMED;
@@ -135,7 +134,9 @@ public class PreviewItemManager {
             mIcon.mPreviewLayoutRule.init(
                     mIcon.mBackground.previewSize, mIntrinsicIconSize,
                     Utilities.isRtl(mIcon.getResources()),
-                    mIcon.mActivity.getDeviceProfile().numFolderColumns
+                    mIcon.mActivity.getDeviceProfile().numFolderColumns,
+                    app.lawnchair.folder.FolderPreviewConfig.getActiveItemCount(mIcon.getContext()),
+                    app.lawnchair.folder.FolderPreviewConfig.getGridSide(mIcon.getContext())
             );
             updatePreviewItems(false);
         }
@@ -225,7 +226,8 @@ public class PreviewItemManager {
         // enter/exit
         // animation purposes and they were added to the front of the list.
         // To index the params properly, we need to skip these params.
-        index = index + Math.max(mFirstPageParams.size() - MAX_NUM_ITEMS_IN_PREVIEW, 0);
+        int activePreviewCount = mIcon.mPreviewLayoutRule.getActivePreviewItemCount();
+        index = index + Math.max(mFirstPageParams.size() - activePreviewCount, 0);
 
         PreviewItemDrawingParams params = index < mFirstPageParams.size() ? mFirstPageParams.get(index) : null;
         if (params != null) {
@@ -244,7 +246,9 @@ public class PreviewItemManager {
             params.add(new PreviewItemDrawingParams(0, 0, 0));
         }
 
-        int numItemsInFirstPagePreview = page == 0 ? items.size() : MAX_NUM_ITEMS_IN_PREVIEW;
+        int numItemsInFirstPagePreview = page == 0
+                ? items.size()
+                : mIcon.mPreviewLayoutRule.getActivePreviewItemCount();
         for (int i = 0; i < params.size(); i++) {
             PreviewItemDrawingParams p = params.get(i);
             setDrawable(p, items.get(i));
@@ -282,6 +286,24 @@ public class PreviewItemManager {
             updatePreviewItems(false);
         }
         onParamsChanged();
+    }
+
+    /**
+     * Re-reads the folder preview grid preference and rebuilds preview drawing params.
+     * Used when the user changes 2×2 / 3×3 without restarting the launcher.
+     */
+    void reapplyPreviewGrid() {
+        int drawableSize = mIntrinsicIconSize > 0
+                ? (int) mIntrinsicIconSize
+                : (mReferenceDrawable != null ? mReferenceDrawable.getIntrinsicWidth() : 0);
+        int totalSize = mTotalWidth > 0 ? mTotalWidth : mIcon.getMeasuredWidth();
+        if (drawableSize <= 0 || totalSize <= 0) {
+            return;
+        }
+        // Reset size guards so computePreviewDrawingParams re-inits the layout rule.
+        mIntrinsicIconSize = -1;
+        mTotalWidth = -1;
+        computePreviewDrawingParams(drawableSize, totalSize);
     }
 
     void updatePreviewItems(boolean animate) {

--- a/src/com/android/launcher3/model/WorkspaceItemProcessor.kt
+++ b/src/com/android/launcher3/model/WorkspaceItemProcessor.kt
@@ -621,7 +621,7 @@ class WorkspaceItemProcessor(
      */
     private fun processFolderItems() {
         // Sort the folder items, update ranks, and make sure all preview items are high res.
-        val verifiers = idp.supportedProfiles.map { createFolderGridOrganizer(it) }
+        val verifiers = idp.supportedProfiles.map { createFolderGridOrganizer(context, it) }
         for (itemInfo in loadedItems) {
             if (itemInfo !is FolderInfo) {
                 continue

--- a/tests/multivalentTests/src/com/android/launcher3/folder/FolderPagedViewTest.kt
+++ b/tests/multivalentTests/src/com/android/launcher3/folder/FolderPagedViewTest.kt
@@ -104,14 +104,15 @@ class FolderPagedViewTest {
     @Test
     fun isItemInPreview() {
         val folderGridOrganizer = FolderGridOrganizer(5, 8)
-        folderGridOrganizer.setContentSize(ClippedFolderIconLayoutRule.MAX_NUM_ITEMS_IN_PREVIEW - 1)
+        val fewItems = ClippedFolderIconLayoutRule.DEFAULT_NUM_ITEMS_IN_PREVIEW - 1
+        folderGridOrganizer.setContentSize(fewItems)
         // Very few items
         for (i in 0..3) {
             assertItemsInPreview(
                 TestCase(
                     maxCountX = 5,
                     maxCountY = 8,
-                    totalItems = ClippedFolderIconLayoutRule.MAX_NUM_ITEMS_IN_PREVIEW - 1
+                    totalItems = fewItems
                 ),
                 expectedIsInPreview = true,
                 page = 0,
@@ -123,37 +124,38 @@ class FolderPagedViewTest {
                 TestCase(
                     maxCountX = 5,
                     maxCountY = 8,
-                    totalItems = ClippedFolderIconLayoutRule.MAX_NUM_ITEMS_IN_PREVIEW - 1
+                    totalItems = fewItems
                 ),
                 expectedIsInPreview = false,
                 page = 0,
                 rank = i
             )
         }
-        // Full of items
+        // Full of items: preview is the first N items in reading order, not the
+        // upper-left corner of the opened folder grid.
         assertItemsInPreview(
             TestCase(maxCountX = 5, maxCountY = 8, totalItems = 40),
-            expectedIsInPreview = false,
+            expectedIsInPreview = true,
             page = 0,
-            rank = 2
-        )
-        assertItemsInPreview(
-            TestCase(maxCountX = 5, maxCountY = 8, totalItems = 40),
-            expectedIsInPreview = false,
-            page = 0,
-            rank = 2
+            rank = 0
         )
         assertItemsInPreview(
             TestCase(maxCountX = 5, maxCountY = 8, totalItems = 40),
             expectedIsInPreview = true,
+            page = 0,
+            rank = 3
+        )
+        assertItemsInPreview(
+            TestCase(maxCountX = 5, maxCountY = 8, totalItems = 40),
+            expectedIsInPreview = false,
+            page = 0,
+            rank = 4
+        )
+        assertItemsInPreview(
+            TestCase(maxCountX = 5, maxCountY = 8, totalItems = 40),
+            expectedIsInPreview = false,
             page = 0,
             rank = 5
-        )
-        assertItemsInPreview(
-            TestCase(maxCountX = 5, maxCountY = 8, totalItems = 40),
-            expectedIsInPreview = true,
-            page = 0,
-            rank = 6
         )
     }
 

--- a/tests/multivalentTests/src/com/android/launcher3/folder/FolderPagedViewTest.kt
+++ b/tests/multivalentTests/src/com/android/launcher3/folder/FolderPagedViewTest.kt
@@ -103,11 +103,10 @@ class FolderPagedViewTest {
 
     @Test
     fun isItemInPreview() {
-        val folderGridOrganizer = FolderGridOrganizer(5, 8)
-        val fewItems = ClippedFolderIconLayoutRule.DEFAULT_NUM_ITEMS_IN_PREVIEW - 1
-        folderGridOrganizer.setContentSize(fewItems)
+        val defaultPreviewCount = ClippedFolderIconLayoutRule.DEFAULT_NUM_ITEMS_IN_PREVIEW
+        val fewItems = defaultPreviewCount - 1
         // Very few items
-        for (i in 0..3) {
+        for (i in 0 until defaultPreviewCount) {
             assertItemsInPreview(
                 TestCase(
                     maxCountX = 5,
@@ -119,7 +118,7 @@ class FolderPagedViewTest {
                 rank = i
             )
         }
-        for (i in 4..40) {
+        for (i in defaultPreviewCount..40) {
             assertItemsInPreview(
                 TestCase(
                     maxCountX = 5,
@@ -143,19 +142,19 @@ class FolderPagedViewTest {
             TestCase(maxCountX = 5, maxCountY = 8, totalItems = 40),
             expectedIsInPreview = true,
             page = 0,
-            rank = 3
+            rank = defaultPreviewCount - 1
         )
         assertItemsInPreview(
             TestCase(maxCountX = 5, maxCountY = 8, totalItems = 40),
             expectedIsInPreview = false,
             page = 0,
-            rank = 4
+            rank = defaultPreviewCount
         )
         assertItemsInPreview(
             TestCase(maxCountX = 5, maxCountY = 8, totalItems = 40),
             expectedIsInPreview = false,
             page = 0,
-            rank = 5
+            rank = defaultPreviewCount + 1
         )
     }
 


### PR DESCRIPTION
### Description

Add a Folders setting to show either a 2×2 (4) or 3×3 (9) icon preview on closed folders (home screen and app drawer). Previews fill in reading order, open/close animation targets those same slots, and changing the preference updates folder icons immediately without restarting.

<img height="720" alt="photo_2026-07-18_19-36-03" src="https://github.com/user-attachments/assets/c22fca78-458c-4ed0-96a4-b1577eb05339" />
<img height="720" alt="photo_2026-07-18_19-36-05" src="https://github.com/user-attachments/assets/5f5cf4ca-227a-49dc-ac38-76df36797304" />



### Reasoning

Closed-folder previews were hardwired to a 2×2 collage and, for larger folders, took the upper-left corner of the opened folder grid. With a 4-column folder that skipped icons mid-row (e.g. Gemini after YouTube) and looked inconsistent next to reading order inside the folder. A global 2×2 / 3×3 preference matches common launcher customization, keeps home and drawer consistent, and applies live so users don’t need a restart.

### Testing

1. Open **Settings → Folders → Preview icons** and switch between **2×2 (4 icons)** and **3×3 (9 icons)**.
2. Confirm home screen and app drawer folder previews update immediately (no launcher restart).
3. Open a folder with 4 columns and 9+ apps: preview should show the first N apps in reading order (left-to-right, top-to-bottom), not the upper-left corner of the open grid.
4. Open and close folders in both 2×2 and 3×3 modes: icons should animate into the same slots shown on the closed preview (no “reassembly” / shifted grid after close).
5. Check a folder with exactly 3 apps in 2×2 mode: layout should be `OO` / `O` (bottom-right empty).

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

:x: **Bug fix** (A non-breaking change that fixes an issue)
:white_check_mark: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added folder preview grid customization with 2×2 and 3×3 layout options.
  * Folder previews can now show up to 9 items using a consistent rectangular grid.
  * Folder preview rendering updates automatically when the grid size preference changes (no restart).
  * Improved preview item ordering to match the folder’s reading order.
* **Tests**
  * Updated folder preview boundary assertions to reflect the configurable default preview size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->