### PR TITLE
fix: Restore default icon after resetting a custom override

### DIFF
--- a/lawnchair/src/app/lawnchair/data/iconoverride/IconOverrideRepository.kt
+++ b/lawnchair/src/app/lawnchair/data/iconoverride/IconOverrideRepository.kt
@@ -1,6 +1,7 @@
 package app.lawnchair.data.iconoverride
 
 import android.content.Context
+import android.os.UserHandle
 import app.lawnchair.data.AppDatabase
 import app.lawnchair.icons.picker.IconPickerItem
 import com.android.launcher3.LauncherAppState
@@ -52,11 +53,15 @@ class IconOverrideRepository @Inject constructor(
 
     suspend fun setOverride(target: ComponentKey, item: IconPickerItem) {
         dao.insert(IconOverride(target, item))
+        // Keep the in-memory map in sync before any icon reload. The Room Flow update is
+        // async and can race with onAppIconChanged / forceReload, leaving stale icons cached.
+        _overridesMap = _overridesMap + (target to item)
         updatePackageQueue.offer(target)
     }
 
     suspend fun deleteOverride(target: ComponentKey) {
         dao.delete(target)
+        _overridesMap = _overridesMap - target
         updatePackageQueue.offer(target)
     }
 
@@ -64,8 +69,24 @@ class IconOverrideRepository @Inject constructor(
 
     fun observeCount() = dao.observeCount()
 
+    /**
+     * Returns a persistable fingerprint of per-app icon overrides for [packageName]/[user].
+     * Used as part of icon-cache freshness so clearing an override invalidates the cache entry.
+     */
+    fun getPackageOverrideState(packageName: String, user: UserHandle): String {
+        return overridesMap.asSequence()
+            .filter {
+                it.key.componentName.packageName == packageName && it.key.user == user
+            }
+            .sortedBy { it.key.componentName.className }
+            .joinToString(";") { (key, item) ->
+                "${key.componentName.className}:${item.packPackageName}/${item.drawableName}/${item.type}"
+            }
+    }
+
     suspend fun deleteAll() {
         dao.deleteAll()
+        _overridesMap = emptyMap()
         LauncherAppState.getInstance(context).model.reloadIfActive()
     }
 

--- a/lawnchair/src/app/lawnchair/icons/LawnchairIconProvider.kt
+++ b/lawnchair/src/app/lawnchair/icons/LawnchairIconProvider.kt
@@ -215,13 +215,20 @@ class LawnchairIconProvider @Inject constructor(
 
     override fun getStateForApp(info: ApplicationInfo?): String {
         val base = super.getStateForApp(info)
+        val overrideState = if (info != null) {
+            val user = UserHandle.getUserHandleForUid(info.uid)
+            overrideRepo.getPackageOverrideState(info.packageName, user)
+        } else {
+            ""
+        }
         return "$base|lc:" +
             "ip=${iconPackPref.get()}," +
             "tip=${themedIconSourcePref.get()}," +
             "ti=${prefs.themedIcons.get()}," +
             "dti=${prefs.drawerThemedIcons.get()}," +
             "fm=${prefs.forceIconMonochrome.get()}," +
-            "tb=${prefs.tintIconPackBackgrounds.get()}"
+            "tb=${prefs.tintIconPackBackgrounds.get()}," +
+            "ov=$overrideState"
     }
 
     override fun getThemeDataForPackage(packageName: String?): ThemeData? {

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/SelectIconPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/SelectIconPreference.kt
@@ -26,7 +26,9 @@ import app.lawnchair.util.requireSystemService
 import com.android.launcher3.LauncherAppState
 import com.android.launcher3.R
 import com.android.launcher3.util.ComponentKey
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 private const val TAG = "SelectIconPreference"
 
@@ -48,7 +50,10 @@ fun SelectIconPreference(componentKey: ComponentKey) {
             repo.setOverride(componentKey, item)
             // Refresh package icons while the model is still loaded; forceReload alone can
             // skip PackageUpdatedTask and leave icon-cache entries that look "fresh".
-            model.onAppIconChanged(componentKey.componentName.packageName, componentKey.user)
+            // onAppIconChanged is @WorkerThread (blocking ShortcutManager query).
+            withContext(Dispatchers.IO) {
+                model.onAppIconChanged(componentKey.componentName.packageName, componentKey.user)
+            }
             (context as Activity).let {
                 it.setResult(Activity.RESULT_OK)
                 it.finish()
@@ -67,10 +72,12 @@ fun SelectIconPreference(componentKey: ComponentKey) {
                     onClick = {
                         scope.launch {
                             repo.deleteOverride(componentKey)
-                            model.onAppIconChanged(
-                                componentKey.componentName.packageName,
-                                componentKey.user,
-                            )
+                            withContext(Dispatchers.IO) {
+                                model.onAppIconChanged(
+                                    componentKey.componentName.packageName,
+                                    componentKey.user,
+                                )
+                            }
                             (context as Activity).let {
                                 it.setResult(Activity.RESULT_OK)
                                 it.finish()

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/SelectIconPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/SelectIconPreference.kt
@@ -46,11 +46,12 @@ fun SelectIconPreference(componentKey: ComponentKey) {
     OnResult<IconPickerItem> { item ->
         scope.launch {
             repo.setOverride(componentKey, item)
+            // Refresh package icons while the model is still loaded; forceReload alone can
+            // skip PackageUpdatedTask and leave icon-cache entries that look "fresh".
+            model.onAppIconChanged(componentKey.componentName.packageName, componentKey.user)
             (context as Activity).let {
                 it.setResult(Activity.RESULT_OK)
                 it.finish()
-                model.onAppIconChanged(componentKey.componentName.packageName, componentKey.user)
-                model.forceReload()
             }
         }
     }
@@ -66,11 +67,13 @@ fun SelectIconPreference(componentKey: ComponentKey) {
                     onClick = {
                         scope.launch {
                             repo.deleteOverride(componentKey)
+                            model.onAppIconChanged(
+                                componentKey.componentName.packageName,
+                                componentKey.user,
+                            )
                             (context as Activity).let {
                                 it.setResult(Activity.RESULT_OK)
                                 it.finish()
-                                model.onAppIconChanged(componentKey.componentName.packageName, componentKey.user)
-                                model.forceReload()
                             }
                         }
                     },


### PR DESCRIPTION
### Description

Fix resetting a per-app custom icon (from an icon pack) so the icon returns to the default/pack icon instead of staying stuck on the previous override. Applies to both personal and work profiles.

### Reasoning

After choosing a custom icon, reset deleted the override from the database, but the icon cache still treated the entry as fresh because `getStateForApp` did not include per-app overrides. Reloading via `forceReload()` could also skip `PackageUpdatedTask`, so the stale bitmap stayed cached. The fix includes override state in cache freshness, updates the in-memory map before refresh, and refreshes icons with `onAppIconChanged` while the model is still loaded.

### Testing

1. Long-press an app → customize → pick an icon from any icon pack (try one in **Personal** and one in **Work**).
2. Confirm the custom icon appears in the drawer/home.
3. Open customize again → **Reset to default**.
4. Confirm the icon immediately reverts to the normal/pack icon (not the custom one).
5. Optional: Settings → Home → **Reset custom icons** if multiple overrides exist; all should revert.

### Type of change

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
:x: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app icon refresh reliability after setting, resetting, or deleting custom icons.
  * Reduced chances of stale icon cache results when icon overrides change.
  * Ensured clearing all icon overrides immediately updates the current icon state.
  * Added more accurate per-app icon override state tracking so cached icons refresh when customizations are updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->