### PR TITLE
fix: Clear stuck workspace icon blur on home

### DIFF
--- a/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
+++ b/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
@@ -457,8 +457,9 @@ class LawnchairLauncher : QuickstepLauncher() {
 
                     dragLayer.post {
                         dragLayer.viewTreeObserver.removeOnDrawListener(this)
+                        // Drop stuck All Apps RenderEffect on icons after returning home.
+                        depthController.clearStuckBlurOnResumeIfHome()
                     }
-                    depthController
                 }
             },
         )

--- a/quickstep/src/com/android/launcher3/statehandlers/DepthController.java
+++ b/quickstep/src/com/android/launcher3/statehandlers/DepthController.java
@@ -187,6 +187,7 @@ public class DepthController extends BaseDepthController implements StateHandler
         // Re-apply even when depth is already 0 so an interrupted All Apps / depth transition
         // cannot leave workspace RenderEffect or surface blur stuck until the next resume.
         if (toState == LauncherState.NORMAL) {
+            clearWorkspaceRenderEffects();
             applyDepthAndBlur();
         }
     }
@@ -196,12 +197,34 @@ public class DepthController extends BaseDepthController implements StateHandler
             PendingAnimation animation) {
         if (config.hasAnimationFlag(SKIP_DEPTH_CONTROLLER)
                 || mIgnoreStateChangesDuringMultiWindowAnimation) {
+            if (toState == LauncherState.NORMAL) {
+                clearWorkspaceRenderEffects();
+            }
             return;
         }
 
         float toDepth = toState.getDepth(mLauncher);
         animation.setFloat(stateDepth, MULTI_PROPERTY_VALUE, toDepth,
                 config.getInterpolator(ANIM_DEPTH, LINEAR));
+        if (toState == LauncherState.NORMAL) {
+            animation.addEndListener(success -> {
+                if (mLauncher.getStateManager().getState() == LauncherState.NORMAL) {
+                    clearWorkspaceRenderEffects();
+                    applyDepthAndBlur();
+                }
+            });
+        }
+    }
+
+    /**
+     * Clears a stuck workspace icon blur after resume when settled on home.
+     */
+    public void clearStuckBlurOnResumeIfHome() {
+        if (mLauncher.getStateManager().getState() == LauncherState.NORMAL
+                && !mLauncher.getStateManager().isInTransition()) {
+            clearWorkspaceRenderEffects();
+            applyDepthAndBlur();
+        }
     }
 
     @Override
@@ -210,9 +233,19 @@ public class DepthController extends BaseDepthController implements StateHandler
             if (LawnchairQuickstepCompat.ATLEAST_R && mEnableDepth) {
                 ensureDependencies();
                 super.applyDepthAndBlur();
+            } else if (mLauncher.getStateManager().getState() == LauncherState.NORMAL
+                    && !mLauncher.getStateManager().isInTransition()) {
+                clearWorkspaceRenderEffects();
             }
         } catch (Throwable t) {
             // LC-Ignored
+            if (mLauncher.getStateManager().getState() == LauncherState.NORMAL) {
+                try {
+                    clearWorkspaceRenderEffects();
+                } catch (Throwable ignored) {
+                    // LC-Ignored
+                }
+            }
         }
     }
 

--- a/quickstep/src/com/android/quickstep/util/BaseDepthController.java
+++ b/quickstep/src/com/android/quickstep/util/BaseDepthController.java
@@ -340,24 +340,50 @@ public class BaseDepthController {
         if (!Utilities.ATLEAST_S) {
             return false;
         }
-        if (!Flags.allAppsBlur()) {
-            // Still clear any leftover effect if the flag flips or blur was applied earlier.
-            mLauncher.getDepthBlurTargets().forEach(target -> target.setRenderEffect(null));
+        StateManager<LauncherState, Launcher> stateManager = mLauncher.getStateManager();
+        LauncherState settledState = stateManager.getState();
+
+        // Stuck-blur bug: AllAppsState.shouldBlurWorkspace(NORMAL) is true during close, and a
+        // skipped/interrupted apply can leave RenderEffect on workspace/hotseat icons after home
+        // is settled. Always clear once we are on NORMAL with no active transition, or depth is 0.
+        if (!Flags.allAppsBlur()
+                || mDepth <= 0f
+                || mCurrentBlur <= 0
+                || (settledState == LauncherState.NORMAL && !stateManager.isInTransition())) {
+            clearWorkspaceRenderEffects();
             return false;
         }
-        StateManager<LauncherState, Launcher> stateManager = mLauncher.getStateManager();
+
         LauncherState targetState = stateManager.getTargetState() != null
-                ? stateManager.getTargetState() : stateManager.getState();
+                ? stateManager.getTargetState() : settledState;
         // Only blur workspace if the current state wants to blur based on the target state.
         boolean shouldBlurWorkspace =
                 stateManager.getCurrentStableState().shouldBlurWorkspace(targetState);
 
-        RenderEffect blurEffect = shouldBlurWorkspace && mCurrentBlur > 0
+        RenderEffect blurEffect = shouldBlurWorkspace
                 ? RenderEffect.createBlurEffect(mCurrentBlur, mCurrentBlur, Shader.TileMode.DECAL)
-                // If blur is not desired, clear the blur effect from the depth targets.
                 : null;
-        mLauncher.getDepthBlurTargets().forEach(target -> target.setRenderEffect(blurEffect));
-        return shouldBlurWorkspace;
+        mLauncher.getDepthBlurTargets().forEach(target -> {
+            target.setRenderEffect(blurEffect);
+            if (blurEffect == null) {
+                target.invalidate();
+            }
+        });
+        return shouldBlurWorkspace && blurEffect != null;
+    }
+
+    /**
+     * Clears {@link RenderEffect} from workspace/hotseat. Public so callers can drop a stuck
+     * icon blur without going through SurfaceControl apply.
+     */
+    public void clearWorkspaceRenderEffects() {
+        if (!Utilities.ATLEAST_S) {
+            return;
+        }
+        mLauncher.getDepthBlurTargets().forEach(target -> {
+            target.setRenderEffect(null);
+            target.invalidate();
+        });
     }
 
     private void setDepth(float depth) {

--- a/quickstep/src/com/android/quickstep/util/BaseDepthController.java
+++ b/quickstep/src/com/android/quickstep/util/BaseDepthController.java
@@ -357,19 +357,15 @@ public class BaseDepthController {
         LauncherState targetState = stateManager.getTargetState() != null
                 ? stateManager.getTargetState() : settledState;
         // Only blur workspace if the current state wants to blur based on the target state.
-        boolean shouldBlurWorkspace =
-                stateManager.getCurrentStableState().shouldBlurWorkspace(targetState);
+        if (!stateManager.getCurrentStableState().shouldBlurWorkspace(targetState)) {
+            clearWorkspaceRenderEffects();
+            return false;
+        }
 
-        RenderEffect blurEffect = shouldBlurWorkspace
-                ? RenderEffect.createBlurEffect(mCurrentBlur, mCurrentBlur, Shader.TileMode.DECAL)
-                : null;
-        mLauncher.getDepthBlurTargets().forEach(target -> {
-            target.setRenderEffect(blurEffect);
-            if (blurEffect == null) {
-                target.invalidate();
-            }
-        });
-        return shouldBlurWorkspace && blurEffect != null;
+        RenderEffect blurEffect = RenderEffect.createBlurEffect(
+                mCurrentBlur, mCurrentBlur, Shader.TileMode.DECAL);
+        mLauncher.getDepthBlurTargets().forEach(target -> target.setRenderEffect(blurEffect));
+        return true;
     }
 
     /**


### PR DESCRIPTION
### Description

Fix the home screen getting stuck with a heavy All Apps blur on workspace/hotseat icons. After leaving search or another activity (for example App Info) and returning home, icon `RenderEffect` is now cleared when settled on `NORMAL`.

### Reasoning

All Apps applies a `RenderEffect` blur to workspace and hotseat. `AllAppsState.shouldBlurWorkspace(NORMAL)` stays true during the close transition, and if a depth apply is skipped, interrupted, or races with resume, that effect can remain after home is already settled. Clearing the effect explicitly on `NORMAL` (including resume and skipped depth animations) removes the stuck blur without changing the intentional blur while All Apps is open.

<img height="720" alt="photo_2026-07-19_01-19-20" src="https://github.com/user-attachments/assets/7ffda209-75da-40a5-901d-f90560235863" />


### Testing

1. Open All Apps / search, long-press an app → **App info**, then swipe back to the launcher / home.
2. Confirm the home screen icons are sharp (not fully blurred/black).
3. Repeat a few times: open/close the drawer, open any app and return home, open a folder and close it.
4. Confirm All Apps still blurs the workspace while the drawer is open.

### Type of change

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
:x: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where workspace and home screen icons could remain “stuck” blurred after returning to the launcher.
  * Improved the removal and reapplication of workspace blur/depth effects when entering the normal launcher state and during resume.
  * Ensured blur effects are cleared reliably when blurring isn’t applicable, unavailable, or when the launcher is idle on the home screen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->