### PR TITLE
fix: Align widget visually to the icon

### DIFF
--- a/src/com/android/launcher3/DeviceProfile.java
+++ b/src/com/android/launcher3/DeviceProfile.java
@@ -258,6 +258,10 @@ public class DeviceProfile {
     // Additional padding added to the widget inside its cellSpace. It is applied outside
     // the widgetView, such that the actual view size is same as the widget size.
     public final Rect widgetPadding = new Rect();
+    // Lawnchair: extra horizontal inset applied only to widgets touching the left/right
+    // edge of the grid, so that widget edges align closer to icon centers without
+    // inflating the gap between adjacent widgets.
+    public int widgetEdgeInsetPx;
 
     // Notification dots
     public final DotRenderer mDotRendererWorkSpace;
@@ -1399,9 +1403,11 @@ public class DeviceProfile {
         } else {
             widgetPadding.setEmpty();
         }
+        // Lawnchair: extra inset for edge widgets to align closer to icon centre.
+        widgetEdgeInsetPx = widgetPadding.left;
         // Lawnchair: scale widget padding by user factor (0 = remove, 1 = default).
-        widgetPadding.left = Math.round(widgetPadding.left * widgetPaddingFactor);
-        widgetPadding.right = Math.round(widgetPadding.right * widgetPaddingFactor);
+        widgetPadding.left = widgetPadding.right =
+                Math.round(widgetPadding.left * widgetPaddingFactor);
         widgetPadding.top = Math.round(widgetPadding.top * widgetPaddingFactor);
         widgetPadding.bottom = Math.round(widgetPadding.bottom * widgetPaddingFactor);
     }

--- a/src/com/android/launcher3/ShortcutAndWidgetContainer.java
+++ b/src/com/android/launcher3/ShortcutAndWidgetContainer.java
@@ -150,7 +150,8 @@ public class ShortcutAndWidgetContainer extends ViewGroup implements FolderIcon.
             DeviceProfile profile = mActivity.getDeviceProfile();
             final PointF appWidgetScale = profile.getAppWidgetScale((ItemInfo) child.getTag());
             lp.setup(mCellWidth, mCellHeight, invertLayoutHorizontally(), mCountX, mCountY,
-                    appWidgetScale.x, appWidgetScale.y, mBorderSpace, profile.widgetPadding);
+                    appWidgetScale.x, appWidgetScale.y, mBorderSpace, profile.widgetPadding,
+                    profile.widgetEdgeInsetPx);
         } else {
             lp.setup(mCellWidth, mCellHeight, invertLayoutHorizontally(), mCountX, mCountY,
                     mBorderSpace);
@@ -175,13 +176,15 @@ public class ShortcutAndWidgetContainer extends ViewGroup implements FolderIcon.
         if (child instanceof NavigableAppWidgetHostView) {
             final PointF appWidgetScale = dp.getAppWidgetScale((ItemInfo) child.getTag());
             lp.setup(mCellWidth, mCellHeight, invertLayoutHorizontally(), mCountX, mCountY,
-                    appWidgetScale.x, appWidgetScale.y, mBorderSpace, dp.widgetPadding);
+                    appWidgetScale.x, appWidgetScale.y, mBorderSpace, dp.widgetPadding,
+                    dp.widgetEdgeInsetPx);
         } else if (isChildQsb(child)) {
             lp.setup(mCellWidth, mCellHeight, invertLayoutHorizontally(), mCountX, mCountY,
-                    mBorderSpace);
+                    1.0f, 1.0f, mBorderSpace, null, dp.widgetEdgeInsetPx);
             // No need to add padding for Qsb, which is either Smartspace (actual or
             // preview), or
             // QsbContainerView.
+            // LC-Note: but still apply edge inset so its outer edges align with icon centre
         } else {
             lp.setup(mCellWidth, mCellHeight, invertLayoutHorizontally(), mCountX, mCountY,
                     mBorderSpace);

--- a/src/com/android/launcher3/celllayout/CellLayoutLayoutParams.java
+++ b/src/com/android/launcher3/celllayout/CellLayoutLayoutParams.java
@@ -128,6 +128,19 @@ public class CellLayoutLayoutParams extends ViewGroup.MarginLayoutParams {
     public void setup(int cellWidth, int cellHeight, boolean invertHorizontally, int colCount,
             int rowCount, float cellScaleX, float cellScaleY, Point borderSpace,
             @Nullable Rect inset) {
+        setup(cellWidth, cellHeight, invertHorizontally, colCount, rowCount, cellScaleX,
+                cellScaleY, borderSpace, inset, 0);
+    }
+
+    /**
+     * Lawnchair: {@link #setup(int, int, boolean, int, int, float, float, Point, Rect)}, 
+     * with the addition of [edgeInset] (after inset) in case extra inset needs to be applied on the outer grid edges
+     * 
+     * Lawnchair-TODO: Maybe the proper solution is to modify the profile of the device directly, but what value?
+     */
+    public void setup(int cellWidth, int cellHeight, boolean invertHorizontally, int colCount,
+            int rowCount, float cellScaleX, float cellScaleY, Point borderSpace,
+            @Nullable Rect inset, int edgeInset) {
         if (isLockedToGrid) {
             final int myCellHSpan = cellHSpan;
             final int myCellVSpan = cellVSpan;
@@ -154,6 +167,19 @@ public class CellLayoutLayoutParams extends ViewGroup.MarginLayoutParams {
                 y += inset.top;
                 width -= inset.left + inset.right;
                 height -= inset.top + inset.bottom;
+            }
+
+            // Lawnchair: apply extra inset only on the outer edges of the grid
+            if (edgeInset > 0) {
+                boolean atLeft = myCellX == 0;
+                boolean atRight = myCellX + myCellHSpan >= colCount;
+                if (atLeft) {
+                    x += edgeInset;
+                    width -= edgeInset;
+                }
+                if (atRight) {
+                    width -= edgeInset;
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Align widget visually to the centre of the icon.

#6988

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->

This PR only align the "outer edge" of the widget to the icon, the "inner edge" stays the same sizing so widget wouldn't feels awkwards with lot of spacings in the middle.

This PR also fixes the smartspace spacing sitting too close to the edge of the screen, which also happens to regular widget too because they're using the shared the same spacings value.

Although do note that I don't think this is the right solution, I think the proper solution is reconfiguring the device profile (*the profile*) which is more risky than this purposed fix due to there's being multiple profiles.

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Visual

Old

![Screenshot_20260722-222655.png](https://github.com/user-attachments/assets/9b0610c1-5dae-4c24-921a-4247c555600c)

New

![Screenshot_20260722-222635.png](https://github.com/user-attachments/assets/754aa3e3-fa83-485c-a06d-66a537684872)

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)
