### PR TITLE
fix: Show themed icon on customise popup when icon theming is on

### DIFF
--- a/lawnchair/src/app/lawnchair/ui/popup/LawnchairShortcut.kt
+++ b/lawnchair/src/app/lawnchair/ui/popup/LawnchairShortcut.kt
@@ -10,6 +10,7 @@ import android.content.pm.ApplicationInfo
 import android.content.pm.LauncherActivityInfo
 import android.content.pm.LauncherApps
 import android.content.pm.SuspendDialogInfo
+import android.graphics.drawable.AdaptiveIconDrawable
 import android.net.Uri
 import android.os.UserHandle
 import android.util.Log
@@ -27,9 +28,11 @@ import com.android.launcher3.LauncherSettings.Favorites.ITEM_TYPE_APPLICATION
 import com.android.launcher3.LauncherSettings.Favorites.ITEM_TYPE_TASK
 import com.android.launcher3.R
 import com.android.launcher3.Utilities
-import com.android.launcher3.icons.BitmapInfo
+import com.android.launcher3.graphics.ThemeManager
+import com.android.launcher3.icons.LauncherIcons
 import com.android.launcher3.model.data.AppInfo as ModelAppInfo
 import com.android.launcher3.model.data.ItemInfo
+import com.android.launcher3.model.data.ItemInfoWithIcon
 import com.android.launcher3.popup.SystemShortcut
 import com.android.launcher3.util.ApplicationInfoWrapper
 import com.android.launcher3.util.ComponentKey
@@ -125,9 +128,15 @@ class LawnchairShortcut {
         override fun onClick(v: View) {
             val outObj = Array<Any?>(1) { null }
             var icon = Utilities.loadFullDrawableWithoutTheme(launcher, appInfo, 0, 0, outObj)
-            if (mItemInfo.screenId != NO_ID && icon is BitmapInfo.Extender) {
-                // Lawnchair-TODO-BubbleTea: Fix getThemedDrawable
-                // icon = icon.getThemedDrawable(launcher)
+            if (mItemInfo.screenId != NO_ID) {
+                val themeController = ThemeManager.INSTANCE.get(launcher).themeController
+                themeController?.createThemedAdaptiveIcon(
+                    launcher,
+                    icon as AdaptiveIconDrawable,
+                    appInfo.bitmap,
+                )?.let {
+                    icon = it
+                }
             }
             val launcherActivityInfo = outObj[0] as LauncherActivityInfo?
             if (launcherActivityInfo != null) {

--- a/lawnchair/src/app/lawnchair/ui/popup/LawnchairShortcut.kt
+++ b/lawnchair/src/app/lawnchair/ui/popup/LawnchairShortcut.kt
@@ -29,10 +29,8 @@ import com.android.launcher3.LauncherSettings.Favorites.ITEM_TYPE_TASK
 import com.android.launcher3.R
 import com.android.launcher3.Utilities
 import com.android.launcher3.graphics.ThemeManager
-import com.android.launcher3.icons.LauncherIcons
 import com.android.launcher3.model.data.AppInfo as ModelAppInfo
 import com.android.launcher3.model.data.ItemInfo
-import com.android.launcher3.model.data.ItemInfoWithIcon
 import com.android.launcher3.popup.SystemShortcut
 import com.android.launcher3.util.ApplicationInfoWrapper
 import com.android.launcher3.util.ComponentKey

--- a/lawnchair/src/app/lawnchair/ui/popup/LawnchairShortcut.kt
+++ b/lawnchair/src/app/lawnchair/ui/popup/LawnchairShortcut.kt
@@ -29,6 +29,7 @@ import com.android.launcher3.LauncherSettings.Favorites.ITEM_TYPE_TASK
 import com.android.launcher3.R
 import com.android.launcher3.Utilities
 import com.android.launcher3.graphics.ThemeManager
+import com.android.launcher3.icons.LauncherIcons
 import com.android.launcher3.model.data.AppInfo as ModelAppInfo
 import com.android.launcher3.model.data.ItemInfo
 import com.android.launcher3.popup.SystemShortcut
@@ -126,14 +127,18 @@ class LawnchairShortcut {
         override fun onClick(v: View) {
             val outObj = Array<Any?>(1) { null }
             var icon = Utilities.loadFullDrawableWithoutTheme(launcher, appInfo, 0, 0, outObj)
-            if (mItemInfo.screenId != NO_ID) {
-                val themeController = ThemeManager.INSTANCE.get(launcher).themeController
-                themeController?.createThemedAdaptiveIcon(
-                    launcher,
-                    icon as AdaptiveIconDrawable,
-                    appInfo.bitmap,
-                )?.let {
-                    icon = it
+            if (mItemInfo.screenId != NO_ID && Utilities.ATLEAST_T) {
+                val adaptiveIcon = icon as? AdaptiveIconDrawable
+                    ?: LauncherIcons.obtain(launcher).use { it.wrapToAdaptiveIcon(icon) }
+                if (adaptiveIcon != null) {
+                    val themeController = ThemeManager.INSTANCE.get(launcher).themeController
+                    themeController?.createThemedAdaptiveIcon(
+                        launcher,
+                        adaptiveIcon,
+                        appInfo.bitmap,
+                    )?.let {
+                        icon = it
+                    }
                 }
             }
             val launcherActivityInfo = outObj[0] as LauncherActivityInfo?


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Show the correct icon on customise popup when themed icon variant (monochrome, force monochrome, other effects) is selected, previously the customise popup only show the unthemed icon of the app regardless of settings on Lawnchair 16.

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->

Visual consistent

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Visual

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved themed adaptive icon rendering for the **Customize** shortcut.
  * Ensures the Customize icon is re-themed using the app’s bitmap when adaptive icon theming is supported and screen placement is available.
  * Maintains the prior icon behavior for cases where no valid screen placement applies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->