### PR TITLE
feat: Improve drawer search animations and state

### DIFF
--- a/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
+++ b/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
@@ -280,6 +280,17 @@ class LawnchairLauncher : QuickstepLauncher() {
         }
     }
 
+    override fun onStateBack() {
+        val searchInput = mAppsView?.searchUiManager?.editText
+        val isSearching = mAppsView?.isSearching == true || searchInput?.hasFocus() == true
+        if (isSearching) {
+            mAppsView?.searchUiManager?.resetSearch()
+            allAppsController.animateAllAppsToNoScale()
+        } else {
+            super.onStateBack()
+        }
+    }
+
     override fun createTouchControllers(): Array<TouchController> {
         val verticalSwipeController = VerticalSwipeTouchController(this, gestureController)
         return arrayOf<TouchController>(verticalSwipeController) + super.createTouchControllers()

--- a/lawnchair/src/app/lawnchair/allapps/AllAppsSearchInput.kt
+++ b/lawnchair/src/app/lawnchair/allapps/AllAppsSearchInput.kt
@@ -1,6 +1,7 @@
 package app.lawnchair.allapps
 
 import android.animation.ValueAnimator
+import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Color
 import android.graphics.Rect
@@ -12,6 +13,7 @@ import android.text.method.TextKeyListener
 import android.text.style.ForegroundColorSpan
 import android.util.AttributeSet
 import android.view.KeyEvent
+import android.view.MotionEvent
 import android.view.ViewTreeObserver
 import android.view.ViewTreeObserver.OnGlobalFocusChangeListener
 import android.view.animation.DecelerateInterpolator
@@ -248,11 +250,13 @@ class AllAppsSearchInput(context: Context, attrs: AttributeSet?) :
         val currentPaddingLeft = initialPaddingLeft
         val currentPaddingRight = initialPaddingRight
 
-        // Activate zero search on click
-        input.setOnClickListener {
-            if (input.text.isNullOrEmpty()) {
-                searchAlgorithm?.doZeroStateSearch(this)
+        // Activate zero search on tap
+        @SuppressLint("ClickableViewAccessibility")
+        input.setOnTouchListener { _, event ->
+            if (event.action == MotionEvent.ACTION_DOWN && !input.hasFocus()) {
+                setDirectFocus(true)
             }
+            false
         }
 
         input.onFocusChangeListener = { _, hasFocus ->
@@ -307,7 +311,11 @@ class AllAppsSearchInput(context: Context, attrs: AttributeSet?) :
                     launcher.stateManager.goToState(LauncherState.NORMAL)
                 }
 
-                queryEmpty = it.isNullOrEmpty()
+                val isEmpty = it.isNullOrEmpty()
+                if (isEmpty && !input.hasFocus()) {
+                    animatePadding(currentPaddingLeft, currentPaddingRight)
+                }
+                queryEmpty = isEmpty
             },
         )
 
@@ -413,6 +421,7 @@ class AllAppsSearchInput(context: Context, attrs: AttributeSet?) :
             appsView.appsStore?.removeUpdateListener(this)
         }
         input.viewTreeObserver.removeOnGlobalLayoutListener(this)
+        setDirectFocus(false)
     }
 
     override fun onAppsUpdated() {

--- a/lawnchair/src/app/lawnchair/allapps/AllAppsSearchInput.kt
+++ b/lawnchair/src/app/lawnchair/allapps/AllAppsSearchInput.kt
@@ -1,6 +1,7 @@
 package app.lawnchair.allapps
 
 import android.animation.ValueAnimator
+import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Color
 import android.graphics.Rect
@@ -12,10 +13,14 @@ import android.text.method.TextKeyListener
 import android.text.style.ForegroundColorSpan
 import android.util.AttributeSet
 import android.view.KeyEvent
+import android.view.MotionEvent
 import android.view.ViewTreeObserver
+import android.view.ViewTreeObserver.OnGlobalFocusChangeListener
 import android.view.animation.DecelerateInterpolator
 import android.widget.FrameLayout
 import android.widget.TextView
+import androidx.compose.animation.core.animateIntAsState
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -93,6 +98,7 @@ class AllAppsSearchInput(context: Context, attrs: AttributeSet?) :
     private lateinit var appsView: ActivityAllAppsContainerView<*>
     private var searchAlgorithm: LawnchairSearchAlgorithm? = null
 
+    private var isDirectFocus = false
     private var focusedResultTitle = ""
     private var canShowHint = false
     private var queryEmpty by mutableStateOf(true)
@@ -129,6 +135,26 @@ class AllAppsSearchInput(context: Context, attrs: AttributeSet?) :
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
 
             setContent {
+                var isFocused by remember(input) { mutableStateOf(input.hasFocus()) }
+
+                // Yes, this is a bit hacky, but it's the only way to ensure that
+                // we can check if the input has focus in Compose without wrestling
+                // with multiple global variables or state changes
+                DisposableEffect(input) {
+                    val focusListener = OnGlobalFocusChangeListener { _, _ ->
+                        isFocused = input.hasFocus()
+                    }
+
+                    val observer = input.viewTreeObserver
+                    observer.addOnGlobalFocusChangeListener(focusListener)
+
+                    onDispose {
+                        if (observer.isAlive) {
+                            observer.removeOnGlobalFocusChangeListener(focusListener)
+                        }
+                    }
+                }
+
                 val searchProviderPref by prefs2.hotseatQsbProvider.asState()
                 val searchProvider = remember(searchProviderPref, context) {
                     getSearchProvider(context, searchProviderPref)
@@ -159,12 +185,16 @@ class AllAppsSearchInput(context: Context, attrs: AttributeSet?) :
                     ColorTokens.SearchboxHighlight.resolveColor(context)
                 }
 
+                val backgroundAlpha by animateIntAsState(
+                    if (isFocused || !queryEmpty) 0 else 100,
+                )
+
                 // Ignore other theme attributes to preserve existing behavior
                 val style = buildQsbStyle(
                     context = context,
                     themed = themedQsb,
                     backgroundColor = backgroundColor,
-                    backgroundAlpha = (bgAlphaState * 100).toInt(),
+                    backgroundAlpha = backgroundAlpha,
                     cornerRadius = 1f,
                     strokeColor = null,
                     strokeWidth = 0f,
@@ -172,6 +202,9 @@ class AllAppsSearchInput(context: Context, attrs: AttributeSet?) :
 
                 val actions = QsbActions(
                     onQsbClick = {
+                        if (input.text.isNullOrEmpty()) {
+                            searchAlgorithm?.doZeroStateSearch(this@AllAppsSearchInput)
+                        }
                         input.requestFocus()
                         input.showKeyboard()
                     },
@@ -217,6 +250,13 @@ class AllAppsSearchInput(context: Context, attrs: AttributeSet?) :
         val currentPaddingLeft = initialPaddingLeft
         val currentPaddingRight = initialPaddingRight
 
+        // Activate zero search on click
+        input.setOnClickListener {
+            if (input.text.isNullOrEmpty()) {
+                searchAlgorithm?.doZeroStateSearch(this)
+            }
+        }
+
         input.onFocusChangeListener = { _, hasFocus ->
             if (hasFocus) {
                 if (prefs2.searchAlgorithm.firstCached() != LawnchairSearchAlgorithm.APP_SEARCH) {
@@ -225,16 +265,14 @@ class AllAppsSearchInput(context: Context, attrs: AttributeSet?) :
                     input.setHint(R.string.all_apps_search_bar_hint)
                 }
 
-                if (input.text.toString().isEmpty()) {
+                if (input.text.toString().isEmpty() && isDirectFocus) {
                     searchAlgorithm?.doZeroStateSearch(this)
+                    setDirectFocus(false)
                 }
 
                 setBackgroundVisibility(false, 0f)
                 animateHintVisibility(true)
                 animatePadding(currentPaddingLeft / 2, currentPaddingRight / 2)
-
-                // Sometimes the user has to click the input bar one more time
-                // for the keyboard to show.
             } else {
                 setBackgroundVisibility(true, 1f)
                 animateHintVisibility(false)
@@ -243,7 +281,9 @@ class AllAppsSearchInput(context: Context, attrs: AttributeSet?) :
                     suggestionsRecent.saveRecentQuery(query, null)
                 }
 
-                animatePadding(currentPaddingLeft, currentPaddingRight)
+                if (input.text.isNullOrEmpty()) {
+                    animatePadding(currentPaddingLeft, currentPaddingRight)
+                }
                 focusedResultTitle = ""
                 input.setHint("")
                 hint.text = ""
@@ -260,7 +300,7 @@ class AllAppsSearchInput(context: Context, attrs: AttributeSet?) :
             },
             afterTextChanged = {
                 updateHint()
-                if (input.text.isNullOrEmpty()) {
+                if (input.text.isNullOrEmpty() && input.hasFocus()) {
                     searchAlgorithm?.doZeroStateSearch(this)
                 }
                 if (input.text.toString() == "/lawnchairdebug") {
@@ -397,6 +437,10 @@ class AllAppsSearchInput(context: Context, attrs: AttributeSet?) :
 
     override fun resetSearch() {
         searchBarController.reset()
+    }
+
+    override fun setDirectFocus(directFocus: Boolean) {
+        isDirectFocus = directFocus
     }
 
     override fun preDispatchKeyEvent(event: KeyEvent) {

--- a/lawnchair/src/app/lawnchair/allapps/AllAppsSearchInput.kt
+++ b/lawnchair/src/app/lawnchair/allapps/AllAppsSearchInput.kt
@@ -1,7 +1,6 @@
 package app.lawnchair.allapps
 
 import android.animation.ValueAnimator
-import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Color
 import android.graphics.Rect
@@ -13,7 +12,6 @@ import android.text.method.TextKeyListener
 import android.text.style.ForegroundColorSpan
 import android.util.AttributeSet
 import android.view.KeyEvent
-import android.view.MotionEvent
 import android.view.ViewTreeObserver
 import android.view.ViewTreeObserver.OnGlobalFocusChangeListener
 import android.view.animation.DecelerateInterpolator
@@ -300,7 +298,7 @@ class AllAppsSearchInput(context: Context, attrs: AttributeSet?) :
             },
             afterTextChanged = {
                 updateHint()
-                if (input.text.isNullOrEmpty() && input.hasFocus()) {
+                if (input.text.isNullOrEmpty() && input.hasFocus() && !input.isResetting) {
                     searchAlgorithm?.doZeroStateSearch(this)
                 }
                 if (input.text.toString() == "/lawnchairdebug") {

--- a/lawnchair/src/app/lawnchair/allapps/FallbackSearchInputView.kt
+++ b/lawnchair/src/app/lawnchair/allapps/FallbackSearchInputView.kt
@@ -14,12 +14,23 @@ import com.android.launcher3.allapps.ActivityAllAppsContainerView
 class FallbackSearchInputView(context: Context, attrs: AttributeSet?) : ExtendedEditText(context, attrs) {
 
     private var appsView: ActivityAllAppsContainerView<*>? = null
+    var isResetting = false
+        private set
 
     init {
         val accentColor = ColorTokens.ColorAccent.resolveColor(context)
         setCursorColor(accentColor)
         setTextSelectHandleColor(accentColor)
         highlightColor = ColorUtils.setAlphaComponent(accentColor, 82)
+    }
+
+    override fun reset() {
+        isResetting = true
+        try {
+            super.reset()
+        } finally {
+            isResetting = false
+        }
     }
 
     fun initialize(appsView: ActivityAllAppsContainerView<*>?) {

--- a/lawnchair/src/app/lawnchair/gestures/handlers/OpenAppDrawerGestureHandler.kt
+++ b/lawnchair/src/app/lawnchair/gestures/handlers/OpenAppDrawerGestureHandler.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import app.lawnchair.LawnchairLauncher
 import app.lawnchair.animateToAllApps
 
-open class OpenAppDrawerGestureHandler(context: Context) : GestureHandler(context) {
+class OpenAppDrawerGestureHandler(context: Context) : GestureHandler(context) {
 
     override suspend fun onTrigger(launcher: LawnchairLauncher) {
         launcher.animateToAllApps()

--- a/lawnchair/src/app/lawnchair/gestures/handlers/OpenAppSearchGestureHandler.kt
+++ b/lawnchair/src/app/lawnchair/gestures/handlers/OpenAppSearchGestureHandler.kt
@@ -2,13 +2,14 @@ package app.lawnchair.gestures.handlers
 
 import android.content.Context
 import app.lawnchair.LawnchairLauncher
+import app.lawnchair.animateToAllApps
 
-class OpenAppSearchGestureHandler(context: Context) : OpenAppDrawerGestureHandler(context) {
+class OpenAppSearchGestureHandler(context: Context) : GestureHandler(context) {
 
     override suspend fun onTrigger(launcher: LawnchairLauncher) {
-        super.onTrigger(launcher)
         val searchUiManager = launcher.appsView.searchUiManager
         searchUiManager.setDirectFocus(true)
         searchUiManager.editText?.showKeyboard()
+        launcher.animateToAllApps()
     }
 }

--- a/lawnchair/src/app/lawnchair/gestures/handlers/OpenAppSearchGestureHandler.kt
+++ b/lawnchair/src/app/lawnchair/gestures/handlers/OpenAppSearchGestureHandler.kt
@@ -7,6 +7,8 @@ class OpenAppSearchGestureHandler(context: Context) : OpenAppDrawerGestureHandle
 
     override suspend fun onTrigger(launcher: LawnchairLauncher) {
         super.onTrigger(launcher)
-        launcher.appsView.searchUiManager.editText?.showKeyboard()
+        val searchUiManager = launcher.appsView.searchUiManager
+        searchUiManager.setDirectFocus(true)
+        searchUiManager.editText?.showKeyboard()
     }
 }

--- a/lawnchair/src/app/lawnchair/qsb/LawnQsbLayout.kt
+++ b/lawnchair/src/app/lawnchair/qsb/LawnQsbLayout.kt
@@ -105,7 +105,9 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
                                 val launcher = context.launcher
                                 launcher.lifecycleScope.launch {
                                     if (prefs2.matchHotseatQsbStyle.firstCached()) {
-                                        launcher.appsView.searchUiManager.editText?.showKeyboard()
+                                        val searchUiManager = launcher.appsView.searchUiManager
+                                        searchUiManager.setDirectFocus(true)
+                                        searchUiManager.editText?.showKeyboard()
                                         launcher.animateToAllApps()
                                     } else {
                                         searchProvider.launch(launcher)

--- a/lawnchair/src/app/lawnchair/qsb/LawnQsbUi.kt
+++ b/lawnchair/src/app/lawnchair/qsb/LawnQsbUi.kt
@@ -3,9 +3,11 @@ package app.lawnchair.qsb
 import android.content.Context
 import androidx.annotation.ColorInt
 import androidx.annotation.DrawableRes
-import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.SizeTransform
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -393,23 +395,27 @@ fun LawnQsbUi(
 
         Spacer(Modifier.weight(1f))
 
-        state.endIcons.forEachIndexed { index, icon ->
-            val isLastVisible = remember(state.endIcons, index) {
-                state.endIcons.drop(index + 1).none { it.visible }
-            }
-            AnimatedVisibility(
-                visible = icon.visible,
-                enter = fadeIn(),
-                exit = fadeOut(),
-            ) {
-                QsbIcon(
-                    icon = icon,
-                    shape = shape,
-                    onClick = { actions.onEndIconClick(icon.id) },
-                    modifier = Modifier.addIf(isLastVisible) {
-                        offset(x = (-6).dp)
-                    },
-                )
+        val visibleIcons = state.endIcons.filter { it.visible }
+        AnimatedContent(
+            targetState = visibleIcons,
+            transitionSpec = {
+                fadeIn() togetherWith fadeOut() using SizeTransform(clip = false)
+            },
+            label = "endIcons",
+            contentAlignment = Alignment.CenterEnd,
+        ) { icons ->
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                icons.forEachIndexed { index, icon ->
+                    val isLast = index == icons.lastIndex
+                    QsbIcon(
+                        icon = icon,
+                        shape = shape,
+                        onClick = { actions.onEndIconClick(icon.id) },
+                        modifier = Modifier.addIf(isLast) {
+                            offset(x = (-6).dp)
+                        },
+                    )
+                }
             }
         }
     }

--- a/lawnchair/src/app/lawnchair/qsb/providers/AppSearch.kt
+++ b/lawnchair/src/app/lawnchair/qsb/providers/AppSearch.kt
@@ -16,6 +16,8 @@ data object AppSearch : QsbSearchProvider(
 ) {
     override suspend fun launch(launcher: Launcher, forceWebsite: Boolean) {
         launcher.animateToAllApps()
-        launcher.appsView.searchUiManager.editText?.showKeyboard()
+        val searchUiManager = launcher.appsView.searchUiManager
+        searchUiManager.setDirectFocus(true)
+        searchUiManager.editText?.showKeyboard()
     }
 }

--- a/src/com/android/launcher3/allapps/ActivityAllAppsContainerView.java
+++ b/src/com/android/launcher3/allapps/ActivityAllAppsContainerView.java
@@ -77,6 +77,7 @@ import com.android.launcher3.DeviceProfile;
 import com.android.launcher3.DeviceProfile.OnDeviceProfileChangeListener;
 import com.android.launcher3.DragSource;
 import com.android.launcher3.DropTarget.DragObject;
+import com.android.launcher3.ExtendedEditText;
 import com.android.launcher3.Flags;
 import com.android.launcher3.Insettable;
 import com.android.launcher3.InsettableFrameLayout;
@@ -908,8 +909,22 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
         }
 
         boolean bgVisible = mSearchUiManager.getBackgroundVisibility();
-        if (scrolledOffset == 0 && !isSearching()) {
-            bgVisible = true;
+        if (scrolledOffset == 0) {
+            if (!isSearching()) {
+                bgVisible = true;
+            }
+            // LC-Note: Match Pixel Launcher behavior by focusing
+            // and showing the keyboard on scroll to top
+            if (PreferenceCacheExtensionsKt.firstCached(pref2.getAutoShowKeyboardInDrawer())) {
+                boolean isTransitioning = mAllAppsTransitionController != null
+                    && mAllAppsTransitionController.getProgress() > 0f;
+                if (!isTransitioning) {
+                    ExtendedEditText editText = mSearchUiManager.getEditText();
+                    if (editText != null && !editText.isFocused()) {
+                        editText.showKeyboard();
+                    }
+                }
+            }
         } else if (scrolledOffset > mHeaderThreshold) {
             bgVisible = false;
         }

--- a/src/com/android/launcher3/allapps/ActivityAllAppsContainerView.java
+++ b/src/com/android/launcher3/allapps/ActivityAllAppsContainerView.java
@@ -196,6 +196,7 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
 
     /** {@code true} when rendered view is in search state instead of the scroll state. */
     private boolean mIsSearching;
+    private boolean mSearchExitInProgress;
     boolean showFastScroller;
     private boolean mRebindAdaptersAfterSearchAnimation;
     private int mNavBarScrimHeight = 0;
@@ -469,6 +470,7 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
         if (!mSearchTransitionController.isRunning() && goingToSearch == isSearching()) {
             return;
         }
+        mSearchExitInProgress = !goingToSearch;
         mFastScroller.setVisibility(goingToSearch ? INVISIBLE : VISIBLE);
         if (goingToSearch) {
             // Fade out the button to pause work apps.
@@ -490,12 +492,14 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
 
                     if (goingToSearch) {
                         mSearchUiDelegate.onAnimateToSearchStateCompleted();
+                        mSearchExitInProgress = false;
                     } else {
                         setSearchResults(null);
                         if (mViewPager != null) {
                             mViewPager.setCurrentPage(previousPage);
                         }
                         onActivePageChanged(previousPage);
+                        mSearchExitInProgress = false;
                     }
                 });
     }
@@ -916,9 +920,12 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
             // LC-Note: Match Pixel Launcher behavior by focusing
             // and showing the keyboard on scroll to top
             if (PreferenceCacheExtensionsKt.firstCached(pref2.getAutoShowKeyboardInDrawer())) {
-                boolean isTransitioning = mAllAppsTransitionController != null
-                    && mAllAppsTransitionController.getProgress() > 0f;
-                if (!isTransitioning) {
+                boolean isControllerAnimating = mAllAppsTransitionController != null
+                        && (mAllAppsTransitionController.getProgress() > 0f
+                        || mAllAppsTransitionController.getAllAppScale().isAnimating());
+                boolean isSearchTransitioning = mSearchTransitionController.isRunning()
+                        || mSearchExitInProgress;
+                if (!isControllerAnimating && !isSearchTransitioning) {
                     ExtendedEditText editText = mSearchUiManager.getEditText();
                     if (editText != null && !editText.isFocused()) {
                         editText.showKeyboard();

--- a/src/com/android/launcher3/allapps/SearchUiManager.java
+++ b/src/com/android/launcher3/allapps/SearchUiManager.java
@@ -82,4 +82,9 @@ public interface SearchUiManager {
     default boolean inZeroState() {
         return false;
     }
+
+    /**
+     * Sets whether the search bar is being focused directly (e.g. by tapping it).
+     */
+    default void setDirectFocus(boolean directFocus) {}
 }


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

This PR improves the app drawer search state system to do the following things to match Pixel Launcher:
- Activate zero state only if these conditions are met:
  - The drawer search bar is tapped
  - The dock search bar is tapped, and `matchHotseatQsbStyle` is on or `AppSearch` is the current provider
  - The query is cleared
- Improves the search bar animation state to only remove the background and padding when the search bar has focus or has query
- Fixes the search bar end icon animation on tap
- Add a back state handler in `LawnchairLauncher` so when back button is pressed, it exits search instead of exiting the app drawer, matching the intention of `shouldBackExitSearch`.

Addresses task of #6442.

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Simpler to demonstrate directly:

a. ["Automatically show keyboard" off](https://github.com/user-attachments/assets/40f1eba0-d235-4c2c-884b-910c206b1835)
b. ["Automatically show keyboard" on](https://github.com/user-attachments/assets/1dcfba2a-8463-4ae0-b548-f081d54b6861)
c. [Zero state when launching via dock search bar / gesture handler](https://github.com/user-attachments/assets/a315dd49-ff05-4b9f-a678-446934a26c3c)

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

:white_check_mark: **New feature** (A non-breaking change that adds functionality)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Back navigation now exits All Apps search first (clearing the query) before leaving All Apps.
  - When the list is scrolled to the top, the app can optionally auto-open the search keyboard, while avoiding conflicts with active transitions.
  - Opening search from QSB/app search/gestures now uses “direct focus” for a faster, more responsive keyboard experience.

- **Bug Fixes**
  - Improved search input styling and zero-state search behavior based on focus and whether the query is empty.
  - More consistent search input reset/transition handling.
  - Smoother, list-level animation for QSB end-icon visibility changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->