### PR TITLE
fix: Restore bottom sheet exit behaviour on icon changed

### DIFF
--- a/lawnchair/src/app/lawnchair/override/CustomizeDialog.kt
+++ b/lawnchair/src/app/lawnchair/override/CustomizeDialog.kt
@@ -1,5 +1,6 @@
 package app.lawnchair.override
 
+import android.app.Activity
 import android.graphics.drawable.Drawable
 import android.util.Log
 import androidx.compose.foundation.Image
@@ -23,6 +24,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -31,6 +33,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import app.lawnchair.BlankActivity
 import app.lawnchair.gestures.type.GestureType
 import app.lawnchair.launcher
 import app.lawnchair.preferences.getAdapter
@@ -50,6 +53,7 @@ import com.android.launcher3.LauncherState
 import com.android.launcher3.R
 import com.android.launcher3.util.ComponentKey
 import com.google.accompanist.drawablepainter.rememberDrawablePainter
+import kotlinx.coroutines.launch
 
 @Composable
 fun CustomizeDialog(
@@ -151,10 +155,16 @@ fun CustomizeAppDialog(
 
     Log.d("CustomizeDialog", route.toString())
 
+    val scope = rememberCoroutineScope()
     val openIconPicker = {
         val intent = PreferenceActivity.createIntent(context, route)
-            .addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
-        context.startActivity(intent)
+        scope.launch {
+            val result = BlankActivity.startBlankActivityForResult(context as Activity, intent)
+            if (result.resultCode == Activity.RESULT_OK) {
+                onClose()
+            }
+        }
+        Unit
     }
 
     DisposableEffect(Unit) {


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Restore bottom sheet exit behaviour on icon changed as seen on older modern Lawnchair.

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Bottom sheet trigger, change icon or exit via back navigation, observe result.

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the icon picker flow in the app customization dialog.
  * The dialog now closes automatically after an icon is selected successfully.
  * Improved handling when returning from the icon picker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->