### PR TITLE
refactor: Hide set as default page popup entry by default

### DIFF
--- a/lawnchair/src/app/lawnchair/ui/popup/LauncherOptionsPopup.kt
+++ b/lawnchair/src/app/lawnchair/ui/popup/LauncherOptionsPopup.kt
@@ -24,7 +24,7 @@ object LauncherOptionsPopup {
         LauncherOptionPopupItem("all_apps", true),
         LauncherOptionPopupItem("home_settings", true),
         LauncherOptionPopupItem("sys_settings", false),
-        LauncherOptionPopupItem("default_page", true),
+        LauncherOptionPopupItem("default_page", false),
     )
 
     fun restoreMissingPopupOptions(


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Hide set as default page popup entry by default.

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->

Restore the default of Launcher3/Pixel Launcher, and the entry is too easy to be triggered for a mildly destructive/annoyance action.

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->


Trigger popup menu, and observe

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Refactor** (A code change that neither fixes a bug nor adds a feature)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restored launcher popup options now keep the “Default page” option disabled when it is missing from the configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->