### PR TITLE
fix: Protolog init crash on Q and R (below Release 41)

### DIFF
--- a/quickstep/src/com/android/launcher3/uioverrides/QuickstepLauncher.java
+++ b/quickstep/src/com/android/launcher3/uioverrides/QuickstepLauncher.java
@@ -942,9 +942,6 @@ public class QuickstepLauncher extends Launcher implements RecentsViewContainer,
     @Override
     protected void logOnNewIntent(boolean alreadyOnHome, boolean shouldMoveToDefaultScreen,
             String action, boolean internalStateHandled) {
-        // LC-Note: This is workaround for skipping Android 11 Release 41. 
-        //          Not the best solutions but this is not significant enough to Lawnchair.
-        if (!Utilities.ATLEAST_S) return;
         OverviewCommandHelperProtoLogProxy.logOnNewIntent(alreadyOnHome, shouldMoveToDefaultScreen,
                 action, internalStateHandled);
     }

--- a/quickstep/src_protolog/com/android/quickstep/util/QuickstepProtoLogGroup.java
+++ b/quickstep/src_protolog/com/android/quickstep/util/QuickstepProtoLogGroup.java
@@ -41,7 +41,10 @@ public enum QuickstepProtoLogGroup implements IProtoLogGroup {
     private final @NonNull String mTag;
 
     public static boolean isProtoLogInitialized() {
-        if (!Utilities.ATLEAST_R) return false;
+        // LC-Note: This is workaround for skipping Android 11 Release 41. 
+        //          Not the best solutions but this is not significant enough to Lawnchair.
+        if (!Utilities.ATLEAST_S) return false;
+
 
         if (!Variables.sIsInitialized) {
             Log.w(Constants.TAG,

--- a/quickstep/src_protolog/com/android/quickstep/util/QuickstepProtoLogGroup.java
+++ b/quickstep/src_protolog/com/android/quickstep/util/QuickstepProtoLogGroup.java
@@ -55,6 +55,10 @@ public enum QuickstepProtoLogGroup implements IProtoLogGroup {
     }
 
     public static void initProtoLog() {
+        // LC-Note: This is workaround for skipping Android 11 Release 41. 
+        //          Not the best solutions but this is not significant enough to Lawnchair.
+        if (!Utilities.ATLEAST_S) return;
+        
         if (Variables.sIsInitialized) {
             Log.e(Constants.TAG,
                     "Attempting to re-initialize ProtoLog.", new IllegalStateException());


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Prevent Protolog from init in Android 11 Release 41 and older device.

Fixes https://discord.com/channels/803299970169700402/803506450805817385/1531100587788341519 (from crash logs)
Fixes #6387

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->


### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved launcher event logging behavior across supported Android versions by consistently forwarding intent logging to the appropriate logging handler.
  * Updated ProtoLog initialization checks to align with Android S and newer, including the relevant workaround guidance, while keeping existing idempotency and warning/error handling behavior intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->