### PR TITLE
fix: Cancel GestureController when launcher instance's destroyed

### DIFF
--- a/lawnchair/src/app/lawnchair/gestures/GestureController.kt
+++ b/lawnchair/src/app/lawnchair/gestures/GestureController.kt
@@ -25,7 +25,6 @@ import app.lawnchair.gestures.handlers.NoOpGestureHandler
 import app.lawnchair.preferences2.PreferenceManager2
 import com.android.launcher3.util.VibratorWrapper
 import com.patrykmichalik.opto.domain.Preference
-import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.distinctUntilChanged

--- a/lawnchair/src/app/lawnchair/gestures/GestureController.kt
+++ b/lawnchair/src/app/lawnchair/gestures/GestureController.kt
@@ -36,7 +36,7 @@ import kotlinx.coroutines.launch
 
 class GestureController(private val launcher: LawnchairLauncher) {
     private val prefs = PreferenceManager2.getInstance(launcher)
-    private val scope = MainScope()
+    private val scope = launcher.lifecycleScope
 
     private val doubleTapHandler = handler(prefs.doubleTapGestureHandler)
     private val swipeUpHandler = handler(prefs.swipeUpGestureHandler)


### PR DESCRIPTION
…her is destroyed

<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Limit GestureController scope from MainScope to LawnchairLauncher instance to prevent a small and rare memory leak.

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Reproduce with LeakCanary should yield zero result related to GestureController

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gesture handling lifecycle management to help prevent background activity from continuing after the launcher is closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->