### PR TITLE
refactor: Add PreferenceManager2 firstCached in FlowUtils

### DIFF
--- a/lawnchair/src/app/lawnchair/util/FlowUtils.kt
+++ b/lawnchair/src/app/lawnchair/util/FlowUtils.kt
@@ -9,6 +9,10 @@ import androidx.compose.runtime.Composable
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import app.lawnchair.LawnchairApp
+import app.lawnchair.preferences2.PreferenceManager2
+import com.patrykmichalik.opto.core.PreferenceImpl
+import com.patrykmichalik.opto.core.getFromPreferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
@@ -23,11 +27,15 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
-@Discouraged("This is a blocking read, use firstCached() for non-blocking reads")
+@Discouraged("This is a blocking read, use firstCached() for non-blocking reads or equivalent where possible")
 fun <T> Flow<T>.firstBlocking() = runBlocking { first() }
 
 @Composable
 fun <T> Flow<T>.collectAsStateBlocking() = collectAsStateWithLifecycle(initialValue = firstBlocking())
+
+fun <C, S> PreferenceImpl<C, S>.firstCached(
+    prefs2: PreferenceManager2 = PreferenceManager2.getInstance(LawnchairApp.instance),
+): C = getFromPreferences(prefs2.getCachedPreferences())
 
 fun broadcastReceiverFlow(context: Context, filter: IntentFilter) = callbackFlow {
     val receiver = object : BroadcastReceiver() {


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Allow preference flow to use cached preference

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->


### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Refactor** (A code change that neither fixes a bug nor adds a feature)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Added faster cached preference reads to reduce waiting when retrieving previously stored settings.

* **Developer Guidance**
  * Updated guidance for blocking preference and flow reads, recommending cached reads when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->