### PR TITLE
fix: List item use the incorrect shapes for rendering template

### DIFF
--- a/lawnchair/src/app/lawnchair/ui/preferences/components/controls/WarningPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/controls/WarningPreference.kt
@@ -81,7 +81,7 @@ fun WarningPreference(
                 draggedShape = MaterialTheme.shapes.large,
             )
         } else {
-            ListItemDefaults.segmentedShapes(index = 0, count = 1)
+            ListItemDefaults.shapes()
         },
         colors = colors,
     )

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/layout/PreferenceTemplate.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/layout/PreferenceTemplate.kt
@@ -47,7 +47,7 @@ fun PreferenceTemplate(
     description: (@Composable () -> Unit)? = null,
     startWidget: (@Composable () -> Unit)? = null,
     endWidget: (@Composable () -> Unit)? = null,
-    shapes: ListItemShapes = ListItemDefaults.segmentedShapes(index = 0, count = 1),
+    shapes: ListItemShapes = ListItemDefaults.shapes(),
     onClick: (() -> Unit)? = null,
     colors: ListItemColors = ListItemDefaults.segmentedColors(
         containerColor = MaterialTheme.colorScheme.surfaceContainer,


### PR DESCRIPTION
…late

<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

List item use the incorrect shapes for rendering template, or adapt to AndroidX Compose Material3 `1.5.0 alpha25`

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->

After `alpha25`, all the list item were rendered as bubbly (single item segmented list). Before `alpha25`, all the items were rendered as the middle position of segmented list (which is intended).

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Visual

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated preference list items to use consistent default shapes.
  * Improved visual consistency for warning preferences and preference templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->