### PR TITLE
fix: Avoid calling file related to Protolog under S

### DIFF
--- a/quickstep/src/com/android/launcher3/uioverrides/QuickstepLauncher.java
+++ b/quickstep/src/com/android/launcher3/uioverrides/QuickstepLauncher.java
@@ -677,7 +677,7 @@ public class QuickstepLauncher extends Launcher implements RecentsViewContainer,
                     TaskView taskToLaunch = currentPageTask;
                     if (currentPageTask == null) {
                         taskToLaunch = fallbackTask;
-                        ActiveGestureProtoLogProxy.logQuickSwitchFromHomeFallback(
+                        if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logQuickSwitchFromHomeFallback(
                                 rv.getCurrentPage());
                     }
                     taskToLaunch.launchWithoutAnimation(success -> {
@@ -689,7 +689,7 @@ public class QuickstepLauncher extends Launcher implements RecentsViewContainer,
                         return Unit.INSTANCE;
                     });
                 } else {
-                    ActiveGestureProtoLogProxy.logQuickSwitchFromHomeFailed(rv.getCurrentPage());
+                    if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logQuickSwitchFromHomeFailed(rv.getCurrentPage());
                     getStateManager().goToState(NORMAL);
                 }
                 break;
@@ -942,6 +942,7 @@ public class QuickstepLauncher extends Launcher implements RecentsViewContainer,
     @Override
     protected void logOnNewIntent(boolean alreadyOnHome, boolean shouldMoveToDefaultScreen,
             String action, boolean internalStateHandled) {
+        if (!Utilities.ATLEAST_S) return;
         OverviewCommandHelperProtoLogProxy.logOnNewIntent(alreadyOnHome, shouldMoveToDefaultScreen,
                 action, internalStateHandled);
     }

--- a/quickstep/src/com/android/quickstep/AbsSwipeUpHandler.java
+++ b/quickstep/src/com/android/quickstep/AbsSwipeUpHandler.java
@@ -387,7 +387,7 @@ public abstract class AbsSwipeUpHandler<
         mContextInitListener =
                 mContainerInterface.createActivityInitListener(this::onActivityInit);
         mLauncherOnDestroyCallback = () -> {
-            ActiveGestureProtoLogProxy.logLauncherDestroyed();
+            if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logLauncherDestroyed();
             mContextInitListener.unregister("AbsSwipeUpHandler.mLauncherOnDestroyCallback");
             if (mRecentsView != null) {
                 mRecentsView.removeOnScrollChangedListener(mOnRecentsScrollListener);
@@ -1045,7 +1045,7 @@ public abstract class AbsSwipeUpHandler<
 
     @Override
     public void onRecentsAnimationCanceled(HashMap<Integer, ThumbnailData> thumbnailDatas) {
-        ActiveGestureProtoLogProxy.logAbsSwipeUpHandlerOnRecentsAnimationCanceled();
+        if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logAbsSwipeUpHandlerOnRecentsAnimationCanceled();
         mContextInitListener.unregister("AbsSwipeUpHandler.onRecentsAnimationCanceled");
         mStateCallback.setStateOnUiThread(STATE_GESTURE_CANCELLED | STATE_HANDLER_INVALIDATED);
         // Defer clearing the controller and the targets until after we've updated the state
@@ -1265,7 +1265,7 @@ public abstract class AbsSwipeUpHandler<
             // Resets this value as the gesture is now complete.
             mContainerInterface.getTaskbarController().setUserIsNotGoingHome(false);
         }
-        ActiveGestureProtoLogProxy.logOnSettledOnEndTarget(endTarget.name());
+        if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logOnSettledOnEndTarget(endTarget.name());
     }
 
     /** @return Whether this was the task we were waiting to appear, and thus handled it. */
@@ -1301,7 +1301,7 @@ public abstract class AbsSwipeUpHandler<
             boolean isFlingY,
             boolean isCancel,
             boolean horizontalTouchSlopPassed) {
-        ActiveGestureProtoLogProxy.logOnCalculateEndTarget(
+        if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logOnCalculateEndTarget(
                 dpiFromPx(velocityPxPerMs.x),
                 dpiFromPx(velocityPxPerMs.y),
                 Math.toDegrees(Math.atan2(-velocityPxPerMs.y, velocityPxPerMs.x)));
@@ -1866,7 +1866,7 @@ public abstract class AbsSwipeUpHandler<
                         mRemoteTargetHandles, timestamp, velocityPxPerMs);
         mRecentsAnimationController.handOffAnimation(
                 targetsAndStates.first, targetsAndStates.second);
-        ActiveGestureProtoLogProxy.logHandOffAnimation();
+        if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logHandOffAnimation();
     }
 
     private int calculateWindowRotation(RemoteAnimationTarget runningTaskTarget,
@@ -2144,7 +2144,7 @@ public abstract class AbsSwipeUpHandler<
      * handler (in case of quick switch).
      */
     private void cancelCurrentAnimation() {
-        ActiveGestureProtoLogProxy.logAbsSwipeUpHandlerCancelCurrentAnimation();
+        if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logAbsSwipeUpHandlerCancelCurrentAnimation();
         mCanceled = true;
         mCurrentShift.cancelAnimation();
 
@@ -2476,7 +2476,7 @@ public abstract class AbsSwipeUpHandler<
                 if (!hasTaskPreviouslyAppeared) {
                     ActiveGestureLog.INSTANCE.trackEvent(EXPECTING_TASK_APPEARED);
                 }
-                ActiveGestureProtoLogProxy.logStartNewTask(nextTaskLog);
+                if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logStartNewTask(nextTaskLog);
                 nextTask.launchWithoutAnimation(true, success -> {
                     resultCallback.accept(success);
                     if (success) {
@@ -2555,7 +2555,7 @@ public abstract class AbsSwipeUpHandler<
             return;
         }
         final Runnable onFinishComplete = () -> {
-            ActiveGestureProtoLogProxy.logAbsSwipeUpHandlerOnTasksAppeared();
+            if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logAbsSwipeUpHandlerOnTasksAppeared();
             mStateCallback.setStateOnUiThread(STATE_GESTURE_CANCELLED | STATE_HANDLER_INVALIDATED);
         };
         ActiveGestureLog.CompoundString forceFinishReason =
@@ -2566,7 +2566,7 @@ public abstract class AbsSwipeUpHandler<
             // previous quickswitch task launch, then cancel the animation back to the app
             RemoteAnimationTarget appearedTaskTarget = appearedTaskTargets[0];
             TaskInfo taskInfo = appearedTaskTarget.taskInfo;
-            ActiveGestureProtoLogProxy.logUnexpectedTaskAppeared(
+            if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logUnexpectedTaskAppeared(
                     taskInfo.taskId,
                     taskInfo.baseIntent.getComponent().getPackageName());
             finishRecentsAnimationOnTasksAppeared(onFinishComplete);
@@ -2576,7 +2576,7 @@ public abstract class AbsSwipeUpHandler<
                 ActiveGestureLog.CompoundString.newEmptyString();
         if (!handleTaskAppeared(appearedTaskTargets, handleTaskFailureReason)) {
             forceFinishReason.append(handleTaskFailureReason);
-            ActiveGestureProtoLogProxy.logHandleTaskAppearedFailed(forceFinishReason);
+            if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logHandleTaskAppearedFailed(forceFinishReason);
             finishRecentsAnimationOnTasksAppeared(onFinishComplete);
             return;
         }
@@ -2585,7 +2585,7 @@ public abstract class AbsSwipeUpHandler<
                 .toArray(RemoteAnimationTarget[]::new);
         if (taskTargets.length == 0) {
             forceFinishReason.append("No appeared task matching started task id");
-            ActiveGestureProtoLogProxy.logHandleTaskAppearedFailed(forceFinishReason);
+            if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logHandleTaskAppearedFailed(forceFinishReason);
             finishRecentsAnimationOnTasksAppeared(onFinishComplete);
             return;
         }
@@ -2595,13 +2595,13 @@ public abstract class AbsSwipeUpHandler<
         if (taskView == null || taskView.getTaskContainers().stream().noneMatch(
                 TaskContainer::getShouldShowSplashView)) {
             forceFinishReason.append("Splash not needed");
-            ActiveGestureProtoLogProxy.logHandleTaskAppearedFailed(forceFinishReason);
+            if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logHandleTaskAppearedFailed(forceFinishReason);
             finishRecentsAnimationOnTasksAppeared(onFinishComplete);
             return;
         }
         if (mContainer == null) {
             forceFinishReason.append("Activity destroyed");
-            ActiveGestureProtoLogProxy.logHandleTaskAppearedFailed(forceFinishReason);
+            if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logHandleTaskAppearedFailed(forceFinishReason);
             finishRecentsAnimationOnTasksAppeared(onFinishComplete);
             return;
         }
@@ -2657,7 +2657,7 @@ public abstract class AbsSwipeUpHandler<
         if (mRecentsAnimationController != null) {
             mRecentsAnimationController.finish(false /* toRecents */, onFinishComplete);
         }
-        ActiveGestureProtoLogProxy.logFinishRecentsAnimationOnTasksAppeared();
+        if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logFinishRecentsAnimationOnTasksAppeared();
     }
 
     /**

--- a/quickstep/src/com/android/quickstep/GestureState.java
+++ b/quickstep/src/com/android/quickstep/GestureState.java
@@ -38,6 +38,7 @@ import android.window.TransitionInfo;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.android.launcher3.Utilities;
 import com.android.launcher3.statemanager.BaseState;
 import com.android.launcher3.statemanager.StatefulContainer;
 import com.android.quickstep.TopTaskTracker.CachedTaskInfo;
@@ -441,7 +442,7 @@ public class GestureState implements RecentsAnimationCallbacks.RecentsAnimationL
     public void setEndTarget(GestureEndTarget target, boolean isAtomic) {
         mEndTarget = target;
         mStateCallback.setState(STATE_END_TARGET_SET);
-        ActiveGestureProtoLogProxy.logSetEndTarget(mEndTarget.name());
+        if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logSetEndTarget(mEndTarget.name());
         switch (mEndTarget) {
             case HOME:
                 ActiveGestureLog.INSTANCE.trackEvent(SET_END_TARGET_HOME);

--- a/quickstep/src/com/android/quickstep/InputConsumerUtils.kt
+++ b/quickstep/src/com/android/quickstep/InputConsumerUtils.kt
@@ -18,6 +18,7 @@ package com.android.quickstep
 import android.content.Context
 import android.view.MotionEvent
 import androidx.annotation.VisibleForTesting
+import com.android.launcher3.Utilities
 import com.android.launcher3.anim.AnimatedFloat
 import com.android.launcher3.statemanager.BaseState
 import com.android.launcher3.statemanager.StatefulContainer
@@ -538,7 +539,7 @@ object InputConsumerUtils {
             // running activity as the task behind the overlay.
             val otherVisibleTask = runningTask?.visibleNonExcludedTask
             if (otherVisibleTask != null) {
-                ActiveGestureProtoLogProxy.logUpdateGestureStateRunningTask(
+                if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logUpdateGestureStateRunningTask(
                     otherVisibleTask.packageName ?: "MISSING",
                     runningTask.packageName ?: "MISSING",
                 )
@@ -838,7 +839,7 @@ object InputConsumerUtils {
         consumer: InputConsumer,
         reasonString: CompoundString,
     ) {
-        ActiveGestureProtoLogProxy.logSetInputConsumer(consumer.name, reasonString.toString())
+        if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logSetInputConsumer(consumer.name, reasonString.toString())
         if ((consumer.type and InputConsumer.TYPE_OTHER_ACTIVITY) != 0) {
             ActiveGestureLog.INSTANCE.trackEvent(
                 ActiveGestureErrorDetector.GestureEvent.FLAG_USING_OTHER_ACTIVITY_INPUT_CONSUMER

--- a/quickstep/src/com/android/quickstep/MultiStateCallback.java
+++ b/quickstep/src/com/android/quickstep/MultiStateCallback.java
@@ -25,6 +25,7 @@ import android.util.SparseArray;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.android.launcher3.Utilities;
 import com.android.launcher3.config.FeatureFlags;
 import com.android.quickstep.util.ActiveGestureErrorDetector;
 import com.android.quickstep.util.ActiveGestureLog;
@@ -116,7 +117,7 @@ public class MultiStateCallback {
                 continue;
             }
             if (gestureEvent.mLogEvent) {
-                ActiveGestureProtoLogProxy.logDynamicString(
+                if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logDynamicString(
                         gestureEvent.name(), gestureEvent.mTrackEvent ? gestureEvent : null);
             } else if (gestureEvent.mTrackEvent) {
                 ActiveGestureLog.INSTANCE.trackEvent(gestureEvent);

--- a/quickstep/src/com/android/quickstep/OrientationTouchTransformer.java
+++ b/quickstep/src/com/android/quickstep/OrientationTouchTransformer.java
@@ -32,6 +32,7 @@ import android.view.MotionEvent;
 import android.view.Surface;
 
 import com.android.launcher3.R;
+import com.android.launcher3.Utilities;
 import com.android.launcher3.testing.shared.ResourceUtils;
 import com.android.launcher3.testing.shared.TestProtocol;
 import com.android.launcher3.util.DisplayController.Info;
@@ -270,7 +271,7 @@ class OrientationTouchTransformer {
             }
         }
         updateOneHandedRegions(orientationRectF);
-        ActiveGestureProtoLogProxy.logCreateTouchRegionForDisplay(rotation, size, orientationRectF,
+        if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logCreateTouchRegionForDisplay(rotation, size, orientationRectF,
                 mOneHandedModeRegion, mNavBarGesturalHeight, mNavBarLargerGesturalHeight,
                 reason);
 

--- a/quickstep/src/com/android/quickstep/OverviewCommandHelper.kt
+++ b/quickstep/src/com/android/quickstep/OverviewCommandHelper.kt
@@ -32,6 +32,7 @@ import com.android.app.displaylib.PerDisplayRepository
 import com.android.internal.jank.Cuj
 import com.android.launcher3.DeviceProfile
 import com.android.launcher3.PagedView
+import com.android.launcher3.Utilities
 import com.android.launcher3.logger.LauncherAtom
 import com.android.launcher3.logging.StatsLogManager
 import com.android.launcher3.logging.StatsLogManager.LauncherEvent.LAUNCHER_OVERVIEW_SHOW_OVERVIEW_FROM_3_BUTTON
@@ -118,7 +119,7 @@ constructor(
         isLastOfBatch: Boolean = true,
     ): CommandInfo? {
         if (commandQueue.size >= MAX_QUEUE_SIZE) {
-            OverviewCommandHelperProtoLogProxy.logCommandQueueFull(type, commandQueue)
+            if (Utilities.ATLEAST_S) OverviewCommandHelperProtoLogProxy.logCommandQueueFull(type, commandQueue)
             return null
         }
 
@@ -130,13 +131,13 @@ constructor(
                 isLastOfBatch = isLastOfBatch,
             )
         commandQueue.add(command)
-        OverviewCommandHelperProtoLogProxy.logCommandAdded(command)
+        if (Utilities.ATLEAST_S) OverviewCommandHelperProtoLogProxy.logCommandAdded(command)
 
         if (commandQueue.size == 1) {
-            OverviewCommandHelperProtoLogProxy.logCommandExecuted(command, commandQueue.size)
+            if (Utilities.ATLEAST_S) OverviewCommandHelperProtoLogProxy.logCommandExecuted(command, commandQueue.size)
             coroutineScope.launch(dispatcherProvider.main) { processNextCommand() }
         } else {
-            OverviewCommandHelperProtoLogProxy.logCommandNotExecuted(command, commandQueue.size)
+            if (Utilities.ATLEAST_S) OverviewCommandHelperProtoLogProxy.logCommandNotExecuted(command, commandQueue.size)
         }
 
         return command
@@ -172,7 +173,7 @@ constructor(
 
     /** Clear pending or completed commands from the queue */
     fun clearPendingCommands() {
-        OverviewCommandHelperProtoLogProxy.logClearPendingCommands(commandQueue)
+        if (Utilities.ATLEAST_S) OverviewCommandHelperProtoLogProxy.logClearPendingCommands(commandQueue)
         commandQueue.removeAll { it.status != CommandStatus.PROCESSING }
     }
 
@@ -185,12 +186,12 @@ constructor(
     private fun processNextCommand() {
             val command: CommandInfo? = commandQueue.firstOrNull()
             if (command == null) {
-                OverviewCommandHelperProtoLogProxy.logNoPendingCommands()
+                if (Utilities.ATLEAST_S) OverviewCommandHelperProtoLogProxy.logNoPendingCommands()
                 return
             }
 
             command.status = CommandStatus.PROCESSING
-            OverviewCommandHelperProtoLogProxy.logExecutingCommand(command)
+            if (Utilities.ATLEAST_S) OverviewCommandHelperProtoLogProxy.logExecutingCommand(command)
 
             coroutineScope.launch(dispatcherProvider.main) {
                     withTimeout(QUEUE_WAIT_DURATION_IN_MS) {
@@ -208,7 +209,7 @@ constructor(
     @VisibleForTesting
     fun executeCommand(command: CommandInfo, onCallbackResult: () -> Unit): Boolean {
         val recentsView = getVisibleRecentsView(command.displayId)
-        OverviewCommandHelperProtoLogProxy.logExecutingCommand(command, recentsView)
+        if (Utilities.ATLEAST_S) OverviewCommandHelperProtoLogProxy.logExecutingCommand(command, recentsView)
         return if (recentsView != null) {
             executeWhenRecentsIsVisible(command, recentsView, onCallbackResult)
         } else {
@@ -223,14 +224,14 @@ constructor(
     private suspend fun executeCommandSuspended(command: CommandInfo) =
         suspendCancellableCoroutine { continuation ->
             fun processResult(isCompleted: Boolean) {
-                OverviewCommandHelperProtoLogProxy.logExecutedCommandWithResult(
+                if (Utilities.ATLEAST_S) OverviewCommandHelperProtoLogProxy.logExecutedCommandWithResult(
                     command,
                     isCompleted,
                 )
                 if (isCompleted) {
                     continuation.resume(Unit)
                 } else {
-                    OverviewCommandHelperProtoLogProxy.logWaitingForCommandCallback(command)
+                    if (Utilities.ATLEAST_S) OverviewCommandHelperProtoLogProxy.logWaitingForCommandCallback(command)
                 }
             }
 
@@ -326,10 +327,10 @@ constructor(
 
         if (callbackList != null) {
             callbackList.add {
-                OverviewCommandHelperProtoLogProxy.logLaunchingTaskCallback(command)
+                if (Utilities.ATLEAST_S) OverviewCommandHelperProtoLogProxy.logLaunchingTaskCallback(command)
                 onCallbackResult()
             }
-            OverviewCommandHelperProtoLogProxy.logLaunchingTaskWaitingForCallback(command)
+            if (Utilities.ATLEAST_S) OverviewCommandHelperProtoLogProxy.logLaunchingTaskWaitingForCallback(command)
             return false
         } else {
             recents.startHome()
@@ -361,7 +362,7 @@ constructor(
         val taskAnimationManager = taskAnimationManagerRepository[command.displayId]
         if (taskAnimationManager == null) {
             Log.e(TAG, "No TaskAnimationManager found for display ${command.displayId}")
-            ActiveGestureProtoLogProxy.logOnTaskAnimationManagerNotAvailable(command.displayId)
+            if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logOnTaskAnimationManagerNotAvailable(command.displayId)
             return false
         }
 
@@ -422,21 +423,21 @@ constructor(
         val animatorListener: Animator.AnimatorListener =
             object : AnimatorListenerAdapter() {
                 override fun onAnimationStart(animation: Animator) {
-                    OverviewCommandHelperProtoLogProxy.logSwitchingToOverviewStateStart(command)
+                    if (Utilities.ATLEAST_S) OverviewCommandHelperProtoLogProxy.logSwitchingToOverviewStateStart(command)
                     super.onAnimationStart(animation)
                     updateRecentsViewFocus(command)
                     logShowOverviewFrom(command)
                 }
 
                 override fun onAnimationEnd(animation: Animator) {
-                    OverviewCommandHelperProtoLogProxy.logSwitchingToOverviewStateEnd(command)
+                    if (Utilities.ATLEAST_S) OverviewCommandHelperProtoLogProxy.logSwitchingToOverviewStateEnd(command)
                     super.onAnimationEnd(animation)
                     onRecentsViewFocusUpdated(command)
                     onCallbackResult()
                 }
             }
         if (containerInterface.switchToRecentsIfVisible(animatorListener)) {
-            OverviewCommandHelperProtoLogProxy.logSwitchingToOverviewStateWaiting(command)
+            if (Utilities.ATLEAST_S) OverviewCommandHelperProtoLogProxy.logSwitchingToOverviewStateWaiting(command)
             // If successfully switched, wait until animation finishes
             return false
         }
@@ -465,7 +466,7 @@ constructor(
                         // and treat the running activity as the task behind the overlay.
                         val otherVisibleTask = runningTask?.visibleNonExcludedTask
                         if (otherVisibleTask != null) {
-                            ActiveGestureProtoLogProxy.logUpdateGestureStateRunningTask(
+                            if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logUpdateGestureStateRunningTask(
                                 otherVisibleTask.packageName ?: "MISSING",
                                 runningTask.packageName ?: "MISSING",
                             )
@@ -480,7 +481,7 @@ constructor(
         if (interactionHandler == null) {
             // Can happen e.g. when a display is disconnected, so try to handle gracefully.
             Log.d(TAG, "AbsSwipeUpHandler not available for displayId=${command.displayId})")
-            ActiveGestureProtoLogProxy.logOnAbsSwipeUpHandlerNotAvailable(command.displayId)
+            if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logOnAbsSwipeUpHandlerNotAvailable(command.displayId)
             return true
         }
         interactionHandler.setGestureAnimationEndCallback {
@@ -495,7 +496,7 @@ constructor(
                     targets: RecentsAnimationTargets,
                     transitionInfo: TransitionInfo?,
                 ) {
-                    OverviewCommandHelperProtoLogProxy.logRecentsAnimStarted(command)
+                    if (Utilities.ATLEAST_S) OverviewCommandHelperProtoLogProxy.logRecentsAnimStarted(command)
                     if (recentsViewContainer is RecentsWindowManager) {
                         recentsViewContainer.rootView?.let { view ->
                             InteractionJankMonitorWrapper.begin(view, Cuj.CUJ_LAUNCHER_QUICK_SWITCH)
@@ -505,7 +506,7 @@ constructor(
                     updateRecentsViewFocus(command)
                     logShowOverviewFrom(command)
                     containerInterface.runOnInitBackgroundStateUI {
-                        OverviewCommandHelperProtoLogProxy.logOnInitBackgroundStateUI(command)
+                        if (Utilities.ATLEAST_S) OverviewCommandHelperProtoLogProxy.logOnInitBackgroundStateUI(command)
                         interactionHandler.onGestureEnded(
                             0f,
                             PointF(),
@@ -518,7 +519,7 @@ constructor(
                 override fun onRecentsAnimationCanceled(
                     thumbnailDatas: HashMap<Int, ThumbnailData>
                 ) {
-                    OverviewCommandHelperProtoLogProxy.logRecentsAnimCanceled(command)
+                    if (Utilities.ATLEAST_S) OverviewCommandHelperProtoLogProxy.logRecentsAnimCanceled(command)
                     interactionHandler.onGestureCancelled()
                     command.removeListener(this)
 
@@ -547,7 +548,7 @@ constructor(
             interactionHandler.onGestureStarted(false /*isLikelyToStartNewTask*/)
             command.addListener(recentAnimListener)
         }
-        OverviewCommandHelperProtoLogProxy.logSwitchingViaRecentsAnim(command)
+        if (Utilities.ATLEAST_S) OverviewCommandHelperProtoLogProxy.logSwitchingViaRecentsAnim(command)
         return false
     }
 
@@ -562,7 +563,7 @@ constructor(
         handler: AbsSwipeUpHandler<*, *, *>,
         onCommandResult: () -> Unit,
     ) {
-        OverviewCommandHelperProtoLogProxy.logSwitchingViaRecentsAnimComplete(command)
+        if (Utilities.ATLEAST_S) OverviewCommandHelperProtoLogProxy.logSwitchingViaRecentsAnimComplete(command)
         command.removeListener(handler)
         onRecentsViewFocusUpdated(command)
         onCommandResult()
@@ -572,21 +573,21 @@ constructor(
     private fun onCommandFinished(command: CommandInfo) {
         command.status = CommandStatus.COMPLETED
         if (commandQueue.firstOrNull() !== command) {
-            OverviewCommandHelperProtoLogProxy.logCommandFinishedButNotScheduled(
+            if (Utilities.ATLEAST_S) OverviewCommandHelperProtoLogProxy.logCommandFinishedButNotScheduled(
                 commandQueue.firstOrNull(),
                 command,
             )
             return
         }
 
-        OverviewCommandHelperProtoLogProxy.logCommandFinishedSuccessfully(command)
+        if (Utilities.ATLEAST_S) OverviewCommandHelperProtoLogProxy.logCommandFinishedSuccessfully(command)
         commandQueue.remove(command)
         processNextCommand()
     }
 
     private fun cancelCommand(command: CommandInfo, throwable: Throwable?) {
         command.status = CommandStatus.CANCELED
-        OverviewCommandHelperProtoLogProxy.logCommandCanceled(command, throwable)
+        if (Utilities.ATLEAST_S) OverviewCommandHelperProtoLogProxy.logCommandCanceled(command, throwable)
         commandQueue.remove(command)
         processNextCommand()
     }

--- a/quickstep/src/com/android/quickstep/OverviewComponentObserver.java
+++ b/quickstep/src/com/android/quickstep/OverviewComponentObserver.java
@@ -45,6 +45,7 @@ import androidx.annotation.UiThread;
 
 import com.android.app.displaylib.PerDisplayRepository;
 import com.android.launcher3.R;
+import com.android.launcher3.Utilities;
 import com.android.launcher3.dagger.ApplicationContext;
 import com.android.launcher3.dagger.LauncherAppComponent;
 import com.android.launcher3.dagger.LauncherAppSingleton;
@@ -372,7 +373,7 @@ public final class OverviewComponentObserver {
             @NonNull Intent homeIntent,
             @Nullable Bundle options,
             @NonNull String reason) {
-        ActiveGestureProtoLogProxy.logStartHomeIntent(reason);
+        if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logStartHomeIntent(reason);
         try {
             context.startActivity(homeIntent, options);
         } catch (NullPointerException | ActivityNotFoundException | SecurityException e) {

--- a/quickstep/src/com/android/quickstep/RecentsAnimationCallbacks.java
+++ b/quickstep/src/com/android/quickstep/RecentsAnimationCallbacks.java
@@ -131,7 +131,7 @@ public class RecentsAnimationCallbacks implements
                 .count() > 0;
         if (appCount == 0 && (!(mContainer instanceof RecentsWindowManager)
                 || isOpeningHome)) {
-            ActiveGestureProtoLogProxy.logOnRecentsAnimationStartCancelled();
+            if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logOnRecentsAnimationStartCancelled();
             // Edge case, if there are no closing app targets, then Launcher has nothing to handle
             notifyAnimationCanceled();
             animationController.finish(false /* toHome */, false /* sendUserLeaveHint */,
@@ -159,7 +159,7 @@ public class RecentsAnimationCallbacks implements
                     extras);
 
             Utilities.postAsyncCallback(MAIN_EXECUTOR.getHandler(), () -> {
-                ActiveGestureProtoLogProxy.logOnRecentsAnimationStart(targets.apps.length);
+                if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logOnRecentsAnimationStart(targets.apps.length);
                 for (RecentsAnimationListener listener : getListeners()) {
                     listener.onRecentsAnimationStart(mController, targets, transitionInfo);
                 }
@@ -171,7 +171,7 @@ public class RecentsAnimationCallbacks implements
     @Override
     public final void onAnimationCanceled(HashMap<Integer, ThumbnailData> thumbnailDatas) {
         Utilities.postAsyncCallback(MAIN_EXECUTOR.getHandler(), () -> {
-            ActiveGestureProtoLogProxy.logRecentsAnimationCallbacksOnAnimationCancelled();
+            if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logRecentsAnimationCallbacksOnAnimationCancelled();
             for (RecentsAnimationListener listener : getListeners()) {
                 listener.onRecentsAnimationCanceled(thumbnailDatas);
             }
@@ -183,7 +183,7 @@ public class RecentsAnimationCallbacks implements
     public void onTasksAppeared(
             RemoteAnimationTarget[] apps, @Nullable TransitionInfo transitionInfo) {
         Utilities.postAsyncCallback(MAIN_EXECUTOR.getHandler(), () -> {
-            ActiveGestureProtoLogProxy.logRecentsAnimationCallbacksOnTasksAppeared();
+            if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logRecentsAnimationCallbacksOnTasksAppeared();
             for (RecentsAnimationListener listener : getListeners()) {
                 listener.onTasksAppeared(apps, transitionInfo);
             }
@@ -192,7 +192,7 @@ public class RecentsAnimationCallbacks implements
 
     private void onAnimationFinished(RecentsAnimationController controller) {
         Utilities.postAsyncCallback(MAIN_EXECUTOR.getHandler(), () -> {
-            ActiveGestureProtoLogProxy.logAbsSwipeUpHandlerOnRecentsAnimationFinished();
+            if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logAbsSwipeUpHandlerOnRecentsAnimationFinished();
             for (RecentsAnimationListener listener : getListeners()) {
                 listener.onRecentsAnimationFinished(controller);
             }

--- a/quickstep/src/com/android/quickstep/RecentsAnimationController.java
+++ b/quickstep/src/com/android/quickstep/RecentsAnimationController.java
@@ -31,6 +31,7 @@ import androidx.annotation.UiThread;
 
 import com.android.internal.jank.Cuj;
 import com.android.internal.os.IResultReceiver;
+import com.android.launcher3.Utilities;
 import com.android.launcher3.util.Preconditions;
 import com.android.launcher3.util.RunnableList;
 import com.android.quickstep.util.ActiveGestureProtoLogProxy;
@@ -145,7 +146,7 @@ public class RecentsAnimationController {
             // trigger the callback to be called immediately
             return;
         }
-        ActiveGestureProtoLogProxy.logFinishRecentsAnimation(toRecents);
+        if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logFinishRecentsAnimation(toRecents);
         // Finish not yet requested
         mFinishRequested = true;
         mFinishTargetIsLauncher = toRecents;
@@ -154,7 +155,7 @@ public class RecentsAnimationController {
             mController.finish(toRecents, sendUserLeaveHint, new IResultReceiver.Stub() {
                 @Override
                 public void send(int i, Bundle bundle) throws RemoteException {
-                    ActiveGestureProtoLogProxy.logFinishRecentsAnimationCallback();
+                    if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logFinishRecentsAnimationCallback();
                     MAIN_EXECUTOR.execute(() -> {
                         mPendingFinishCallbacks.executeAllAndDestroy();
                     });

--- a/quickstep/src/com/android/quickstep/TaskAnimationManager.java
+++ b/quickstep/src/com/android/quickstep/TaskAnimationManager.java
@@ -151,7 +151,7 @@ public class TaskAnimationManager implements RecentsAnimationCallbacks.RecentsAn
     @UiThread
     public RecentsAnimationCallbacks startRecentsAnimation(@NonNull GestureState gestureState,
             Intent intent, RecentsAnimationCallbacks.RecentsAnimationListener listener) {
-        ActiveGestureProtoLogProxy.logStartRecentsAnimation();
+        if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logStartRecentsAnimation();
         // Check displayId
         if (mDisplayId != gestureState.getDisplayId()) {
             String msg = String.format(Locale.ENGLISH,
@@ -194,7 +194,7 @@ public class TaskAnimationManager implements RecentsAnimationCallbacks.RecentsAn
             mRecentsAnimationStartPending = false;
             Log.wtf(TAG, "Recents animation start has been pending for over "
                     + RECENTS_ANIMATION_START_TIMEOUT_MS + "ms");
-            ActiveGestureProtoLogProxy.logRecentsAnimationStartTimedOut();
+            if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logRecentsAnimationStartTimedOut();
             cleanUpRecentsAnimation(newCallbacks);
         };
         mCallbacks.addListener(new RecentsAnimationCallbacks.RecentsAnimationListener() {
@@ -202,7 +202,7 @@ public class TaskAnimationManager implements RecentsAnimationCallbacks.RecentsAn
             public void onRecentsAnimationStart(RecentsAnimationController controller,
                     RecentsAnimationTargets targets, @Nullable TransitionInfo transitionInfo) {
                 if (mRecentsAnimationStartPending) {
-                    ActiveGestureProtoLogProxy.logStartRecentsAnimationCallback(
+                    if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logStartRecentsAnimationCallback(
                             "onRecentsAnimationStart");
                     mRecentsAnimationStartPending = false;
                     MAIN_EXECUTOR.getHandler().removeCallbacks(
@@ -249,7 +249,7 @@ public class TaskAnimationManager implements RecentsAnimationCallbacks.RecentsAn
             @Override
             public void onRecentsAnimationCanceled(HashMap<Integer, ThumbnailData> thumbnailDatas) {
                 if (mRecentsAnimationStartPending) {
-                    ActiveGestureProtoLogProxy.logStartRecentsAnimationCallback(
+                    if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logStartRecentsAnimationCallback(
                             "onRecentsAnimationCanceled");
                     mRecentsAnimationStartPending = false;
                     MAIN_EXECUTOR.getHandler().removeCallbacks(
@@ -261,7 +261,7 @@ public class TaskAnimationManager implements RecentsAnimationCallbacks.RecentsAn
             @Override
             public void onRecentsAnimationFinished(RecentsAnimationController controller) {
                 if (mRecentsAnimationStartPending) {
-                    ActiveGestureProtoLogProxy.logStartRecentsAnimationCallback(
+                    if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logStartRecentsAnimationCallback(
                             "onRecentsAnimationFinished");
                     mRecentsAnimationStartPending = false;
                     MAIN_EXECUTOR.getHandler().removeCallbacks(
@@ -311,7 +311,7 @@ public class TaskAnimationManager implements RecentsAnimationCallbacks.RecentsAn
                     RecentsView recentsView =
                             containerInterface.getCreatedContainer().getOverviewPanel();
                     if (recentsView != null) {
-                        ActiveGestureProtoLogProxy.logLaunchingSideTask(appearedTaskTarget.taskId);
+                        if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logLaunchingSideTask(appearedTaskTarget.taskId);
                         recentsView.launchSideTaskInLiveTileMode(appearedTaskTarget.taskId,
                                 appearedTaskTargets,
                                 new RemoteAnimationTarget[0] /* wallpaper */,
@@ -319,7 +319,7 @@ public class TaskAnimationManager implements RecentsAnimationCallbacks.RecentsAn
                                 transitionInfo);
                         return;
                     } else {
-                        ActiveGestureProtoLogProxy.logLaunchingSideTaskFailed();
+                        if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logLaunchingSideTaskFailed();
                     }
                 } else if (nonAppTargets.length > 0) {
                     TaskViewUtils.createSplitAuxiliarySurfacesAnimator(nonAppTargets /* nonApps */,
@@ -377,7 +377,7 @@ public class TaskAnimationManager implements RecentsAnimationCallbacks.RecentsAn
             MAIN_EXECUTOR.getHandler().postDelayed(
                     recentsAnimationStartTimeoutCallback, RECENTS_ANIMATION_START_TIMEOUT_MS);
         }
-        ActiveGestureProtoLogProxy.logSettingRecentsAnimationStartPending(
+        if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logSettingRecentsAnimationStartPending(
                 mRecentsAnimationStartPending);
         gestureState.setState(STATE_RECENTS_ANIMATION_INITIALIZED);
         return mCallbacks;
@@ -408,7 +408,7 @@ public class TaskAnimationManager implements RecentsAnimationCallbacks.RecentsAn
      * Continues the existing running recents animation for a new gesture.
      */
     public RecentsAnimationCallbacks continueRecentsAnimation(GestureState gestureState) {
-        ActiveGestureProtoLogProxy.logContinueRecentsAnimation();
+        if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logContinueRecentsAnimation();
         mCallbacks.removeListener(mLastGestureState);
         mLastGestureState = gestureState;
         mCallbacks.addListener(gestureState);
@@ -497,7 +497,7 @@ public class TaskAnimationManager implements RecentsAnimationCallbacks.RecentsAn
             @Nullable Runnable forceFinishCb,
             @Nullable RecentsAnimationController controller) {
         if (controller != null) {
-            ActiveGestureProtoLogProxy.logFinishRunningRecentsAnimation(toHome);
+            if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logFinishRunningRecentsAnimation(toHome);
             if (forceFinish) {
                 controller.finishController(toHome, forceFinishCb, false /* sendUserLeaveHint */,
                         true /* forceFinish */);
@@ -539,7 +539,7 @@ public class TaskAnimationManager implements RecentsAnimationCallbacks.RecentsAn
         if (mLauncherDestroyCallbackSet) {
             return;
         }
-        ActiveGestureProtoLogProxy.logQueuingForceFinishRecentsAnimation();
+        if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logQueuingForceFinishRecentsAnimation();
         mLauncherDestroyCallbackSet = true;
         mCallbacks.addListener(new RecentsAnimationCallbacks.RecentsAnimationListener() {
             @Override
@@ -562,10 +562,10 @@ public class TaskAnimationManager implements RecentsAnimationCallbacks.RecentsAn
      */
     private void cleanUpRecentsAnimation(RecentsAnimationCallbacks targetCallbacks) {
         if (mCallbacks != targetCallbacks) {
-            ActiveGestureProtoLogProxy.logCleanUpRecentsAnimationSkipped();
+            if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logCleanUpRecentsAnimationSkipped();
             return;
         }
-        ActiveGestureProtoLogProxy.logCleanUpRecentsAnimation();
+        if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logCleanUpRecentsAnimation();
         if (mLiveTileCleanUpHandler != null) {
             mLiveTileCleanUpHandler.run();
             mLiveTileCleanUpHandler = null;

--- a/quickstep/src/com/android/quickstep/TouchInteractionService.java
+++ b/quickstep/src/com/android/quickstep/TouchInteractionService.java
@@ -79,6 +79,7 @@ import com.android.launcher3.EncryptionType;
 import com.android.launcher3.Flags;
 import com.android.launcher3.Launcher;
 import com.android.launcher3.LauncherPrefs;
+import com.android.launcher3.Utilities;
 import com.android.launcher3.anim.AnimatedFloat;
 import com.android.launcher3.dagger.LauncherComponentProvider;
 import com.android.launcher3.desktop.DesktopAppLaunchTransitionManager;
@@ -1019,7 +1020,7 @@ public class TouchInteractionService extends Service {
     private void onInputEvent(InputEvent ev) {
         int displayId = ev.getDisplayId();
         if (!(ev instanceof MotionEvent)) {
-            ActiveGestureProtoLogProxy.logUnknownInputEvent(displayId, ev.toString());
+            if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logUnknownInputEvent(displayId, ev.toString());
             return;
         }
         MotionEvent event = (MotionEvent) ev;
@@ -1028,7 +1029,7 @@ public class TouchInteractionService extends Service {
                 TestProtocol.SEQUENCE_TIS, "TouchInteractionService.onInputEvent", event);
 
         if (!LockedUserState.get(this).isUserUnlocked()) {
-            ActiveGestureProtoLogProxy.logOnInputEventUserLocked(displayId);
+            if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logOnInputEventUserLocked(displayId);
             return;
         }
 
@@ -1047,13 +1048,13 @@ public class TouchInteractionService extends Service {
         NavigationMode currentNavMode = deviceState.getMode();
         NavigationMode gestureStartNavMode = mGestureStartNavMode.get(displayId);
         if (gestureStartNavMode != null && gestureStartNavMode != currentNavMode) {
-            ActiveGestureProtoLogProxy.logOnInputEventNavModeSwitched(
+            if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logOnInputEventNavModeSwitched(
                     displayId, gestureStartNavMode.name(), currentNavMode.name());
             event.setAction(ACTION_CANCEL);
         } else if (deviceState.isButtonNavMode()
                 && !deviceState.supportsAssistantGestureInButtonNav()
                 && !isTrackpadMotionEvent(event)) {
-            ActiveGestureProtoLogProxy.logOnInputEventThreeButtonNav(displayId);
+            if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logOnInputEventThreeButtonNav(displayId);
             return;
         }
 
@@ -1066,7 +1067,7 @@ public class TouchInteractionService extends Service {
         TaskAnimationManager taskAnimationManager = mTaskAnimationManagerRepository.get(displayId);
         if (taskAnimationManager == null) {
             Log.e(TAG, "TaskAnimationManager not available for displayId " + displayId);
-            ActiveGestureProtoLogProxy.logOnTaskAnimationManagerNotAvailable(displayId);
+            if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logOnTaskAnimationManagerNotAvailable(displayId);
             return;
         }
         if (action == ACTION_DOWN || isHoverActionWithoutConsumer) {
@@ -1074,7 +1075,7 @@ public class TouchInteractionService extends Service {
         }
         if (taskAnimationManager.shouldIgnoreMotionEvents()) {
             if (action == ACTION_DOWN || isHoverActionWithoutConsumer) {
-                ActiveGestureProtoLogProxy.logOnInputIgnoringFollowingEvents(displayId);
+                if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logOnInputIgnoringFollowingEvents(displayId);
             }
             return;
         }
@@ -1189,10 +1190,10 @@ public class TouchInteractionService extends Service {
         if (mUncheckedConsumer.getType() != InputConsumer.TYPE_NO_OP) {
             switch (action) {
                 case ACTION_DOWN:
-                    ActiveGestureProtoLogProxy.logOnInputEventActionDown(displayId, reasonString);
+                    if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logOnInputEventActionDown(displayId, reasonString);
                     // fall through
                 case ACTION_UP:
-                    ActiveGestureProtoLogProxy.logOnInputEventActionUp(
+                    if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logOnInputEventActionUp(
                             (int) event.getRawX(),
                             (int) event.getRawY(),
                             action,
@@ -1200,14 +1201,14 @@ public class TouchInteractionService extends Service {
                             displayId);
                     break;
                 case ACTION_MOVE:
-                    ActiveGestureProtoLogProxy.logOnInputEventActionMove(
+                    if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logOnInputEventActionMove(
                             MotionEvent.actionToString(action),
                             MotionEvent.classificationToString(event.getClassification()),
                             event.getPointerCount(),
                             displayId);
                     break;
                 default: {
-                    ActiveGestureProtoLogProxy.logOnInputEventGenericAction(
+                    if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logOnInputEventGenericAction(
                             MotionEvent.actionToString(action),
                             MotionEvent.classificationToString(event.getClassification()),
                             displayId);
@@ -1284,10 +1285,10 @@ public class TouchInteractionService extends Service {
         gestureState.setTrackpadGestureType(trackpadGestureType);
 
         // Log initial state for the gesture.
-        ActiveGestureProtoLogProxy.logRunningTaskPackage(taskInfo.getPackageName());
+        if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logRunningTaskPackage(taskInfo.getPackageName());
         RecentsAnimationDeviceState deviceState = mDeviceStateRepository.get(displayId);
         if (deviceState != null) {
-            ActiveGestureProtoLogProxy.logSysuiStateFlags(deviceState.getSystemUiStateString());
+            if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logSysuiStateFlags(deviceState.getSystemUiStateString());
         }
         return gestureState;
     }

--- a/quickstep/src/com/android/quickstep/fallback/window/RecentsWindowManager.kt
+++ b/quickstep/src/com/android/quickstep/fallback/window/RecentsWindowManager.kt
@@ -40,6 +40,7 @@ import com.android.launcher3.BaseActivity
 import com.android.launcher3.LauncherAnimationRunner
 import com.android.launcher3.LauncherAnimationRunner.RemoteAnimationFactory
 import com.android.launcher3.R
+import com.android.launcher3.Utilities
 import com.android.launcher3.compat.AccessibilityManagerCompat
 import com.android.launcher3.dagger.LauncherAppSingleton
 import com.android.launcher3.dagger.WindowContext
@@ -271,7 +272,7 @@ constructor(
     }
 
     fun startRecentsWindow(callbacks: RecentsAnimationCallbacks? = null) {
-        RecentsWindowProtoLogProxy.logStartRecentsWindow(isShowing(), windowView == null)
+        if (Utilities.ATLEAST_S) RecentsWindowProtoLogProxy.logStartRecentsWindow(isShowing(), windowView == null)
         if (isShowing()) {
             return
         }
@@ -364,7 +365,7 @@ constructor(
     }
 
     fun cleanupRecentsWindow() {
-        RecentsWindowProtoLogProxy.logCleanup(isShowing())
+        if (Utilities.ATLEAST_S) RecentsWindowProtoLogProxy.logCleanup(isShowing())
         if (isShowing()) {
             AbstractFloatingView.closeAllOpenViews(this, /* animate= */ false)
             windowManager.removeViewImmediate(windowView)
@@ -422,12 +423,12 @@ constructor(
 
     override fun onStateSetStart(state: RecentsState) {
         super.onStateSetStart(state)
-        RecentsWindowProtoLogProxy.logOnStateSetStart(state.toString())
+        if (Utilities.ATLEAST_S) RecentsWindowProtoLogProxy.logOnStateSetStart(state.toString())
     }
 
     override fun onStateSetEnd(state: RecentsState) {
         super.onStateSetEnd(state)
-        RecentsWindowProtoLogProxy.logOnStateSetEnd(state.toString())
+        if (Utilities.ATLEAST_S) RecentsWindowProtoLogProxy.logOnStateSetEnd(state.toString())
         if (!state.isRecentsViewVisible) {
             cleanupRecentsWindow()
         }
@@ -436,7 +437,7 @@ constructor(
 
     override fun onRepeatStateSetAborted(state: RecentsState) {
         super.onRepeatStateSetAborted(state)
-        RecentsWindowProtoLogProxy.logOnRepeatStateSetAborted(state.toString())
+        if (Utilities.ATLEAST_S) RecentsWindowProtoLogProxy.logOnRepeatStateSetAborted(state.toString())
         if (!state.isRecentsViewVisible) {
             cleanupRecentsWindow()
         }

--- a/quickstep/src/com/android/quickstep/inputconsumers/DelegateInputConsumer.java
+++ b/quickstep/src/com/android/quickstep/inputconsumers/DelegateInputConsumer.java
@@ -2,6 +2,7 @@ package com.android.quickstep.inputconsumers;
 
 import android.view.MotionEvent;
 
+import com.android.launcher3.Utilities;
 import com.android.launcher3.testing.TestLogging;
 import com.android.launcher3.testing.shared.TestProtocol;
 import com.android.quickstep.InputConsumer;
@@ -66,7 +67,7 @@ public abstract class DelegateInputConsumer implements InputConsumer {
     }
 
     protected void setActive(MotionEvent ev) {
-        ActiveGestureProtoLogProxy.logInputConsumerBecameActive(getDelegatorName());
+        if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logInputConsumerBecameActive(getDelegatorName());
 
         mState = STATE_ACTIVE;
         TestLogging.recordEvent(TestProtocol.SEQUENCE_PILFER, "pilferPointers");

--- a/quickstep/src/com/android/quickstep/inputconsumers/OtherActivityInputConsumer.java
+++ b/quickstep/src/com/android/quickstep/inputconsumers/OtherActivityInputConsumer.java
@@ -424,7 +424,7 @@ public class OtherActivityInputConsumer extends ContextWrapper implements InputC
         if (mInteractionHandler == null) {
             // Can happen e.g. when a display is disconnected, so try to handle gracefully.
             Log.d(TAG, "AbsSwipeUpHandler not available for displayId=$focusedDisplayId");
-            ActiveGestureProtoLogProxy.logOnAbsSwipeUpHandlerNotAvailable(
+            if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logOnAbsSwipeUpHandlerNotAvailable(
                     mGestureState.getDisplayId());
             return;
         }
@@ -433,7 +433,7 @@ public class OtherActivityInputConsumer extends ContextWrapper implements InputC
         mMotionPauseDetector.setIsTrackpadGesture(mGestureState.isTrackpadGesture());
         mInteractionHandler.initWhenReady(
                 "OtherActivityInputConsumer.startTouchTrackingForWindowAnimation");
-        ActiveGestureProtoLogProxy.logGestureStartSwipeHandler(
+        if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logGestureStartSwipeHandler(
                 mInteractionHandler.getClass().getSimpleName());
 
         if (DEBUG) {

--- a/quickstep/src/com/android/quickstep/util/MotionPauseDetector.java
+++ b/quickstep/src/com/android/quickstep/util/MotionPauseDetector.java
@@ -251,6 +251,7 @@ public class MotionPauseDetector {
                     .append(event)
                     .toString());
         }
+        if (!Utilities.ATLEAST_S) return;
         ActiveGestureProtoLogProxy.logMotionPauseDetectorEvent(event);
     }
 

--- a/quickstep/src/com/android/quickstep/util/TaskRemovedDuringLaunchListener.java
+++ b/quickstep/src/com/android/quickstep/util/TaskRemovedDuringLaunchListener.java
@@ -26,6 +26,7 @@ import android.content.Context;
 
 import androidx.annotation.NonNull;
 
+import com.android.launcher3.Utilities;
 import com.android.quickstep.RecentsModel;
 import com.android.quickstep.views.RecentsViewContainer;
 
@@ -98,7 +99,7 @@ public class TaskRemovedDuringLaunchListener {
             final Runnable taskLaunchFailedCallback = mTaskLaunchFailedCallback;
             RecentsModel.INSTANCE.get(mContext).isTaskRemoved(mLaunchedTaskId, (taskRemoved) -> {
                 if (taskRemoved) {
-                    ActiveGestureProtoLogProxy.logTaskLaunchFailed(launchedTaskId);
+                    if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logTaskLaunchFailed(launchedTaskId);
                     taskLaunchFailedCallback.run();
                 }
             }, (task) -> true /* filter */);

--- a/quickstep/src/com/android/quickstep/views/RecentsView.java
+++ b/quickstep/src/com/android/quickstep/views/RecentsView.java
@@ -1737,7 +1737,7 @@ public abstract class RecentsView<
     @Override
     protected void onPageEndTransition() {
         super.onPageEndTransition();
-        ActiveGestureProtoLogProxy.logOnPageEndTransition(getNextPage());
+        if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logOnPageEndTransition(getNextPage());
         if (!mContainer.getDeviceProfile().getDeviceProperties().isTablet()) {
             mActionsView.updateDisabledFlags(OverviewActionsView.DISABLED_SCROLLING, false);
         }
@@ -1934,7 +1934,7 @@ public abstract class RecentsView<
 
     @Override
     protected void onScrollerAnimationAborted() {
-        ActiveGestureProtoLogProxy.logOnScrollerAnimationAborted();
+        if (Utilities.ATLEAST_S) ActiveGestureProtoLogProxy.logOnScrollerAnimationAborted();
     }
 
     @Override

--- a/quickstep/src_protolog/com/android/launcher3/util/OverviewCommandHelperProtoLogProxy.java
+++ b/quickstep/src_protolog/com/android/launcher3/util/OverviewCommandHelperProtoLogProxy.java
@@ -22,11 +22,13 @@ import static com.android.quickstep.util.QuickstepProtoLogGroup.isProtoLogInitia
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import androidx.annotation.RequiresApi;
 import com.android.internal.protolog.ProtoLog;
 
 /**
  * Proxy class used for OverviewCommandHelper ProtoLog support. (e.g. for 3 button nav)
  */
+@RequiresApi(31) // Because this class uses ProtoLog which requires API level 31
 public class OverviewCommandHelperProtoLogProxy {
 
     public static void logCommandQueueFull(@NonNull Object type, @NonNull Object commandQueue) {

--- a/quickstep/src_protolog/com/android/launcher3/util/StateManagerProtoLogProxy.java
+++ b/quickstep/src_protolog/com/android/launcher3/util/StateManagerProtoLogProxy.java
@@ -23,12 +23,14 @@ import android.window.DesktopModeFlags.DesktopModeFlag;
 
 import androidx.annotation.NonNull;
 
+import androidx.annotation.RequiresApi;
 import com.android.internal.protolog.ProtoLog;
 import com.android.launcher3.Flags;
 
 /**
  * Proxy class used for StateManager ProtoLog support.
  */
+@RequiresApi(31) // LC-Note: IProtoLogGroup only available to Android 11 Releases 41, or Android 12.0 for us. DO NOT call anything related to this or ProtoLog 
 public class StateManagerProtoLogProxy {
     private static final DesktopModeFlag ENABLE_STATE_MANAGER_PROTO_LOG =
             new DesktopModeFlag(Flags::enableStateManagerProtoLog, true);

--- a/quickstep/src_protolog/com/android/quickstep/util/ActiveGestureProtoLogProxy.java
+++ b/quickstep/src_protolog/com/android/quickstep/util/ActiveGestureProtoLogProxy.java
@@ -46,6 +46,7 @@ import android.view.MotionEvent;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import androidx.annotation.RequiresApi;
 import com.android.internal.protolog.ProtoLog;
 import com.android.internal.protolog.common.IProtoLogGroup;
 
@@ -59,6 +60,7 @@ import com.android.internal.protolog.common.IProtoLogGroup;
  * to be modified), add it here under a new unique method and make sure the ProtoLog entry matches
  * to avoid confusion.
  */
+@RequiresApi(31) // LC-Note: IProtoLogGroup only available to Android 11 Releases 41, or Android 12.0 for us. DO NOT call anything related to this or ProtoLog 
 public class ActiveGestureProtoLogProxy {
 
     public static void logLauncherDestroyed() {

--- a/quickstep/src_protolog/com/android/quickstep/util/QuickstepProtoLogGroup.java
+++ b/quickstep/src_protolog/com/android/quickstep/util/QuickstepProtoLogGroup.java
@@ -20,6 +20,7 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 
+import androidx.annotation.RequiresApi;
 import com.android.internal.protolog.ProtoLog;
 import com.android.internal.protolog.common.IProtoLogGroup;
 
@@ -27,6 +28,7 @@ import com.android.launcher3.Utilities;
 import java.util.UUID;
 
 /** Enums used to interface with the ProtoLog API. */
+@RequiresApi(31) // LC-Note: IProtoLogGroup only available to Android 11 Releases 41, or Android 12.0 for us. DO NOT call anything related to this or ProtoLog 
 public enum QuickstepProtoLogGroup implements IProtoLogGroup {
 
     ACTIVE_GESTURE_LOG(true, true, Constants.DEBUG_ACTIVE_GESTURE, "ActiveGestureLog"),
@@ -41,11 +43,6 @@ public enum QuickstepProtoLogGroup implements IProtoLogGroup {
     private final @NonNull String mTag;
 
     public static boolean isProtoLogInitialized() {
-        // LC-Note: This is workaround for skipping Android 11 Release 41. 
-        //          Not the best solutions but this is not significant enough to Lawnchair.
-        if (!Utilities.ATLEAST_S) return false;
-
-
         if (!Variables.sIsInitialized) {
             Log.w(Constants.TAG,
                     "Attempting to log to ProtoLog before initializing it.",
@@ -55,10 +52,6 @@ public enum QuickstepProtoLogGroup implements IProtoLogGroup {
     }
 
     public static void initProtoLog() {
-        // LC-Note: This is workaround for skipping Android 11 Release 41. 
-        //          Not the best solutions but this is not significant enough to Lawnchair.
-        if (!Utilities.ATLEAST_S) return;
-        
         if (Variables.sIsInitialized) {
             Log.e(Constants.TAG,
                     "Attempting to re-initialize ProtoLog.", new IllegalStateException());

--- a/quickstep/src_protolog/com/android/quickstep/util/RecentsWindowProtoLogProxy.java
+++ b/quickstep/src_protolog/com/android/quickstep/util/RecentsWindowProtoLogProxy.java
@@ -23,6 +23,7 @@ import android.window.DesktopExperienceFlags;
 
 import androidx.annotation.NonNull;
 
+import androidx.annotation.RequiresApi;
 import com.android.internal.protolog.ProtoLog;
 import com.android.internal.protolog.common.IProtoLogGroup;
 import com.android.launcher3.Flags;
@@ -36,6 +37,7 @@ import com.android.launcher3.Flags;
  * When a new Recents Window log needs to be added to the codebase, add it here under a new unique
  * method. Or, if an existing entry needs to be modified, simply update it here.
  */
+@RequiresApi(31) // LC-Note: IProtoLogGroup only available to Android 11 Releases 41, or Android 12.0 for us. DO NOT call anything related to this or ProtoLog 
 public class RecentsWindowProtoLogProxy {
     private static final DesktopExperienceFlags.DesktopExperienceFlag
             ENABLE_RECENTS_WINDOW_PROTO_LOG =

--- a/src/com/android/launcher3/statemanager/StateManager.java
+++ b/src/com/android/launcher3/statemanager/StateManager.java
@@ -33,6 +33,7 @@ import android.util.Log;
 
 import androidx.annotation.FloatRange;
 
+import com.android.launcher3.Utilities;
 import com.android.launcher3.anim.AnimationSuccessListener;
 import com.android.launcher3.anim.AnimatorPlaybackController;
 import com.android.launcher3.anim.PendingAnimation;
@@ -250,7 +251,7 @@ public class StateManager<S extends BaseState<S>, T extends StatefulContainer<S>
 
     private void goToState(
             S state, boolean animated, long delay, AnimatorListener listener) {
-        if (enableStateManagerProtoLog()) {
+        if (enableStateManagerProtoLog() && Utilities.ATLEAST_S) {
             StateManagerProtoLogProxy.logGoToState(
                     mState, state, getTrimmedStackTrace("StateManager.goToState"));
         } else if (DEBUG) {
@@ -343,7 +344,7 @@ public class StateManager<S extends BaseState<S>, T extends StatefulContainer<S>
      */
     public AnimatorSet createAtomicAnimation(
             S fromState, S toState, StateAnimationConfig config) {
-        if (enableStateManagerProtoLog()) {
+        if (enableStateManagerProtoLog() && Utilities.ATLEAST_S) {
             StateManagerProtoLogProxy.logCreateAtomicAnimation(
                     mState, toState, getTrimmedStackTrace("StateManager.createAtomicAnimation"));
         } else if (DEBUG) {
@@ -423,7 +424,7 @@ public class StateManager<S extends BaseState<S>, T extends StatefulContainer<S>
         mState = state;
         mContainer.onStateSetStart(mState);
 
-        if (enableStateManagerProtoLog()) {
+        if (enableStateManagerProtoLog() && Utilities.ATLEAST_S) {
             StateManagerProtoLogProxy.logOnStateTransitionStart(state);
         } else if (DEBUG) {
             Log.d(TAG, "onStateTransitionStart - state: " + state);
@@ -445,7 +446,7 @@ public class StateManager<S extends BaseState<S>, T extends StatefulContainer<S>
             setRestState(null);
         }
 
-        if (enableStateManagerProtoLog()) {
+        if (enableStateManagerProtoLog() && Utilities.ATLEAST_S) {
             StateManagerProtoLogProxy.logOnStateTransitionEnd(state);
         } else if (DEBUG) {
             Log.d(TAG, "onStateTransitionEnd - state: " + state);
@@ -456,7 +457,7 @@ public class StateManager<S extends BaseState<S>, T extends StatefulContainer<S>
     }
 
     private void onRepeatStateSetAborted(S state) {
-        if (enableStateManagerProtoLog()) {
+        if (enableStateManagerProtoLog() && Utilities.ATLEAST_S) {
             StateManagerProtoLogProxy.logOnRepeatStateSetAborted(state);
         } else if (DEBUG) {
             Log.d(TAG, "onRepeatStateSetAborted - state: " + state);
@@ -496,7 +497,7 @@ public class StateManager<S extends BaseState<S>, T extends StatefulContainer<S>
      * Cancels the current animation.
      */
     public void cancelAnimation() {
-        if (enableStateManagerProtoLog()) {
+        if (enableStateManagerProtoLog() && Utilities.ATLEAST_S) {
             StateManagerProtoLogProxy.logCancelAnimation(
                     mConfig.currentAnimation != null,
                     getTrimmedStackTrace("StateManager.cancelAnimation"));


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Avoid calling file related to Protolog under S api

Fixes https://discord.com/channels/803299970169700402/803506450805817385/1532409467344257166
Fixes https://discord.com/channels/803299970169700402/803506450805817385/1532408797199335595
Fixes my own skill issue in #7071

Additionally this PR makes all function that extends `IProtoLogGroup` to requires at least Android 12 before calling because only extending `IProtoLogGroup` does not make the function requires at least Android 12 or let alone Android 11 Releases 41
### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->



### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Testing environment used during development:

- 📱 Honor 10 Lite | Android 10

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android version compatibility by limiting gesture, recents, state, and task-transition diagnostic logging to Android 12 (S) and newer.
  * Preserved existing gesture, animation, navigation, and task-management behavior on older Android versions.
  * Added platform requirements for diagnostic logging components to prevent unsupported usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->