### PR TITLE
revert: fix: Align widget visually to the icon

### DIFF
--- a/src/com/android/launcher3/DeviceProfile.java
+++ b/src/com/android/launcher3/DeviceProfile.java
@@ -258,10 +258,6 @@ public class DeviceProfile {
     // Additional padding added to the widget inside its cellSpace. It is applied outside
     // the widgetView, such that the actual view size is same as the widget size.
     public final Rect widgetPadding = new Rect();
-    // Lawnchair: extra horizontal inset applied only to widgets touching the left/right
-    // edge of the grid, so that widget edges align closer to icon centers without
-    // inflating the gap between adjacent widgets.
-    public int widgetEdgeInsetPx;
 
     // Notification dots
     public final DotRenderer mDotRendererWorkSpace;
@@ -1403,11 +1399,9 @@ public class DeviceProfile {
         } else {
             widgetPadding.setEmpty();
         }
-        // Lawnchair: extra inset for edge widgets to align closer to icon centre.
-        widgetEdgeInsetPx = widgetPadding.left;
         // Lawnchair: scale widget padding by user factor (0 = remove, 1 = default).
-        widgetPadding.left = widgetPadding.right =
-                Math.round(widgetPadding.left * widgetPaddingFactor);
+        widgetPadding.left = Math.round(widgetPadding.left * widgetPaddingFactor);
+        widgetPadding.right = Math.round(widgetPadding.right * widgetPaddingFactor);
         widgetPadding.top = Math.round(widgetPadding.top * widgetPaddingFactor);
         widgetPadding.bottom = Math.round(widgetPadding.bottom * widgetPaddingFactor);
     }

--- a/src/com/android/launcher3/ShortcutAndWidgetContainer.java
+++ b/src/com/android/launcher3/ShortcutAndWidgetContainer.java
@@ -150,8 +150,7 @@ public class ShortcutAndWidgetContainer extends ViewGroup implements FolderIcon.
             DeviceProfile profile = mActivity.getDeviceProfile();
             final PointF appWidgetScale = profile.getAppWidgetScale((ItemInfo) child.getTag());
             lp.setup(mCellWidth, mCellHeight, invertLayoutHorizontally(), mCountX, mCountY,
-                    appWidgetScale.x, appWidgetScale.y, mBorderSpace, profile.widgetPadding,
-                    profile.widgetEdgeInsetPx);
+                    appWidgetScale.x, appWidgetScale.y, mBorderSpace, profile.widgetPadding);
         } else {
             lp.setup(mCellWidth, mCellHeight, invertLayoutHorizontally(), mCountX, mCountY,
                     mBorderSpace);
@@ -176,15 +175,13 @@ public class ShortcutAndWidgetContainer extends ViewGroup implements FolderIcon.
         if (child instanceof NavigableAppWidgetHostView) {
             final PointF appWidgetScale = dp.getAppWidgetScale((ItemInfo) child.getTag());
             lp.setup(mCellWidth, mCellHeight, invertLayoutHorizontally(), mCountX, mCountY,
-                    appWidgetScale.x, appWidgetScale.y, mBorderSpace, dp.widgetPadding,
-                    dp.widgetEdgeInsetPx);
+                    appWidgetScale.x, appWidgetScale.y, mBorderSpace, dp.widgetPadding);
         } else if (isChildQsb(child)) {
             lp.setup(mCellWidth, mCellHeight, invertLayoutHorizontally(), mCountX, mCountY,
-                    1.0f, 1.0f, mBorderSpace, null, dp.widgetEdgeInsetPx);
+                    mBorderSpace);
             // No need to add padding for Qsb, which is either Smartspace (actual or
             // preview), or
             // QsbContainerView.
-            // LC-Note: but still apply edge inset so its outer edges align with icon centre
         } else {
             lp.setup(mCellWidth, mCellHeight, invertLayoutHorizontally(), mCountX, mCountY,
                     mBorderSpace);

--- a/src/com/android/launcher3/celllayout/CellLayoutLayoutParams.java
+++ b/src/com/android/launcher3/celllayout/CellLayoutLayoutParams.java
@@ -128,19 +128,6 @@ public class CellLayoutLayoutParams extends ViewGroup.MarginLayoutParams {
     public void setup(int cellWidth, int cellHeight, boolean invertHorizontally, int colCount,
             int rowCount, float cellScaleX, float cellScaleY, Point borderSpace,
             @Nullable Rect inset) {
-        setup(cellWidth, cellHeight, invertHorizontally, colCount, rowCount, cellScaleX,
-                cellScaleY, borderSpace, inset, 0);
-    }
-
-    /**
-     * Lawnchair: {@link #setup(int, int, boolean, int, int, float, float, Point, Rect)}, 
-     * with the addition of [edgeInset] (after inset) in case extra inset needs to be applied on the outer grid edges
-     * 
-     * Lawnchair-TODO: Maybe the proper solution is to modify the profile of the device directly, but what value?
-     */
-    public void setup(int cellWidth, int cellHeight, boolean invertHorizontally, int colCount,
-            int rowCount, float cellScaleX, float cellScaleY, Point borderSpace,
-            @Nullable Rect inset, int edgeInset) {
         if (isLockedToGrid) {
             final int myCellHSpan = cellHSpan;
             final int myCellVSpan = cellVSpan;
@@ -167,19 +154,6 @@ public class CellLayoutLayoutParams extends ViewGroup.MarginLayoutParams {
                 y += inset.top;
                 width -= inset.left + inset.right;
                 height -= inset.top + inset.bottom;
-            }
-
-            // Lawnchair: apply extra inset only on the outer edges of the grid
-            if (edgeInset > 0) {
-                boolean atLeft = myCellX == 0;
-                boolean atRight = myCellX + myCellHSpan >= colCount;
-                if (atLeft) {
-                    x += edgeInset;
-                    width -= edgeInset;
-                }
-                if (atRight) {
-                    width -= edgeInset;
-                }
             }
         }
     }


### PR DESCRIPTION
Reverts LawnchairLauncher/lawnchair#7047 due to widget scaling issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved widget and search bar spacing for more consistent alignment across launcher layouts.
  * Widget padding now scales independently on the left and right, helping preserve balanced placement across device configurations.
  * Simplified grid layout spacing to prevent unnecessary edge adjustments and improve visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->