### PR TITLE
fix: refresh configured icon gestures

### DIFF
--- a/lawnchair/src/app/lawnchair/gestures/IconGestureListener.kt
+++ b/lawnchair/src/app/lawnchair/gestures/IconGestureListener.kt
@@ -32,10 +32,6 @@ class IconGestureListener(
      */
     private enum class ScrollLock { NONE, HORIZONTAL, VERTICAL }
 
-    private val configuredGestures by lazy {
-        GestureType.entries.filter { resolveGesture(it) != null }.toSet()
-    }
-
     override fun onSwipeRight(velocity: Float) = handleGesture(GestureType.SWIPE_RIGHT, velocity)
     override fun onSwipeLeft(velocity: Float) = handleGesture(GestureType.SWIPE_LEFT, velocity)
     override fun onSwipeTop(velocity: Float) = handleGesture(GestureType.SWIPE_UP, velocity)
@@ -81,7 +77,7 @@ class IconGestureListener(
 
     /** Check if there's any gesture configured for this entry */
     fun hasAnyGestureConfigured(): Boolean {
-        return configuredGestures.isNotEmpty()
+        return GestureType.entries.any(::hasGestureConfigured)
     }
 
     /** Check if there's a horizontal gesture configured for this entry. (Swipe left/right) */
@@ -99,7 +95,10 @@ class IconGestureListener(
     /** Check if there's a specific gesture configured for this entry
      * @param gestureType The type of gesture to check */
     private fun hasGestureConfigured(gestureType: GestureType): Boolean {
-        return configuredGestures.contains(gestureType)
+        // Per-app gesture settings may change while this icon view stays attached to the
+        // workspace. Resolve from PreferenceManager2's in-memory cache so an existing icon
+        // immediately observes new settings instead of requiring it to be recreated.
+        return resolveGesture(gestureType) != null
     }
 
     /** Launch gesture configured operation for a specific gesture type

--- a/lawnchair/src/app/lawnchair/gestures/IconGestureListener.kt
+++ b/lawnchair/src/app/lawnchair/gestures/IconGestureListener.kt
@@ -2,6 +2,7 @@ package app.lawnchair.gestures
 
 import android.util.Log
 import android.view.ViewConfiguration
+import androidx.datastore.preferences.core.Preferences
 import androidx.dynamicanimation.animation.DynamicAnimation
 import androidx.dynamicanimation.animation.SpringForce
 import androidx.lifecycle.lifecycleScope
@@ -27,6 +28,8 @@ class IconGestureListener(
     private val touchSlop = ViewConfiguration.get(context).scaledTouchSlop
     private var scrollLock = ScrollLock.NONE
     private var isAnimating = false
+    private var cachedPreferences: Preferences? = null
+    private var configuredGestures = emptySet<GestureType>()
 
     /** Represents the axis on which the current scroll gesture is locked.
      */
@@ -77,7 +80,7 @@ class IconGestureListener(
 
     /** Check if there's any gesture configured for this entry */
     fun hasAnyGestureConfigured(): Boolean {
-        return GestureType.entries.any(::hasGestureConfigured)
+        return getConfiguredGestures().isNotEmpty()
     }
 
     /** Check if there's a horizontal gesture configured for this entry. (Swipe left/right) */
@@ -95,10 +98,21 @@ class IconGestureListener(
     /** Check if there's a specific gesture configured for this entry
      * @param gestureType The type of gesture to check */
     private fun hasGestureConfigured(gestureType: GestureType): Boolean {
-        // Per-app gesture settings may change while this icon view stays attached to the
-        // workspace. Resolve from PreferenceManager2's in-memory cache so an existing icon
-        // immediately observes new settings instead of requiring it to be recreated.
-        return resolveGesture(gestureType) != null
+        return gestureType in getConfiguredGestures()
+    }
+
+    /**
+     * Refreshes this listener's gesture cache whenever DataStore publishes a new preferences
+     * snapshot. This keeps an existing icon in sync without parsing its JSON configuration on
+     * every scroll event.
+     */
+    private fun getConfiguredGestures(): Set<GestureType> {
+        val preferences = prefs.getCachedPreferences()
+        if (preferences !== cachedPreferences) {
+            cachedPreferences = preferences
+            configuredGestures = GestureType.entries.filter { resolveGesture(it) != null }.toSet()
+        }
+        return configuredGestures
     }
 
     /** Launch gesture configured operation for a specific gesture type


### PR DESCRIPTION
## Description

Per-app icon gestures were cached when an existing workspace icon first checked them. Configuring a gesture later did not affect that icon until it was removed and added again, which created a new listener.

Resolve the configured state from `PreferenceManager2`'s in-memory cache on each check so an existing icon observes updated gesture settings immediately.

## Testing

- `git diff --check`
- `./gradlew projects`
- Not run: Android Kotlin compilation requires a local Android SDK, which is not available in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Gesture settings changes now take effect immediately without requiring icon views to be recreated.
  * Improved detection of configured gestures after per-app settings are updated.
  * Gesture configuration is refreshed more efficiently, improving responsiveness during scrolling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->