### PR TITLE
refactor: Migrate folder item ranking to FolderEntry.rank

### DIFF
--- a/lawnchair/src/app/lawnchair/allapps/LawnchairAlphabeticalAppsList.kt
+++ b/lawnchair/src/app/lawnchair/allapps/LawnchairAlphabeticalAppsList.kt
@@ -7,7 +7,6 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import app.lawnchair.data.folder.FolderEntry
-import app.lawnchair.data.folder.model.FolderOrderUtils
 import app.lawnchair.data.folder.model.FolderViewModel
 import app.lawnchair.launcher
 import app.lawnchair.preferences.PreferenceManager
@@ -46,10 +45,8 @@ class LawnchairAlphabeticalAppsList<T>(
     private val viewModel = FolderViewModel(
         (context as? ComponentActivity)?.application ?: context.launcher.application,
     )
-    private var folderList = mutableListOf<FolderEntry>()
+    private val folderList = mutableListOf<FolderEntry>()
     private val filteredList = mutableListOf<AppInfo>()
-
-    private val folderOrder get() = FolderOrderUtils.stringToIntList(prefs.drawerListOrder.get())
 
     init {
         context.launcher.deviceProfile.inv.addOnChangeListener(this)
@@ -72,12 +69,8 @@ class LawnchairAlphabeticalAppsList<T>(
     private fun observeFolders() {
         viewModel.folders.observeOnce(context as LifecycleOwner) { folders ->
             if (folders != null) {
-                folderList = folders
-                    .sortedBy {
-                        val index = folderOrder.indexOf(it.id)
-                        if (index == -1) Int.MAX_VALUE else index
-                    }
-                    .toMutableList()
+                folderList.clear()
+                folderList.addAll(folders)
                 updateAdapterItems()
             }
         }

--- a/lawnchair/src/app/lawnchair/data/folder/FolderEntity.kt
+++ b/lawnchair/src/app/lawnchair/data/folder/FolderEntity.kt
@@ -42,5 +42,6 @@ data class FolderEntry(
     val id: Int,
     val title: String,
     val hide: Boolean = false,
+    val rank: Int = 0,
     val itemComponentKeys: List<String> = emptyList(),
 )

--- a/lawnchair/src/app/lawnchair/data/folder/model/FolderViewModel.kt
+++ b/lawnchair/src/app/lawnchair/data/folder/model/FolderViewModel.kt
@@ -77,19 +77,10 @@ class FolderViewModel(
         }
         reloadHelper.reloadGrid()
     }
-}
 
-object FolderOrderUtils {
-    private const val DEFAULT_DELIMITER = ","
-
-    fun intListToString(list: List<Int>, delimiter: String = DEFAULT_DELIMITER): String {
-        return list.joinToString(delimiter)
-    }
-
-    fun stringToIntList(string: String, delimiter: String = DEFAULT_DELIMITER): List<Int> {
-        return string.takeIf { it.isNotBlank() }
-            ?.split(delimiter)
-            ?.mapNotNull { it.trim().toIntOrNull() }
-            ?: emptyList()
+    fun updateFolderOrder(orderedIds: List<Int>) {
+        viewModelScope.launch {
+            repository.updateFolderRanks(orderedIds)
+        }
     }
 }

--- a/lawnchair/src/app/lawnchair/data/folder/service/FolderDao.kt
+++ b/lawnchair/src/app/lawnchair/data/folder/service/FolderDao.kt
@@ -21,9 +21,15 @@ interface FolderDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertFolderItems(items: List<FolderItemEntity>)
 
+    @Query("SELECT id FROM Folders ORDER BY rank ASC")
+    suspend fun getAllFolderIds(): List<Int>
+
     @Query("SELECT * FROM Folders ORDER BY rank ASC")
     @Transaction
     fun getAllFoldersWithItems(): Flow<List<FolderWithItems>>
+
+    @Query("SELECT MAX(rank) FROM Folders")
+    suspend fun getMaxFolderRank(): Int?
 
     @Query("DELETE FROM FolderItems WHERE folderId = :folderId")
     suspend fun deleteFolderItemsByFolderId(folderId: Int)
@@ -63,9 +69,6 @@ interface FolderDao {
             updateFolderRank(id, index)
         }
     }
-
-    @Query("SELECT COUNT(*) FROM Folders")
-    suspend fun getFolderCount(): Int
 
     @RawQuery
     suspend fun checkpoint(supportSQLiteQuery: SupportSQLiteQuery): Int

--- a/lawnchair/src/app/lawnchair/data/folder/service/FolderDao.kt
+++ b/lawnchair/src/app/lawnchair/data/folder/service/FolderDao.kt
@@ -65,6 +65,10 @@ interface FolderDao {
 
     @Transaction
     suspend fun updateFolderRanks(orderedIds: List<Int>) {
+        val currentIds = getAllFolderIds().toSet()
+        if (orderedIds.size != currentIds.size || orderedIds.toSet() != currentIds) {
+            return
+        }
         orderedIds.forEachIndexed { index, id ->
             updateFolderRank(id, index)
         }

--- a/lawnchair/src/app/lawnchair/data/folder/service/FolderDao.kt
+++ b/lawnchair/src/app/lawnchair/data/folder/service/FolderDao.kt
@@ -21,7 +21,7 @@ interface FolderDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertFolderItems(items: List<FolderItemEntity>)
 
-    @Query("SELECT * FROM Folders")
+    @Query("SELECT * FROM Folders ORDER BY rank ASC")
     @Transaction
     fun getAllFoldersWithItems(): Flow<List<FolderWithItems>>
 
@@ -53,6 +53,19 @@ interface FolderDao {
 
     @Query("DELETE FROM Folders WHERE id = :folderId")
     suspend fun deleteFolder(folderId: Int)
+
+    @Query("UPDATE Folders SET rank = :rank WHERE id = :id")
+    suspend fun updateFolderRank(id: Int, rank: Int)
+
+    @Transaction
+    suspend fun updateFolderRanks(orderedIds: List<Int>) {
+        orderedIds.forEachIndexed { index, id ->
+            updateFolderRank(id, index)
+        }
+    }
+
+    @Query("SELECT COUNT(*) FROM Folders")
+    suspend fun getFolderCount(): Int
 
     @RawQuery
     suspend fun checkpoint(supportSQLiteQuery: SupportSQLiteQuery): Int

--- a/lawnchair/src/app/lawnchair/data/folder/service/FolderService.kt
+++ b/lawnchair/src/app/lawnchair/data/folder/service/FolderService.kt
@@ -1,10 +1,12 @@
 ﻿package app.lawnchair.data.folder.service
 
 import android.content.Context
+import androidx.core.content.edit
 import app.lawnchair.data.AppDatabase
 import app.lawnchair.data.folder.FolderEntry
 import app.lawnchair.data.folder.FolderInfoEntity
 import app.lawnchair.data.folder.FolderItemEntity
+import app.lawnchair.preferences.PreferenceManager
 import com.android.launcher3.dagger.ApplicationContext
 import com.android.launcher3.dagger.LauncherAppComponent
 import com.android.launcher3.dagger.LauncherAppSingleton
@@ -14,6 +16,7 @@ import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.withContext
 
 @LauncherAppSingleton
@@ -22,11 +25,14 @@ class FolderService @Inject constructor(
 ) : SafeCloseable {
 
     private val folderDao = AppDatabase.INSTANCE.get(context).folderDao()
+    private val prefs = PreferenceManager.getInstance(context)
 
     fun getFoldersFlow(): Flow<List<FolderEntry>> {
-        return folderDao.getAllFoldersWithItems().map { list ->
-            list.map { it.toFolderEntry() }
-        }
+        return folderDao.getAllFoldersWithItems()
+            .onStart { migrateLegacyFolderRanks() }
+            .map { list ->
+                list.map { it.toFolderEntry() }
+            }
     }
 
     suspend fun updateFolderWithItems(folderInfoId: Int, title: String, componentKeys: List<String>) = withContext(Dispatchers.IO) {
@@ -41,7 +47,8 @@ class FolderService @Inject constructor(
     }
 
     suspend fun saveFolderInfo(title: String) = withContext(Dispatchers.IO) {
-        folderDao.insertFolder(FolderInfoEntity(title = title))
+        val rank = folderDao.getFolderCount()
+        folderDao.insertFolder(FolderInfoEntity(title = title, rank = rank))
     }
 
     suspend fun renameFolderInfo(folderId: Int, title: String) = withContext(Dispatchers.IO) {
@@ -52,10 +59,35 @@ class FolderService @Inject constructor(
         folderDao.deleteFolder(id)
     }
 
+    suspend fun updateFolderRanks(orderedIds: List<Int>) = withContext(Dispatchers.IO) {
+        folderDao.updateFolderRanks(orderedIds)
+    }
+
+    private suspend fun migrateLegacyFolderRanks() = withContext(Dispatchers.IO) {
+        val legacyOrder = prefs.sp.getString(LEGACY_FOLDER_ORDER_STRING, "") ?: ""
+        if (legacyOrder.isNotEmpty()) {
+            val orderedIds = stringToIntList(legacyOrder)
+            if (orderedIds.isNotEmpty()) {
+                folderDao.updateFolderRanks(orderedIds)
+                prefs.sp.edit {
+                    putString(LEGACY_FOLDER_ORDER_STRING, "")
+                }
+            }
+        }
+    }
+
+    private fun stringToIntList(string: String, delimiter: String = ","): List<Int> {
+        return string.takeIf { it.isNotBlank() }
+            ?.split(delimiter)
+            ?.mapNotNull { it.trim().toIntOrNull() }
+            ?: emptyList()
+    }
+
     private fun FolderWithItems.toFolderEntry() = FolderEntry(
         id = folder.id,
         title = folder.title,
         hide = folder.hide,
+        rank = folder.rank,
         itemComponentKeys = items
             .sortedBy { it.rank }
             .mapNotNull { it.componentKey },
@@ -69,3 +101,5 @@ class FolderService @Inject constructor(
         val INSTANCE = DaggerSingletonObject(LauncherAppComponent::getFolderService)
     }
 }
+
+private const val LEGACY_FOLDER_ORDER_STRING = "pref_drawerListOrder"

--- a/lawnchair/src/app/lawnchair/data/folder/service/FolderService.kt
+++ b/lawnchair/src/app/lawnchair/data/folder/service/FolderService.kt
@@ -47,7 +47,7 @@ class FolderService @Inject constructor(
     }
 
     suspend fun saveFolderInfo(title: String) = withContext(Dispatchers.IO) {
-        val rank = folderDao.getFolderCount()
+        val rank = (folderDao.getMaxFolderRank() ?: -1) + 1
         folderDao.insertFolder(FolderInfoEntity(title = title, rank = rank))
     }
 
@@ -66,12 +66,17 @@ class FolderService @Inject constructor(
     private suspend fun migrateLegacyFolderRanks() = withContext(Dispatchers.IO) {
         val legacyOrder = prefs.sp.getString(LEGACY_FOLDER_ORDER_STRING, "") ?: ""
         if (legacyOrder.isNotEmpty()) {
-            val orderedIds = stringToIntList(legacyOrder)
+            val legacyIds = stringToIntList(legacyOrder).distinct()
+            val currentIds = folderDao.getAllFolderIds()
+            val validLegacyIds = legacyIds.filter { it in currentIds }
+            val missingCurrentIds = currentIds.filter { it !in validLegacyIds }
+            val orderedIds = validLegacyIds + missingCurrentIds
+
             if (orderedIds.isNotEmpty()) {
                 folderDao.updateFolderRanks(orderedIds)
-                prefs.sp.edit {
-                    putString(LEGACY_FOLDER_ORDER_STRING, "")
-                }
+            }
+            prefs.sp.edit {
+                putString(LEGACY_FOLDER_ORDER_STRING, "")
             }
         }
     }

--- a/lawnchair/src/app/lawnchair/preferences/PreferenceManager.kt
+++ b/lawnchair/src/app/lawnchair/preferences/PreferenceManager.kt
@@ -169,7 +169,6 @@ class PreferenceManager @Inject constructor(
     val wallpaperBlur = IntPref("pref_wallpaperBlur", 25, recreate)
     val wallpaperBlurFactorThreshold = FloatPref("pref_wallpaperBlurFactor", 3.0F, recreate)
 
-    val drawerListOrder = StringPref("pref_drawerListOrder", "", reloadGrid)
     val drawerList = BoolPref("pref_drawerList", true, recreate)
     val folderApps = BoolPref("pref_hideFolderApps", true, reloadGrid)
 

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/AppDrawerFoldersPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/AppDrawerFoldersPreference.kt
@@ -36,7 +36,6 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import app.lawnchair.data.folder.FolderEntry
-import app.lawnchair.data.folder.model.FolderOrderUtils
 import app.lawnchair.data.folder.model.FolderViewModel
 import app.lawnchair.preferences.getAdapter
 import app.lawnchair.preferences.preferenceManager
@@ -97,6 +96,9 @@ fun AppDrawerFoldersPreference(
         onDeleteFolder = {
             viewModel.deleteFolder(it.id)
         },
+        onOrderChange = {
+            viewModel.updateFolderOrder(it)
+        },
     )
 }
 
@@ -108,30 +110,13 @@ fun AppDrawerFoldersPreference(
     onEditFolderItems: (Int) -> Unit,
     onRenameFolder: (Int, String) -> Unit,
     onDeleteFolder: (FolderEntry) -> Unit,
+    onOrderChange: (List<Int>) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val bottomSheetHandler = bottomSheetHandler
     val prefs = preferenceManager()
-    val folderOrderAdapter = prefs.drawerListOrder.getAdapter()
 
-    val folderOrderString by folderOrderAdapter.state
-
-    var sortedDisplayList = remember(folders, folderOrderString) {
-        Log.d("AppDrawerFolders", "Recalculating sortedDisplayList. Folders count: ${folders?.size}")
-        folders?.sortedWith(
-            compareBy { folderEntry ->
-                val index = FolderOrderUtils
-                    .stringToIntList(folderOrderString)
-                    .indexOf(folderEntry.id)
-                if (index == -1) {
-                    // New items go to the end
-                    Integer.MAX_VALUE
-                } else {
-                    index
-                }
-            },
-        ) ?: emptyList()
-    }
+    val sortedDisplayList = folders ?: emptyList()
 
     LoadingScreen(
         isLoading = folders == null,
@@ -183,14 +168,7 @@ fun AppDrawerFoldersPreference(
                 items = sortedDisplayList,
                 defaultList = sortedDisplayList,
                 onOrderChange = { updatedFolders ->
-                    val newOrder = updatedFolders.map { it.id }
-
-                    folderOrderAdapter.onChange(
-                        FolderOrderUtils.intListToString(
-                            newOrder,
-                        ),
-                    )
-                    sortedDisplayList = updatedFolders
+                    onOrderChange(updatedFolders.map { it.id })
                 },
             ) { folderEntry, _, _ ->
                 val interactionSource = remember { MutableInteractionSource() }
@@ -214,15 +192,6 @@ fun AppDrawerFoldersPreference(
                         }
                     },
                     onItemDelete = { folderToDelete ->
-                        val currentOrder =
-                            FolderOrderUtils.stringToIntList(folderOrderAdapter.state.value)
-                        val newOrderAfterDelete =
-                            currentOrder.filter { it != folderToDelete.id }
-                        folderOrderAdapter.onChange(
-                            FolderOrderUtils.intListToString(
-                                newOrderAfterDelete,
-                            ),
-                        )
                         onDeleteFolder(folderToDelete)
                     },
                     dragIndicator = {


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

This PR migrates the folder item ranking to use `FolderEntry.rank`, removing the fragile approach of string-based ordering.

Addresses task of #6442.

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->
1. Create folders from an old version of Lawnchair, or restore a backup containing folders
2. Update and open Lawnchair
3. Open the app drawer
4. See folders are arranged correctly
5. Go to Home settings > App drawer > App drawer folders
6. See folders sorted correctly
7. Re-arrange folder order / make new folder
8. See folders sorted correctly

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

:white_check_mark: **Refactor** (A code change that neither fixes a bug nor adds a feature)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent folder ordering through drag-and-drop placement.
  * New folders are automatically added after existing folders.
  * Folder order changes are saved and retained across app sessions.
  * Existing folder arrangements are migrated to the new ordering system.

* **Bug Fixes**
  * Folder lists now consistently display folders in their saved order.
  * Removing a folder no longer causes unrelated folder ordering changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->