### PR TITLE
feat: optionally keep the keyboard open when clearing the allapps search field

### DIFF
--- a/lawnchair/res/values/config.xml
+++ b/lawnchair/res/values/config.xml
@@ -144,6 +144,7 @@
     <bool name="config_default_enable_smartspace_calendar_selection">true</bool>
     <bool name="config_default_dts2">true</bool>
     <bool name="config_default_auto_show_keyboard_in_drawer">false</bool>
+    <bool name="config_default_keep_keyboard_open_on_clear">false</bool>
     <bool name="config_default_show_icon_labels_on_home_screen">true</bool>
     <bool name="config_default_show_icon_labels_in_drawer">true</bool>
     <bool name="config_default_enable_fuzzy_search">false</bool>

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -951,6 +951,9 @@
     <string name="show_app_search_bar">Show search bar</string>
     <string name="pref_search_auto_show_keyboard">Automatically show keyboard</string>
 
+    <string name="pref_search_keep_keyboard_open_label">Keep keyboard open on clear</string>
+    <string name="pref_search_keep_keyboard_open_description">Keyboard won\'t close when you clear the search field</string>
+
     <string name="fuzzy_search_title">Fuzzy search</string>
     <string name="fuzzy_search_desc">Approximate matching for app searches</string>
 

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -951,8 +951,7 @@
     <string name="show_app_search_bar">Show search bar</string>
     <string name="pref_search_auto_show_keyboard">Automatically show keyboard</string>
 
-    <string name="pref_search_keep_keyboard_open_label">Keep keyboard open on clear</string>
-    <string name="pref_search_keep_keyboard_open_description">Keyboard won\'t close when you clear the search field</string>
+    <string name="pref_search_keep_keyboard_open_label">Keep keyboard open when clearing search</string>
 
     <string name="fuzzy_search_title">Fuzzy search</string>
     <string name="fuzzy_search_desc">Approximate matching for app searches</string>

--- a/lawnchair/src/app/lawnchair/allapps/AllAppsSearchInput.kt
+++ b/lawnchair/src/app/lawnchair/allapps/AllAppsSearchInput.kt
@@ -443,7 +443,7 @@ class AllAppsSearchInput(context: Context, attrs: AttributeSet?) :
     }
 
     override fun resetSearch() {
-        searchBarController.reset()
+        searchBarController.reset(prefs2.keepKeyboardOpenOnClear.firstCached())
     }
 
     override fun setDirectFocus(directFocus: Boolean) {

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
@@ -472,6 +472,11 @@ class PreferenceManager2 @Inject constructor(
         defaultValue = context.resources.getBoolean(R.bool.config_default_auto_show_keyboard_in_drawer),
     )
 
+    val keepKeyboardOpenOnClear = preference(
+        key = booleanPreferencesKey(name = "keep_keyboard_open_on_clear"),
+        defaultValue = context.resources.getBoolean(R.bool.config_default_keep_keyboard_open_on_clear),
+    )
+
     val workspaceTextColor = preference(
         key = stringPreferencesKey(name = "workspace_text_color"),
         defaultValue = ColorMode.AUTO,

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/search/DrawerSearchPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/search/DrawerSearchPreferences.kt
@@ -54,6 +54,11 @@ fun DrawerSearchPreference(
                 adapter = prefs2.autoShowKeyboardInDrawer.getAdapter(),
                 label = stringResource(id = R.string.pref_search_auto_show_keyboard),
             )
+            SwitchPreference(
+                adapter = prefs2.keepKeyboardOpenOnClear.getAdapter(),
+                label = stringResource(id = R.string.pref_search_keep_keyboard_open_label),
+                description = stringResource(id = R.string.pref_search_keep_keyboard_open_description),
+            )
             SearchProvider(
                 context = context,
             )

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/search/DrawerSearchPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/search/DrawerSearchPreferences.kt
@@ -57,7 +57,6 @@ fun DrawerSearchPreference(
             SwitchPreference(
                 adapter = prefs2.keepKeyboardOpenOnClear.getAdapter(),
                 label = stringResource(id = R.string.pref_search_keep_keyboard_open_label),
-                description = stringResource(id = R.string.pref_search_keep_keyboard_open_description),
             )
             SearchProvider(
                 context = context,

--- a/src/com/android/launcher3/allapps/ActivityAllAppsContainerView.java
+++ b/src/com/android/launcher3/allapps/ActivityAllAppsContainerView.java
@@ -653,7 +653,9 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
             return;
         }
         if (currentActivePage != SEARCH) {
-            mActivityContext.hideKeyboard();
+            if (!PreferenceCacheExtensionsKt.firstCached(pref2.getKeepKeyboardOpenOnClear())) {
+                mActivityContext.hideKeyboard();
+            }
         }
         if (mAH.get(currentActivePage).mRecyclerView != null) {
             mAH.get(currentActivePage).mRecyclerView.bindFastScrollbar(mFastScroller,

--- a/src/com/android/launcher3/allapps/search/AllAppsSearchBarController.java
+++ b/src/com/android/launcher3/allapps/search/AllAppsSearchBarController.java
@@ -151,14 +151,18 @@ public class AllAppsSearchBarController
         }
         return false;
     }
-
+    
+    public void reset() {
+        reset(false);
+    }   
+    
     /**
      * Resets the search bar state.
      */
-    public void reset() {
+    public void reset(boolean keepKeyboardOpen) {
         mCallback.clearSearchResult();
         mInput.reset();
-        if (!PreferenceCacheExtensionsKt.firstCached(pref2.getKeepKeyboardOpenOnClear())) {
+        if (!keepKeyboardOpen) {
             mInput.clearFocus();
             mInput.hideKeyboard();
         }

--- a/src/com/android/launcher3/allapps/search/AllAppsSearchBarController.java
+++ b/src/com/android/launcher3/allapps/search/AllAppsSearchBarController.java
@@ -33,6 +33,10 @@ import com.android.launcher3.search.SearchAlgorithm;
 import com.android.launcher3.search.SearchCallback;
 import com.android.launcher3.views.ActivityContext;
 
+import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
+import app.lawnchair.LawnchairApp;
+import app.lawnchair.preferences2.PreferenceManager2;
+
 /**
  * An interface to a search box that AllApps can command.
  */
@@ -48,6 +52,12 @@ public class AllAppsSearchBarController
 
     protected SearchAlgorithm<AdapterItem> mSearchAlgorithm;
 
+    private final PreferenceManager2 pref2;
+    
+    public AllAppsSearchBarController() {
+        pref2 = PreferenceManager2.getInstance(LawnchairApp.getInstance());
+    }
+    
     public void setVisibility(int visibility) {
         mInput.setVisibility(visibility);
     }
@@ -148,8 +158,10 @@ public class AllAppsSearchBarController
     public void reset() {
         mCallback.clearSearchResult();
         mInput.reset();
-        mInput.clearFocus();
-        mInput.hideKeyboard();
+        if (!PreferenceCacheExtensionsKt.firstCached(pref2.getKeepKeyboardOpenOnClear())) {
+            mInput.clearFocus();
+            mInput.hideKeyboard();
+        }
         mQuery = null;
     }
 


### PR DESCRIPTION
### Description

This PR adds an option to keep the keyboard open after clearing the search field in allapps. This is similar behavior to Pixels - typing something, and then clearing it keeps the keyboard open.

Verified on emulator and a real, modern device with Android 16 (Moto Edge 60 Pro)

### Reasoning

The current behavior slows downs users used to quickly launching apps by name. Sometimes, for example, they might mistype the name, tap a backspace a few times to clear the field and type it again. 

### Type of change

:x: **Bug fix** (A non-breaking change that fixes an issue)
:white_check_mark: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a search preference to keep the keyboard open when clearing the search field.
  * Added a localized setting label for this behavior.

* **Bug Fixes**
  * Clearing search now preserves keyboard focus and visibility when enabled.
  * Switching away from search no longer hides the keyboard when the preference is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->