### PR TITLE
feat: Folder allapps shortcut popup

### DIFF
--- a/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
+++ b/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
@@ -59,6 +59,7 @@ import com.android.launcher3.LauncherAppState
 import com.android.launcher3.LauncherState
 import com.android.launcher3.R
 import com.android.launcher3.Utilities
+import com.android.launcher3.folder.FolderIcon
 import com.android.launcher3.model.data.ItemInfo
 import com.android.launcher3.popup.SystemShortcut
 import com.android.launcher3.shortcuts.DeepShortcutView
@@ -262,6 +263,16 @@ class LawnchairLauncher : QuickstepLauncher() {
     override fun collectStateHandlers(out: MutableList<StateHandler<LauncherState>>) {
         super.collectStateHandlers(out)
         out.add(SearchBarStateHandler(this))
+    }
+
+    override fun getAllAppsItemLongClickListener(): View.OnLongClickListener {
+        return View.OnLongClickListener { view ->
+            if (view is FolderIcon && view.mInfo.id != ItemInfo.NO_ID) {
+                LawnchairShortcut.showAppDrawerFolderPopup(this, view)
+            } else {
+                super.getAllAppsItemLongClickListener().onLongClick(view)
+            }
+        }
     }
 
     override fun getSupportedShortcuts(container: Int): Stream<SystemShortcut.Factory<*>> = Stream.concat(

--- a/lawnchair/src/app/lawnchair/allapps/LawnchairAlphabeticalAppsList.kt
+++ b/lawnchair/src/app/lawnchair/allapps/LawnchairAlphabeticalAppsList.kt
@@ -126,6 +126,7 @@ class LawnchairAlphabeticalAppsList<T>(
 
                 if (resolvedApps.size > 1) {
                     val folderInfo = FolderInfo().apply {
+                        id = folderEntry.id
                         title = folderEntry.title
                         resolvedApps.forEach { add(it) }
                     }

--- a/lawnchair/src/app/lawnchair/ui/popup/LawnchairShortcut.kt
+++ b/lawnchair/src/app/lawnchair/ui/popup/LawnchairShortcut.kt
@@ -10,6 +10,8 @@ import android.content.pm.ApplicationInfo
 import android.content.pm.LauncherActivityInfo
 import android.content.pm.LauncherApps
 import android.content.pm.SuspendDialogInfo
+import android.graphics.Rect
+import android.graphics.RectF
 import android.graphics.drawable.AdaptiveIconDrawable
 import android.net.Uri
 import android.os.UserHandle
@@ -22,14 +24,18 @@ import app.lawnchair.LawnchairLauncher
 import app.lawnchair.override.CustomizeAppDialog
 import app.lawnchair.preferences2.PreferenceManager2
 import app.lawnchair.preferences2.firstCached
+import app.lawnchair.ui.preferences.PreferenceActivity
+import app.lawnchair.ui.preferences.navigation.AppDrawerAppListToFolder
 import app.lawnchair.views.ComposeBottomSheet
 import com.android.launcher3.AbstractFloatingView
 import com.android.launcher3.LauncherSettings.Favorites.ITEM_TYPE_APPLICATION
 import com.android.launcher3.LauncherSettings.Favorites.ITEM_TYPE_TASK
 import com.android.launcher3.R
 import com.android.launcher3.Utilities
+import com.android.launcher3.folder.FolderIcon
 import com.android.launcher3.graphics.ThemeManager
 import com.android.launcher3.icons.LauncherIcons
+import com.android.launcher3.logging.StatsLogManager
 import com.android.launcher3.model.data.AppInfo as ModelAppInfo
 import com.android.launcher3.model.data.ItemInfo
 import com.android.launcher3.popup.SystemShortcut
@@ -37,11 +43,47 @@ import com.android.launcher3.util.ApplicationInfoWrapper
 import com.android.launcher3.util.ComponentKey
 import com.android.launcher3.util.PackageManagerHelper
 import com.android.launcher3.views.ActivityContext
+import com.android.launcher3.views.OptionsPopupView
 import java.net.URISyntaxException
 
 class LawnchairShortcut {
 
     companion object {
+
+        fun showAppDrawerFolderPopup(
+            launcher: LawnchairLauncher,
+            folderIcon: FolderIcon,
+        ): Boolean {
+            val folderId = folderIcon.mInfo.id
+            if (folderId == ItemInfo.NO_ID) return false
+
+            val bounds = Rect()
+            launcher.dragLayer.getDescendantRectRelativeToSelf(folderIcon, bounds)
+            // Unlike regular app, folder does not have any code that would allow it to be showing any popup
+            // In the future we should perhaps move this entire code to a dedicated file like
+            // LawnchairFolderShortcut.kt
+            return OptionsPopupView.show<LawnchairLauncher>(
+                launcher,
+                RectF(bounds),
+                listOf(
+                    OptionsPopupView.OptionItem(
+                        launcher,
+                        R.string.edit_folder,
+                        R.drawable.ic_edit,
+                        StatsLogManager.LauncherEvent.IGNORE,
+                    ) {
+                        launcher.startActivity(
+                            PreferenceActivity.createIntent(
+                                launcher,
+                                AppDrawerAppListToFolder(folderId),
+                            ),
+                        )
+                        true
+                    },
+                ),
+                true,
+            ) != null
+        }
 
         val CUSTOMIZE =
             SystemShortcut.Factory { activity: LawnchairLauncher, itemInfo, originalView ->

--- a/lawnchair/src/app/lawnchair/ui/popup/LawnchairShortcut.kt
+++ b/lawnchair/src/app/lawnchair/ui/popup/LawnchairShortcut.kt
@@ -59,7 +59,9 @@ class LawnchairShortcut {
 
             val bounds = Rect()
             launcher.dragLayer.getDescendantRectRelativeToSelf(folderIcon, bounds)
-            // Unlike regular app, folder does not have any code that would allow it to be showing any popup
+            // Unlike regular app, folder does not have any code that would allow it to be showing
+            // any popup we have to create our own.
+            //
             // In the future we should perhaps move this entire code to a dedicated file like
             // LawnchairFolderShortcut.kt
             return OptionsPopupView.show<LawnchairLauncher>(

--- a/src/com/android/launcher3/allapps/BaseAllAppsAdapter.java
+++ b/src/com/android/launcher3/allapps/BaseAllAppsAdapter.java
@@ -364,9 +364,11 @@ public abstract class BaseAllAppsAdapter<T extends Context & ActivityContext> ex
                 FolderInfo folderInfo = mApps.getAdapterItems().get(position).folderInfo;
                 ViewGroup container = (ViewGroup) holder.itemView;
                 container.removeAllViews();
-                container.addView(
-                    FolderIcon.inflateFolderAndIcon(R.layout.all_apps_folder_icon, mActivityContext,
-                    container, folderInfo));
+                // LC-Note: Implement long-press support for folder type for purposes like showing popup
+                FolderIcon folderIcon = FolderIcon.inflateFolderAndIcon(
+                        R.layout.all_apps_folder_icon, mActivityContext, container, folderInfo);
+                folderIcon.setOnLongClickListener(mOnIconLongClickListener);
+                container.addView(folderIcon);
                 break;
             default:
                 if (mAdapterProvider.isViewSupported(holder.getItemViewType())) {


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Fixes task of #6442 

Also somewhat lay the future groundwork for more popup target to every folder type (although in this PR only bound it to the allapps folder)

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Tested by creating a folder, displaying the folder, long-press on the folder, observe the first result (popup menu on folder, AND you should not be able to move it out of the allapps panel to workspace page), tap edit folder after popup has displayed, add/substract app, close preference page, observe the second result (app entry updated)

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **New feature** (A non-breaking change that adds functionality)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added long-press actions for folders in the app drawer.
  * Folder long-press actions now open a popup with options to edit folder settings.

* **Bug Fixes**
  * Enabled folder icons in the app drawer to retain their folder identity and respond correctly to long-press gestures.
  * Preserved existing long-press behavior for non-folder app items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->