### PR TITLE
feat: Enable private space apps on the home screen

### DIFF
--- a/AndroidManifest-common.xml
+++ b/AndroidManifest-common.xml
@@ -43,7 +43,14 @@
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
     <uses-permission android:name="android.permission.EXPAND_STATUS_BAR" />
     <uses-permission android:name="android.permission.ACCESS_RESTRICTED_SETTINGS" />
-    
+
+    <!--
+    Required to see the private profile at all. This is an appop permission granted only while this
+    app holds the home role, so it comes and goes as the default launcher changes. Declared here
+    rather than only in the quickstep manifest so that every flavour can observe the profile.
+    -->
+    <uses-permission android:name="android.permission.ACCESS_HIDDEN_PROFILES" />
+
     <!-- for rotating surface by arbitrary degree -->
     <uses-permission android:name="android.permission.VIBRATE"/>
     <uses-permission android:name="android.permission.ROTATE_SURFACE_FLINGER" />

--- a/lawnchair/res/values/config.xml
+++ b/lawnchair/res/values/config.xml
@@ -115,6 +115,8 @@
     <bool name="config_default_rounded_widgets">true</bool>
     <bool name="config_default_allow_widget_overlap">false</bool>
     <bool name="config_default_force_widget_resize">false</bool>
+    <bool name="config_default_allow_pinning_private_space_apps">false</bool>
+    <bool name="config_default_hide_private_space_app_badge">false</bool>
     <bool name="config_default_widget_unlimited_size">false</bool>
     <bool name="config_default_show_status_bar">true</bool>
     <bool name="config_default_remember_position">false</bool>

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -645,6 +645,15 @@
     <string name="color_light">Light</string>
     <string name="color_dark">Dark</string>
 
+    <string name="private_space_group_label">Private space</string>
+    <string name="private_space_check_failed">Couldn\'t check private space state — some icons may be shown or hidden incorrectly</string>
+    <string name="private_space_pinning_label">Allow on home screen</string>
+    <string name="private_space_pinning_description">Let private space apps be added to the home screen and dock. Their names and icons will be visible outside the private space</string>
+    <string name="private_space_item_relocated">Moved %1$s to a free spot — its place on the home screen was taken</string>
+    <string name="private_space_items_relocated">Moved %1$d private space apps to free spots — their places on the home screen were taken</string>
+    <string name="private_space_hide_badge_label">Hide app badge</string>
+    <string name="private_space_hide_badge_description">Remove the private space badge from these app icons, wherever they appear</string>
+
     <string name="force_rounded_widgets">Rounded corners</string>
     <string name="allow_widget_overlap">Allow overlap</string>
 

--- a/lawnchair/src/app/lawnchair/allapps/LawnchairAlphabeticalAppsList.kt
+++ b/lawnchair/src/app/lawnchair/allapps/LawnchairAlphabeticalAppsList.kt
@@ -11,6 +11,7 @@ import app.lawnchair.data.folder.model.FolderViewModel
 import app.lawnchair.launcher
 import app.lawnchair.preferences.PreferenceManager
 import app.lawnchair.preferences2.PreferenceManager2
+import app.lawnchair.util.PrivateSpaceUtils
 import app.lawnchair.util.categorizeAppsWithSystemAndGoogle
 import com.android.launcher3.InvariantDeviceProfile.OnIDPChangeListener
 import com.android.launcher3.allapps.AllAppsStore
@@ -109,6 +110,12 @@ class LawnchairAlphabeticalAppsList<T>(
                     mAdapterItems.add(AdapterItem.asFolder(folderInfo))
                     folder.getContents().forEach { app ->
                         (appsStore.getApp(app.componentKey) as? AppInfo)?.let {
+                            // Drawer folders resolve their apps straight from the store by
+                            // component, bypassing the private space section that would otherwise
+                            // keep a locked app out of the drawer.
+                            if (PrivateSpaceUtils.isHiddenWhileLocked(context, it)) {
+                                return@let
+                            }
                             folderInfo.add(it)
                             if (prefs.folderApps.get()) filteredList.add(it)
                         }

--- a/lawnchair/src/app/lawnchair/backup/LawnchairBackup.kt
+++ b/lawnchair/src/app/lawnchair/backup/LawnchairBackup.kt
@@ -7,7 +7,11 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
 import androidx.core.graphics.drawable.toBitmap
+import android.database.sqlite.SQLiteDatabase
+import android.os.Build
+import android.util.Log
 import app.lawnchair.LawnchairProto.BackupInfo
+import app.lawnchair.util.PrivateSpaceUtils
 import app.lawnchair.util.hasFlag
 import app.lawnchair.util.scaleDownTo
 import app.lawnchair.util.scaleDownToDisplaySize
@@ -16,14 +20,17 @@ import app.lawnchair.wallpaper.WallpaperManagerCompat
 import com.android.launcher3.BuildConfig
 import com.android.launcher3.LauncherAppState
 import com.android.launcher3.LauncherFiles
+import com.android.launcher3.LauncherSettings.Favorites
 import com.android.launcher3.R
 import com.android.launcher3.model.DeviceGridState
 import com.android.launcher3.model.ModelDbController
 import com.android.launcher3.provider.RestoreDbTask
+import com.android.launcher3.util.PrivateProfileTracker
 import com.google.protobuf.Timestamp
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
+import java.io.IOException
 import java.io.InputStream
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -81,8 +88,42 @@ class LawnchairBackup(
         DeviceGridState(info.gridState).writeToPrefs(context, true)
         readZip(handlers)
 
+        if (contents.hasFlag(INCLUDE_LAYOUT_AND_SETTINGS)) {
+            verifyRestoredDb(context)
+        }
+
         var dbController = ModelDbController(context)
         RestoreDbTask.performRestore(context, dbController)
+    }
+
+    /**
+     * Refuses to restore a database that did not survive the round trip intact.
+     *
+     * Archives written by older builds were plain copies of a live database and can be torn, so a
+     * damaged file is a real possibility rather than a theoretical one. Importing it would replace a
+     * working layout with a broken one, and the failure would surface later as missing or duplicated
+     * icons rather than as a failed restore.
+     */
+    private fun verifyRestoredDb(context: Context) {
+        val restoredDb = context.getDatabasePath(RESTORED_DB_FILE_NAME)
+        if (!restoredDb.exists()) return
+        val result = try {
+            SQLiteDatabase.openDatabase(
+                restoredDb.absolutePath,
+                null,
+                SQLiteDatabase.OPEN_READONLY,
+            ).use { db ->
+                db.rawQuery("PRAGMA integrity_check", null).use { cursor ->
+                    if (cursor.moveToFirst()) cursor.getString(0) else null
+                }
+            }
+        } catch (t: Throwable) {
+            Log.e(TAG, "Restored database could not be opened", t)
+            null
+        }
+        if (result != "ok") {
+            throw IOException("Backup contains a damaged launcher database (integrity: $result)")
+        }
     }
 
     private suspend fun readZip(handlers: Map<String, suspend (InputStream) -> Unit>) {
@@ -104,6 +145,7 @@ class LawnchairBackup(
     }
 
     companion object {
+        private const val TAG = "LawnchairBackup"
         private const val BACKUP_VERSION = 1
         private const val PREFS_FILE_NAME = "${LauncherFiles.SHARED_PREFERENCES_KEY}.xml"
         private const val PREFS_DB_FILE_NAME = "preferences"
@@ -178,14 +220,116 @@ class LawnchairBackup(
                             screenshotBitmap.compress(Bitmap.CompressFormat.PNG, 85, out)
                         }
 
-                        getFiles(context, forRestore = false).entries.forEach {
-                            if (!it.value.exists()) return@forEach
-                            out.putNextEntry(ZipEntry(it.key))
-                            it.value.inputStream().copyTo(out)
+                        val launcherDb = launcherDbFile(context, forRestore = false)
+                        val sanitisedDb = sanitiseLauncherDbIfLocked(context, launcherDb)
+                        try {
+                            getFiles(context, forRestore = false).entries.forEach {
+                                if (!it.value.exists()) return@forEach
+                                val source =
+                                    if (it.value == launcherDb) sanitisedDb ?: it.value else it.value
+                                out.putNextEntry(ZipEntry(it.key))
+                                source.inputStream().copyTo(out)
+                            }
+                        } finally {
+                            sanitisedDb?.let { deleteDbFiles(it) }
                         }
                     }
                 }
             }
+        }
+
+        /**
+         * Returns a scrubbed copy of the launcher database with private space rows removed, or null
+         * when the database can be exported as-is.
+         *
+         * The favorites table stores each pinned app's component name in plain text, so an exported
+         * backup otherwise discloses exactly which apps live in the private space to anyone holding
+         * the unlocked phone - without them ever needing to unlock the space. Rows are kept only
+         * when the space is currently unlocked, i.e. when the person exporting has already proved
+         * they may see them; a backup made then still restores pinned private apps in full.
+         */
+        private fun sanitiseLauncherDbIfLocked(context: Context, launcherDb: File): File? {
+            if (!launcherDb.exists()) return null
+            val mustScrub = PrivateSpaceUtils.isPrivateSpaceLocked(context) &&
+                PrivateProfileTracker.getKnownPrivateProfileSerial(context) !=
+                PrivateProfileTracker.INVALID_SERIAL
+
+            val snapshot = snapshotLauncherDb(context, launcherDb)
+            if (snapshot == null) {
+                // No consistent snapshot available. Exporting the raw file is the historic
+                // behaviour and stays acceptable when there is nothing to hide, but never when we
+                // were supposed to strip private rows.
+                check(!mustScrub) { "Cannot scrub launcher database without a snapshot" }
+                return null
+            }
+            if (!mustScrub) return snapshot
+
+            val privateSerial = PrivateProfileTracker.getKnownPrivateProfileSerial(context)
+            return try {
+                SQLiteDatabase.openDatabase(
+                    snapshot.absolutePath,
+                    null,
+                    SQLiteDatabase.OPEN_READWRITE,
+                ).use { db ->
+                    val removed = db.delete(
+                        Favorites.TABLE_NAME,
+                        "${Favorites.PROFILE_ID} = ?",
+                        arrayOf(privateSerial.toString()),
+                    )
+                    Log.d(TAG, "Excluded $removed private space item(s) from backup")
+                }
+                snapshot
+            } catch (t: Throwable) {
+                // Never fall back to exporting the unscrubbed database: failing to strip is exactly
+                // the case where leaking would be silent.
+                Log.e(TAG, "Unable to scrub launcher database for backup", t)
+                deleteDbFiles(snapshot)
+                throw t
+            }
+        }
+
+        /**
+         * Takes a point-in-time consistent copy of the live launcher database, or null when this
+         * platform cannot and the caller should fall back to copying the file.
+         *
+         * A plain file copy of a database that is open for writing is unsafe twice over. The copy is
+         * not atomic, so a page written while it runs is captured half-old and half-new, producing a
+         * genuinely corrupt archive. And Android opens this database in WAL mode, so recently
+         * committed rows live in the sibling `-wal` file that a single-file copy leaves behind -
+         * quietly yielding a backup that is stale rather than broken, which is harder to notice.
+         * Both matter more now that the model rewrites positions on load to relocate private items.
+         *
+         * `VACUUM INTO` reads through a proper read transaction and writes a fully checkpointed
+         * database, so it is consistent by construction. It needs SQLite 3.27, which Android has had
+         * since API 29; below that we fall back, and no private space can exist there to leak.
+         */
+        private fun snapshotLauncherDb(context: Context, launcherDb: File): File? {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return null
+            // VACUUM INTO refuses to overwrite, so hand it a path that does not exist yet.
+            val target = File(context.cacheDir, "launcher-backup-${System.nanoTime()}.db")
+            deleteDbFiles(target)
+            return try {
+                SQLiteDatabase.openDatabase(
+                    launcherDb.absolutePath,
+                    null,
+                    SQLiteDatabase.OPEN_READONLY,
+                ).use { db ->
+                    db.execSQL("VACUUM INTO ?", arrayOf(target.absolutePath))
+                }
+                target
+            } catch (t: Throwable) {
+                Log.e(TAG, "Unable to snapshot launcher database, falling back to a file copy", t)
+                deleteDbFiles(target)
+                null
+            }
+        }
+
+        /** Removes a database along with any journal siblings it may have left behind. */
+        private fun deleteDbFiles(db: File) {
+            db.delete()
+            File("${db.absolutePath}-wal").delete()
+            File("${db.absolutePath}-shm").delete()
+            File("${db.absolutePath}-journal").delete()
         }
 
         private fun launcherDbFile(context: Context, forRestore: Boolean): File {

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
@@ -265,6 +265,35 @@ class PreferenceManager2 private constructor(private val context: Context) :
         defaultValue = context.resources.getBoolean(R.bool.config_default_force_widget_resize),
     )
 
+    /**
+     * Allows private space apps to be pinned to the home screen and hotseat.
+     *
+     * Off by default: pinning puts the app's name and icon outside the locked container, and records
+     * its component name in the launcher database, so it is a deliberate trade of privacy for
+     * convenience. Changing it reloads the model, which is what recomputes the pinnable flag.
+     */
+    val allowPinningPrivateSpaceApps = preference(
+        key = booleanPreferencesKey(name = "allow_pinning_private_space_apps"),
+        defaultValue = context.resources.getBoolean(
+            R.bool.config_default_allow_pinning_private_space_apps,
+        ),
+        onSet = { reloadHelper.reloadGrid() },
+    )
+
+    /**
+     * Removes the private profile badge from private space app icons, everywhere they appear.
+     *
+     * The badge is the only thing marking a pinned private app as private, so hiding it makes such
+     * an icon indistinguishable from an ordinary one on the home screen.
+     */
+    val hidePrivateSpaceAppBadge = preference(
+        key = booleanPreferencesKey(name = "hide_private_space_app_badge"),
+        defaultValue = context.resources.getBoolean(
+            R.bool.config_default_hide_private_space_app_badge,
+        ),
+        onSet = { reloadHelper.reloadIcons() },
+    )
+
     val widgetUnlimitedSize = preference(
         key = booleanPreferencesKey(name = "widget_unlimited_size"),
         defaultValue = context.resources.getBoolean(R.bool.config_default_widget_unlimited_size),

--- a/lawnchair/src/app/lawnchair/search/algorithms/LawnchairAppSearchAlgorithm.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/LawnchairAppSearchAlgorithm.kt
@@ -6,6 +6,7 @@ import app.lawnchair.preferences2.PreferenceManager2
 import app.lawnchair.search.adapter.SPACE
 import app.lawnchair.search.adapter.SearchTargetCompat
 import app.lawnchair.search.adapter.SearchTargetFactory
+import app.lawnchair.util.PrivateSpaceUtils
 import app.lawnchair.util.isDefaultLauncher
 import com.android.launcher3.LauncherAppState
 import com.android.launcher3.LauncherModel
@@ -75,10 +76,14 @@ class LawnchairAppSearchAlgorithm(context: Context) : LawnchairSearchAlgorithm(c
         apps: MutableList<AppInfo>,
         query: String,
     ): ArrayList<BaseAllAppsAdapter.AdapterItem> {
+        // The all apps list keeps private space apps loaded across a lock, and the drawer only
+        // filters them out when composing its adapter items. Search reads the model directly, so
+        // without this a locked private space is still fully enumerable by typing a name.
+        val searchable = apps.filterNot { PrivateSpaceUtils.isHiddenWhileLocked(context, it) }
         val appResults = if (enableFuzzySearch) {
-            SearchUtils.fuzzySearch(apps, query, maxResultsCount, hiddenApps, hiddenAppsInSearch)
+            SearchUtils.fuzzySearch(searchable, query, maxResultsCount, hiddenApps, hiddenAppsInSearch)
         } else {
-            SearchUtils.normalSearch(apps, query, maxResultsCount, hiddenApps, hiddenAppsInSearch)
+            SearchUtils.normalSearch(searchable, query, maxResultsCount, hiddenApps, hiddenAppsInSearch)
         }
 
         val searchTargets = mutableListOf<SearchTargetCompat>()

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/HomeScreenPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/HomeScreenPreferences.kt
@@ -164,6 +164,28 @@ fun HomeScreenPreferences(
                 description = stringResource(id = R.string.show_dot_pagination_description),
             )
         }
+        // Always offered, never withheld while the space is locked. The section is shown on every
+        // Android 15 device whether or not a private space exists, so its presence reveals nothing
+        // - but its absence would, marking out exactly the devices that have one and have it
+        // locked. Hiding it would have been the leak, not the protection.
+        if (Utilities.ATLEAST_V) {
+            PreferenceGroup(heading = stringResource(id = R.string.private_space_group_label)) {
+                val allowPinningPrivateSpaceAdapter =
+                    prefs2.allowPinningPrivateSpaceApps.getAdapter()
+                SwitchPreference(
+                    adapter = allowPinningPrivateSpaceAdapter,
+                    label = stringResource(id = R.string.private_space_pinning_label),
+                    description = stringResource(id = R.string.private_space_pinning_description),
+                )
+                SwitchPreference(
+                    adapter = prefs2.hidePrivateSpaceAppBadge.getAdapter(),
+                    label = stringResource(id = R.string.private_space_hide_badge_label),
+                    description = stringResource(
+                        id = R.string.private_space_hide_badge_description,
+                    ),
+                )
+            }
+        }
         PreferenceGroup(heading = stringResource(id = R.string.popup_menu)) {
             SwitchPreference(
                 adapter = prefs2.enableMaterialUPopUp.getAdapter(),

--- a/lawnchair/src/app/lawnchair/util/PrivateSpaceUtils.kt
+++ b/lawnchair/src/app/lawnchair/util/PrivateSpaceUtils.kt
@@ -1,0 +1,179 @@
+package app.lawnchair.util
+
+import android.content.Context
+import android.widget.Toast
+import android.os.UserHandle
+import android.os.UserManager
+import app.lawnchair.LawnchairApp
+import app.lawnchair.preferences2.PreferenceManager2
+import com.android.launcher3.model.data.CollectionInfo
+import com.android.launcher3.model.data.ItemInfo
+import com.android.launcher3.model.data.ItemInfoWithIcon
+import com.android.launcher3.pm.UserCache
+import com.android.launcher3.util.ApiWrapper
+import com.android.launcher3.util.Executors
+import com.android.launcher3.util.PrivateProfileTracker
+import com.android.launcher3.R
+import com.android.launcher3.logging.FileLog
+import com.patrykmichalik.opto.core.firstBlocking
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Lawnchair's policy for private space apps that live outside the all apps container.
+ *
+ * AOSP forbids pinning them outright; Lawnchair makes it a user choice, so these helpers are
+ * consulted anywhere the stock behaviour would have been unconditional.
+ */
+object PrivateSpaceUtils {
+
+    private const val TAG = "PrivateSpaceUtils"
+
+    /**
+     * These checks run per item while loading, and per icon while drawing, so a failure repeats for
+     * as long as its cause lasts. Toasting each time would bury the device in notices and drown out
+     * the very problem being reported, so the user is told once and every occurrence is logged.
+     */
+    private val warnedAboutFallback = AtomicBoolean(false)
+
+    private fun onCheckFailed(context: Context, what: String, t: Throwable) {
+        FileLog.e(TAG, "Private space check failed ($what), using a safe default: $t")
+        if (warnedAboutFallback.compareAndSet(false, true)) {
+            val appContext = context.applicationContext
+            Executors.MAIN_EXECUTOR.execute {
+                Toast.makeText(
+                    appContext,
+                    R.string.private_space_check_failed,
+                    Toast.LENGTH_LONG,
+                ).show()
+            }
+        }
+    }
+
+    /** Whether the user has opted in to pinning private space apps to the home screen. */
+    @JvmStatic
+    fun isPinningAllowed(context: Context): Boolean = try {
+        PreferenceManager2.getInstance(context).allowPinningPrivateSpaceApps.firstBlocking()
+    } catch (t: Throwable) {
+        // Fall back to the stock behaviour rather than letting a preference read take down a
+        // caller; several of these run per item while loading or drawing the workspace.
+        onCheckFailed(context, "pinning preference", t)
+        false
+    }
+
+    /** For call sites deep in model code that have no context to hand. */
+    @JvmStatic
+    fun isPinningAllowed(): Boolean = isPinningAllowed(LawnchairApp.instance)
+
+    /** Whether a private profile exists and is currently locked. */
+    @JvmStatic
+    fun isPrivateSpaceLocked(context: Context): Boolean {
+        val userCache = UserCache.getInstance(context)
+        val user =
+            userCache.userProfiles.firstOrNull { userCache.getUserInfo(it).isPrivate }
+                ?: return PrivateProfileTracker.getKnownPrivateProfileSerial(context) !=
+                    PrivateProfileTracker.INVALID_SERIAL
+        return try {
+            context.getSystemService(UserManager::class.java)?.isQuietModeEnabled(user) ?: false
+        } catch (t: Throwable) {
+            true
+        }
+    }
+
+    /**
+     * Whether no view should be created for [info] on the workspace at all.
+     *
+     * Skipping the view - rather than making it invisible - is what leaves the cell genuinely empty:
+     * an invisible child still occupies its cell and silently refuses drops, which would reveal how
+     * many private apps are pinned and where. The database row is untouched, and the item is placed
+     * again, relocating if its cell has since been taken, when the space is unlocked.
+     */
+    @JvmStatic
+    fun shouldSkipWorkspaceBinding(context: Context, info: ItemInfo?): Boolean =
+        isHiddenWhileLocked(context, info)
+
+    /**
+     * Whether [info] must not be surfaced anywhere at all right now.
+     *
+     * Hiding an app is only as good as its least careful presentation: the workspace, the taskbar,
+     * a folder preview and the search results each reach the model independently, and any one of
+     * them showing the icon undoes the rest.
+     */
+    @JvmStatic
+    fun isHiddenWhileLocked(context: Context, info: ItemInfo?): Boolean {
+        // Hiding items inside a container creates states the container was never built for: a
+        // folder is meant to hold at least two apps, and Launcher3 collapses one that does not.
+        // Filtering contents instead produced single-app folders, gaps inside open folders, and
+        // normal apps vanishing when an unrelated one moved out - each needing its own patch. So a
+        // container is hidden whole if any of its contents is hidden. It is either entirely itself
+        // or absent, and no state appears that the launcher could not have produced on its own.
+        if (info is CollectionInfo) {
+            return info.getContents().any { isHiddenWhileLocked(context, it) }
+        }
+        return isLockedPrivateSpaceItem(context, info)
+    }
+
+    /**
+     * Whether the private profile badge should be stripped from [info]'s icon.
+     *
+     * Checks the profile type before the preference: this runs for every icon that is drawn, and a
+     * [UserCache] map lookup is far cheaper than reading a preference.
+     */
+    @JvmStatic
+    fun shouldHideBadge(context: Context, info: ItemInfo?): Boolean {
+        if (!isPrivateSpaceItem(context, info)) return false
+        return try {
+            PreferenceManager2.getInstance(context).hidePrivateSpaceAppBadge.firstBlocking()
+        } catch (t: Throwable) {
+            // Runs for every icon drawn; keeping the badge is harmless, crashing is not.
+            onCheckFailed(context, "badge preference", t)
+            false
+        }
+    }
+
+    /**
+     * Asks the system to unlock the private space.
+     *
+     * Mirrors the all apps lock pill: the call is only permitted for the current home app, so a
+     * [SecurityException] means Lawnchair is not the default launcher and the user is prompted to
+     * make it one rather than being left with an icon that silently does nothing.
+     */
+    @JvmStatic
+    fun requestUnlock(context: Context, user: UserHandle) {
+        Executors.UI_HELPER_EXECUTOR.post {
+            try {
+                context.getSystemService(UserManager::class.java)
+                    ?.requestQuietModeEnabled(false, user)
+            } catch (e: SecurityException) {
+                Executors.MAIN_EXECUTOR.execute {
+                    ApiWrapper.INSTANCE.get(context).assignDefaultHomeRole(context)
+                }
+            }
+        }
+    }
+
+    /** Whether [info] belongs to the private profile. */
+    @JvmStatic
+    fun isPrivateSpaceItem(context: Context, info: ItemInfo?): Boolean {
+        val user = info?.user ?: return false
+        return try {
+            UserCache.getInstance(context).getUserInfo(user).isPrivate
+        } catch (t: Throwable) {
+            onCheckFailed(context, "profile lookup", t)
+            false
+        }
+    }
+
+    /**
+     * Whether [info] is a private space item that cannot currently be launched, i.e. one that should
+     * be rendered as a placeholder rather than a working icon.
+     */
+    @JvmStatic
+    fun isLockedPrivateSpaceItem(context: Context, info: ItemInfo?): Boolean {
+        // Cheap bitmask test first: this runs for every workspace icon that is bound or updated,
+        // and the overwhelming majority are not disabled at all.
+        val flags = (info as? ItemInfoWithIcon)?.runtimeStatusFlags ?: return false
+        if (flags and ItemInfoWithIcon.FLAG_DISABLED_QUIET_USER == 0) return false
+        return isPrivateSpaceItem(context, info)
+    }
+
+}

--- a/quickstep/src/com/android/launcher3/taskbar/TaskbarModelCallbacks.java
+++ b/quickstep/src/com/android/launcher3/taskbar/TaskbarModelCallbacks.java
@@ -40,6 +40,8 @@ import com.android.launcher3.util.Preconditions;
 import com.android.quickstep.LauncherActivityInterface;
 import com.android.quickstep.RecentsModel;
 
+import app.lawnchair.util.PrivateSpaceUtils;
+
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -148,6 +150,13 @@ public class TaskbarModelCallbacks implements
         boolean modified = false;
         for (ItemInfo item : items) {
             if (item.container == Favorites.CONTAINER_HOTSEAT) {
+                // The taskbar mirrors the hotseat through its own model callbacks, so it does not
+                // go through Launcher's binding and would happily show a private space app that the
+                // home screen is hiding. The dock is visible over other apps, which makes this the
+                // most exposed place such an icon could appear.
+                if (PrivateSpaceUtils.shouldSkipWorkspaceBinding(mContext, item)) {
+                    continue;
+                }
                 mHotseatItems.put(item.screenId, item);
                 modified = true;
             }

--- a/src/com/android/launcher3/Launcher.java
+++ b/src/com/android/launcher3/Launcher.java
@@ -288,6 +288,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import app.lawnchair.LawnchairApp;
+import app.lawnchair.util.PrivateSpaceUtils;
 
 /**
  * Default launcher application.
@@ -2354,6 +2355,14 @@ public class Launcher extends StatefulActivity<LauncherState>
         int index = 0;
         for (Pair<ItemInfo, View> e : shortcuts) {
             final ItemInfo item = e.first;
+
+            // A pinned private space app whose space is locked gets no view, leaving its cell
+            // genuinely empty rather than invisibly occupied. Filtered here rather than in
+            // bindItems because model-side inflation calls this method directly, and that is the
+            // path actually taken while enableWorkspaceInflation is on.
+            if (PrivateSpaceUtils.shouldSkipWorkspaceBinding(this, item)) {
+                continue;
+            }
 
             // Remove colliding items.
             CellPos presenterPos = getCellPosMapper().mapModelToPresenter(item);

--- a/src/com/android/launcher3/LauncherModel.java
+++ b/src/com/android/launcher3/LauncherModel.java
@@ -77,6 +77,9 @@ import com.android.launcher3.util.ItemInfoMatcher;
 import com.android.launcher3.util.PackageManagerHelper;
 import com.android.launcher3.util.PackageUserKey;
 import com.android.launcher3.util.Preconditions;
+import com.android.launcher3.util.PrivateProfileTracker;
+
+import app.lawnchair.util.PrivateSpaceUtils;
 
 import java.io.FileDescriptor;
 import java.io.PrintWriter;
@@ -285,6 +288,12 @@ public class LauncherModel implements InstallSessionTracker.Callback {
                     user, UserCache.ACTION_PROFILE_UNLOCKED.equals(action)));
         } else if (UserCache.ACTION_PROFILE_ADDED.equals(action)
                 || UserCache.ACTION_PROFILE_REMOVED.equals(action)) {
+            if (UserCache.ACTION_PROFILE_REMOVED.equals(action)) {
+                // Removal is the only signal that reliably distinguishes a deleted private space
+                // from one that is merely hidden from us. Forget it before reloading, so that the
+                // loader is free to clean up the items it left behind.
+                PrivateProfileTracker.onProfileRemoved(mApp.getContext(), user);
+            }
             forceReload();
         } else if (ACTION_PROFILE_AVAILABLE.equals(action)
                 || ACTION_PROFILE_UNAVAILABLE.equals(action)) {
@@ -295,8 +304,15 @@ public class LauncherModel implements InstallSessionTracker.Callback {
              * ACTION_MANAGED_PROFILE_AVAILABLE/UNAVAILABLE.
              * So effectively, this if block only handles the non-work profile case.
              */
-            enqueueModelUpdateTask(new PackageUpdatedTask(
-                    PackageUpdatedTask.OP_USER_AVAILABILITY_CHANGE, user));
+            if (UserCache.INSTANCE.get(mApp.getContext()).getUserInfo(user).isPrivate()) {
+                // Hidden private items have no views at all, so locking and unlocking has to add
+                // and remove them - a flag update over existing views cannot do that. It is also
+                // what runs the placement pass that relocates any icon whose cell was taken.
+                forceReload();
+            } else {
+                enqueueModelUpdateTask(new PackageUpdatedTask(
+                        PackageUpdatedTask.OP_USER_AVAILABILITY_CHANGE, user));
+            }
         }
         if (Intent.ACTION_MANAGED_PROFILE_REMOVED.equals(action)) {
             LauncherPrefs.get(mApp.getContext()).put(WORK_EDU_STEP, 0);

--- a/src/com/android/launcher3/Utilities.java
+++ b/src/com/android/launcher3/Utilities.java
@@ -115,6 +115,7 @@ import java.util.regex.Pattern;
 
 import app.lawnchair.icons.ExtendedBitmapDrawable;
 import app.lawnchair.preferences.PreferenceManager;
+import app.lawnchair.util.PrivateSpaceUtils;
 
 /**
  * Various utilities shared amongst the Launcher's classes.
@@ -722,8 +723,13 @@ public final class Utilities {
         LauncherAppState appState = LauncherAppState.getInstance(context);
         Drawable mainIcon = null;
 
+        // Drag previews and the launch animation build their badge here instead of going through
+        // ItemInfoWithIcon#newIcon, so the preference has to be honoured again on this path or the
+        // badge would reappear mid-drag on an icon that shows none at rest.
+        boolean hideUserBadge = PrivateSpaceUtils.shouldHideBadge(context, info);
+
         Drawable badge = null;
-        if ((info instanceof ItemInfoWithIcon iiwi) && !iiwi.usingLowResIcon()) {
+        if (!hideUserBadge && (info instanceof ItemInfoWithIcon iiwi) && !iiwi.usingLowResIcon()) {
             badge = iiwi.bitmap.getBadgeDrawable(context, useTheme);
         }
 
@@ -818,11 +824,13 @@ public final class Utilities {
         }
 
         if (badge == null) {
-            badge = BitmapInfo.LOW_RES_INFO.withFlags(
-                    UserCache.INSTANCE.get(context)
-                            .getUserInfo(info.user)
-                            .applyBitmapInfoFlags(FlagOp.NO_OP))
-                    .getBadgeDrawable(context, useTheme);
+            if (!hideUserBadge) {
+                badge = BitmapInfo.LOW_RES_INFO.withFlags(
+                        UserCache.INSTANCE.get(context)
+                                .getUserInfo(info.user)
+                                .applyBitmapInfoFlags(FlagOp.NO_OP))
+                        .getBadgeDrawable(context, useTheme);
+            }
             if (badge == null) {
                 badge = new ColorDrawable(Color.TRANSPARENT);
             }

--- a/src/com/android/launcher3/allapps/search/DefaultAppSearchAlgorithm.java
+++ b/src/com/android/launcher3/allapps/search/DefaultAppSearchAlgorithm.java
@@ -26,6 +26,8 @@ import androidx.annotation.AnyThread;
 import com.android.launcher3.LauncherAppState;
 import com.android.launcher3.allapps.BaseAllAppsAdapter.AdapterItem;
 import com.android.launcher3.model.data.AppInfo;
+
+import app.lawnchair.util.PrivateSpaceUtils;
 import com.android.launcher3.search.SearchAlgorithm;
 import com.android.launcher3.search.SearchCallback;
 import com.android.launcher3.search.StringMatcherUtility;
@@ -41,6 +43,7 @@ public class DefaultAppSearchAlgorithm implements SearchAlgorithm<AdapterItem> {
     protected static final int MAX_RESULTS_COUNT = 5;
 
     private final LauncherAppState mAppState;
+    private final Context mContext;
     private final Handler mResultHandler;
     private final boolean mAddNoResultsMessage;
 
@@ -50,6 +53,7 @@ public class DefaultAppSearchAlgorithm implements SearchAlgorithm<AdapterItem> {
 
     public DefaultAppSearchAlgorithm(Context context, boolean addNoResultsMessage) {
         mAppState = LauncherAppState.getInstance(context);
+        mContext = context;
         mResultHandler = new Handler(MAIN_EXECUTOR.getLooper());
         mAddNoResultsMessage = addNoResultsMessage;
     }
@@ -64,7 +68,7 @@ public class DefaultAppSearchAlgorithm implements SearchAlgorithm<AdapterItem> {
     @Override
     public void doSearch(String query, SearchCallback<AdapterItem> callback) {
         mAppState.getModel().enqueueModelUpdateTask((taskController, dataModel, apps) ->  {
-            ArrayList<AdapterItem> result = getTitleMatchResult(apps.data, query);
+            ArrayList<AdapterItem> result = getTitleMatchResult(mContext, apps.data, query);
             if (mAddNoResultsMessage && result.isEmpty()) {
                 result.add(getEmptyMessageAdapterItem(query));
             }
@@ -85,7 +89,8 @@ public class DefaultAppSearchAlgorithm implements SearchAlgorithm<AdapterItem> {
      * Filters {@link AppInfo}s matching specified query
      */
     @AnyThread
-    private static ArrayList<AdapterItem> getTitleMatchResult(List<AppInfo> apps, String query) {
+    private static ArrayList<AdapterItem> getTitleMatchResult(
+            Context context, List<AppInfo> apps, String query) {
         // Do an intersection of the words in the query and each title, and filter out
         // all the
         // apps that don't match all of the words in the query.
@@ -97,6 +102,11 @@ public class DefaultAppSearchAlgorithm implements SearchAlgorithm<AdapterItem> {
         int total = apps.size();
         for (int i = 0; i < total && resultCount < MAX_RESULTS_COUNT; i++) {
             AppInfo info = apps.get(i);
+            // Private space apps stay loaded in the all apps list across a lock, so without this
+            // a locked space remains fully enumerable by typing an app's name.
+            if (PrivateSpaceUtils.isHiddenWhileLocked(context, info)) {
+                continue;
+            }
             if (StringMatcherUtility.matches(queryTextLower, info.title.toString(), matcher)) {
                 result.add(AdapterItem.asApp(info));
                 resultCount++;

--- a/src/com/android/launcher3/model/AddWorkspaceItemsTask.java
+++ b/src/com/android/launcher3/model/AddWorkspaceItemsTask.java
@@ -44,6 +44,8 @@ import com.android.launcher3.pm.PackageInstallInfo;
 import com.android.launcher3.util.IntArray;
 import com.android.launcher3.util.PackageManagerHelper;
 
+import app.lawnchair.util.PrivateSpaceUtils;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -95,6 +97,14 @@ public class AddWorkspaceItemsTask implements ModelUpdateTask {
             List<ItemInfo> filteredItems = new ArrayList<>();
             for (Pair<ItemInfo, Object> entry : mItemList) {
                 ItemInfo item = entry.first;
+                // Installing an app into the private space must not put it on the home screen
+                // against the user's wishes. This path never consults FLAG_NOT_PINNABLE, so
+                // without this the auto-add would overrule the preference and leave behind an
+                // icon that cannot be dragged - and therefore cannot be dragged off either.
+                if (PrivateSpaceUtils.isPrivateSpaceItem(context, item)
+                        && !PrivateSpaceUtils.isPinningAllowed(context)) {
+                    continue;
+                }
                 if (item.itemType == LauncherSettings.Favorites.ITEM_TYPE_APPLICATION) {
                     // Short-circuit this logic if the icon exists somewhere on the workspace
                     if (shortcutExists(dataModel, item.getIntent(), item.user)) {

--- a/src/com/android/launcher3/model/FirstScreenBroadcast.java
+++ b/src/com/android/launcher3/model/FirstScreenBroadcast.java
@@ -29,6 +29,7 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageInstaller.SessionInfo;
+import android.os.Process;
 import android.os.UserHandle;
 import android.util.Log;
 
@@ -162,6 +163,12 @@ public class FirstScreenBroadcast {
     }
 
     private static String getPackageName(ItemInfo info) {
+        // Only ever report the current user's items. A pinned private space app would otherwise
+        // disclose its package name - and therefore its presence - to that app's installer, which
+        // is exactly what the private space is meant to prevent. The same applies to work items.
+        if (!Process.myUserHandle().equals(info.user)) {
+            return null;
+        }
         String packageName = null;
         if (info instanceof LauncherAppWidgetInfo) {
             LauncherAppWidgetInfo widgetInfo = (LauncherAppWidgetInfo) info;

--- a/src/com/android/launcher3/model/FirstScreenBroadcastHelper.kt
+++ b/src/com/android/launcher3/model/FirstScreenBroadcastHelper.kt
@@ -362,6 +362,10 @@ object FirstScreenBroadcastHelper {
     }
 
     private fun getPackageName(info: ItemInfo): String? {
+        // Only ever report the current user's items. This path resolves an installer for every
+        // first-screen item, so without the check a pinned private space app would disclose its
+        // package name - and therefore its presence - to that app's installer.
+        if (Process.myUserHandle() != info.user) return null
         var packageName: String? = null
         if (info is LauncherAppWidgetInfo) {
             info.providerName?.let { packageName = info.providerName.packageName }

--- a/src/com/android/launcher3/model/GridSizeMigrationUtil.java
+++ b/src/com/android/launcher3/model/GridSizeMigrationUtil.java
@@ -25,8 +25,11 @@ import android.content.ComponentName;
 import android.content.ContentValues;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.LauncherActivityInfo;
+import android.content.pm.LauncherApps;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.os.UserHandle;
 import android.database.Cursor;
 import android.database.DatabaseUtils;
 import android.database.sqlite.SQLiteDatabase;
@@ -44,10 +47,12 @@ import com.android.launcher3.Utilities;
 import com.android.launcher3.config.FeatureFlags;
 import com.android.launcher3.model.data.ItemInfo;
 import com.android.launcher3.pm.InstallSessionHelper;
+import com.android.launcher3.pm.UserCache;
 import com.android.launcher3.provider.LauncherDbUtils.SQLiteTransaction;
 import com.android.launcher3.util.ContentWriter;
 import com.android.launcher3.util.GridOccupancy;
 import com.android.launcher3.util.IntArray;
+import com.android.launcher3.util.PrivateProfileTracker;
 import com.android.launcher3.widget.LauncherAppWidgetProviderInfo;
 import com.android.launcher3.widget.WidgetManagerHelper;
 
@@ -303,10 +308,30 @@ public class GridSizeMigrationUtil {
         // cause
         // any extra data loss and gives us more free space on the grid for better
         // migration.
+        //
+        // That justification does not hold for other profiles, and both work and private
+        // space were affected. The set below was built from the calling user alone, so an
+        // app installed only in another profile was never in it and its row was dropped on
+        // every grid change. For private space the loader no longer removes those items
+        // either, which left this the one remaining path that deleted them silently.
         HashSet<String> validPackages = new HashSet<>();
         for (PackageInfo info : context.getPackageManager()
                 .getInstalledPackages(PackageManager.GET_UNINSTALLED_PACKAGES)) {
             validPackages.add(info.packageName);
+        }
+        // Collect the other profiles the calling user cannot see, so that work and private
+        // space apps are recognised as valid.
+        LauncherApps launcherApps = context.getSystemService(LauncherApps.class);
+        if (launcherApps != null) {
+            for (UserHandle user : UserCache.INSTANCE.get(context).getUserProfiles()) {
+                try {
+                    for (LauncherActivityInfo lai : launcherApps.getActivityList(null, user)) {
+                        validPackages.add(lai.getComponentName().getPackageName());
+                    }
+                } catch (Throwable t) {
+                    Log.w(TAG, "Unable to list packages for user " + user, t);
+                }
+            }
         }
         InstallSessionHelper.INSTANCE.get(context)
                 .getActiveSessions().keySet()
@@ -478,7 +503,8 @@ public class GridSizeMigrationUtil {
                             LauncherSettings.Favorites._ID, // 0
                             LauncherSettings.Favorites.ITEM_TYPE, // 1
                             LauncherSettings.Favorites.INTENT, // 2
-                            LauncherSettings.Favorites.SCREEN }, // 3
+                            LauncherSettings.Favorites.SCREEN, // 3
+                            LauncherSettings.Favorites.PROFILE_ID }, // 4
                     LauncherSettings.Favorites.CONTAINER + " = "
                             + LauncherSettings.Favorites.CONTAINER_HOTSEAT);
 
@@ -486,6 +512,8 @@ public class GridSizeMigrationUtil {
             final int indexItemType = c.getColumnIndexOrThrow(LauncherSettings.Favorites.ITEM_TYPE);
             final int indexIntent = c.getColumnIndexOrThrow(LauncherSettings.Favorites.INTENT);
             final int indexScreen = c.getColumnIndexOrThrow(LauncherSettings.Favorites.SCREEN);
+            final int indexHotseatProfileId = c.getColumnIndexOrThrow(
+                    LauncherSettings.Favorites.PROFILE_ID);
 
             IntArray entriesToRemove = new IntArray();
             while (c.moveToNext()) {
@@ -500,7 +528,7 @@ public class GridSizeMigrationUtil {
                         case LauncherSettings.Favorites.ITEM_TYPE_DEEP_SHORTCUT:
                         case LauncherSettings.Favorites.ITEM_TYPE_APPLICATION: {
                             entry.mIntent = c.getString(indexIntent);
-                            verifyIntent(c.getString(indexIntent));
+                            verifyIntent(c.getString(indexIntent), c.getLong(indexHotseatProfileId));
                             break;
                         }
                         case LauncherSettings.Favorites.ITEM_TYPE_FOLDER: {
@@ -547,7 +575,8 @@ public class GridSizeMigrationUtil {
                             LauncherSettings.Favorites.SPANY, // 6
                             LauncherSettings.Favorites.INTENT, // 7
                             LauncherSettings.Favorites.APPWIDGET_PROVIDER, // 8
-                            LauncherSettings.Favorites.APPWIDGET_ID }, // 9
+                            LauncherSettings.Favorites.APPWIDGET_ID, // 9
+                            LauncherSettings.Favorites.PROFILE_ID }, // 10
                     LauncherSettings.Favorites.CONTAINER + " = "
                             + LauncherSettings.Favorites.CONTAINER_DESKTOP);
             final int indexId = c.getColumnIndexOrThrow(LauncherSettings.Favorites._ID);
@@ -562,6 +591,8 @@ public class GridSizeMigrationUtil {
                     LauncherSettings.Favorites.APPWIDGET_PROVIDER);
             final int indexAppWidgetId = c.getColumnIndexOrThrow(
                     LauncherSettings.Favorites.APPWIDGET_ID);
+            final int indexProfileId = c.getColumnIndexOrThrow(
+                    LauncherSettings.Favorites.PROFILE_ID);
 
             IntArray entriesToRemove = new IntArray();
             WidgetManagerHelper widgetManagerHelper = new WidgetManagerHelper(mContext);
@@ -582,13 +613,13 @@ public class GridSizeMigrationUtil {
                         case LauncherSettings.Favorites.ITEM_TYPE_DEEP_SHORTCUT:
                         case LauncherSettings.Favorites.ITEM_TYPE_APPLICATION: {
                             entry.mIntent = c.getString(indexIntent);
-                            verifyIntent(entry.mIntent);
+                            verifyIntent(entry.mIntent, c.getLong(indexProfileId));
                             break;
                         }
                         case LauncherSettings.Favorites.ITEM_TYPE_APPWIDGET: {
                             entry.mProvider = c.getString(indexAppWidgetProvider);
                             ComponentName cn = ComponentName.unflattenFromString(entry.mProvider);
-                            verifyPackage(cn.getPackageName());
+                            verifyPackage(cn.getPackageName(), c.getLong(indexProfileId));
 
                             int widgetId = c.getInt(indexAppWidgetId);
                             LauncherAppWidgetProviderInfo pInfo = widgetManagerHelper
@@ -644,7 +675,9 @@ public class GridSizeMigrationUtil {
 
         private int getFolderItemsCount(DbEntry entry) {
             Cursor c = queryWorkspace(
-                    new String[] { LauncherSettings.Favorites._ID, LauncherSettings.Favorites.INTENT },
+                    new String[] { LauncherSettings.Favorites._ID,
+                            LauncherSettings.Favorites.INTENT,
+                            LauncherSettings.Favorites.PROFILE_ID },
                     LauncherSettings.Favorites.CONTAINER + " = " + entry.id);
 
             int total = 0;
@@ -652,7 +685,7 @@ public class GridSizeMigrationUtil {
                 try {
                     int id = c.getInt(0);
                     String intent = c.getString(1);
-                    verifyIntent(intent);
+                    verifyIntent(intent, c.getLong(2));
                     total++;
                     if (!entry.mFolderItems.containsKey(intent)) {
                         entry.mFolderItems.put(intent, new HashSet<>());
@@ -671,21 +704,28 @@ public class GridSizeMigrationUtil {
         }
 
         /** Verifies if the mIntent should be restored. */
-        private void verifyIntent(String intentStr)
+        private void verifyIntent(String intentStr, long profileId)
                 throws Exception {
             Intent intent = Intent.parseUri(intentStr, 0);
             if (intent.getComponent() != null) {
-                verifyPackage(intent.getComponent().getPackageName());
+                verifyPackage(intent.getComponent().getPackageName(), profileId);
             } else if (intent.getPackage() != null) {
                 // Only verify package if the component was null.
-                verifyPackage(intent.getPackage());
+                verifyPackage(intent.getPackage(), profileId);
             }
         }
 
         /** Verifies if the package should be restored */
-        private void verifyPackage(String packageName)
+        private void verifyPackage(String packageName, long profileId)
                 throws Exception {
             if (!mValidPackages.contains(packageName)) {
+                // A locked or otherwise hidden private profile cannot be enumerated at all, so its
+                // packages are never in the valid set and every row would be dropped here. Dropping
+                // is only an optimisation to free grid space - the loader is the authority on what
+                // is really gone - so leave these rows for it to judge once the profile is back.
+                if (PrivateProfileTracker.isInaccessiblePrivateProfile(mContext, profileId)) {
+                    return;
+                }
                 // TODO(b/151468819): Handle promise app icon restoration during grid migration.
                 throw new Exception("Package not available");
             }

--- a/src/com/android/launcher3/model/LoaderCursor.java
+++ b/src/com/android/launcher3/model/LoaderCursor.java
@@ -64,6 +64,8 @@ import com.android.launcher3.util.UserIconInfo;
 
 import java.net.URISyntaxException;
 import java.security.InvalidParameterException;
+import java.util.ArrayList;
+import java.util.List;
 
 import app.lawnchair.LawnchairApp;
 import app.lawnchair.preferences2.PreferenceManager2;
@@ -86,6 +88,7 @@ public class LoaderCursor extends CursorWrapper {
 
     private final IntArray mItemsToRemove = new IntArray();
     private final IntArray mRestoredRows = new IntArray();
+    private final ArrayList<ItemInfo> mDeferredPlacements = new ArrayList<>();
     private final IntSparseArrayMap<GridOccupancy> mOccupied = new IntSparseArrayMap<>();
 
     private final int mIconIndex;
@@ -493,6 +496,29 @@ public class LoaderCursor extends CursorWrapper {
 
     public void checkAndAddItem(ItemInfo info, BgDataModel dataModel) {
         checkAndAddItem(info, dataModel, null);
+    }
+
+    /**
+     * Adds the item to the model without claiming its cell. See {@link PrivateSpacePlacement},
+     * which owns the reasoning and places these items once the cursor pass is done.
+     */
+    public void addItemDeferringPlacement(
+            ItemInfo info, BgDataModel dataModel, LoaderMemoryLogger logger) {
+        if (info.itemType == Favorites.ITEM_TYPE_DEEP_SHORTCUT) {
+            // Same guard as checkAndAddItem: an invalid intent must throw here so the item is
+            // skipped, rather than reaching the model and failing somewhere less recoverable.
+            ShortcutKey.fromItemInfo(info);
+        }
+        mDeferredPlacements.add(info);
+        dataModel.addItem(mContext, info, false, logger);
+        if (mRestoreEventLogger != null) {
+            mRestoreEventLogger.logSingleFavoritesItemRestored(itemType);
+        }
+    }
+
+    /** Items added via {@link #addItemDeferringPlacement}, in the order they were read. */
+    public List<ItemInfo> getDeferredPlacements() {
+        return mDeferredPlacements;
     }
 
     /**

--- a/src/com/android/launcher3/model/LoaderTask.java
+++ b/src/com/android/launcher3/model/LoaderTask.java
@@ -45,6 +45,7 @@ import android.content.pm.PackageInstaller.SessionInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.ShortcutInfo;
 import android.os.Bundle;
+import android.os.Process;
 import android.os.Trace;
 import android.os.UserHandle;
 import android.os.UserManager;
@@ -495,6 +496,9 @@ public class LoaderTask implements Runnable {
                 return;
             }
 
+            // Place the items whose cells were deliberately left unclaimed during the pass above.
+            PrivateSpacePlacement.placeDeferredItems(mApp, mBgDataModel, c);
+
             // Remove dead items
             mItemsDeleted = c.commitDeleted();
 
@@ -536,7 +540,7 @@ public class LoaderTask implements Runnable {
     @WorkerThread
     private void queryPinnedShortcutsForUnlockedUsers(Context context,
             LongSparseArray<Boolean> unlockedUsers) {
-        mUserManagerState.init(mUserCache, mUserManager);
+        mUserManagerState.init(mUserCache, mUserManager, context);
 
         for (UserHandle user : mUserCache.getUserProfiles()) {
             long serialNo = mUserCache.getSerialNumberForUser(user);
@@ -566,6 +570,7 @@ public class LoaderTask implements Runnable {
             unlockedUsers.put(serialNo, userUnlocked);
         }
 
+        PrivateSpacePlacement.markUnreachableUsersLocked(mUserManagerState, unlockedUsers);
     }
 
     /**
@@ -712,19 +717,30 @@ public class LoaderTask implements Runnable {
         for (UserHandle user : profiles) {
             // Query for the set of apps
             final List<LauncherActivityInfo> apps = mLauncherApps.getActivityList(null, user);
-            // Fail if we don't have any apps
-            // TODO: Fix this. Only fail for the current user.
-            if (apps == null || apps.isEmpty()) {
-                return allActivityList;
-            }
             boolean quietMode = mUserManagerState.isUserQuiet(user);
 
+            // Record the profile's quiet state before any early exit below. A locked private space
+            // reports no apps at all, and skipping this is what leaves the all apps container
+            // believing the space is unlocked after a cold start.
             if (Flags.enablePrivateSpace()) {
                 if (mUserCache.getUserInfo(user).isWork()) {
                     isWorkProfileQuiet = quietMode;
                 } else if (mUserCache.getUserInfo(user).isPrivate()) {
                     isPrivateProfileQuiet = quietMode;
                 }
+            }
+
+            if (apps == null || apps.isEmpty()) {
+                if (Process.myUserHandle().equals(user)) {
+                    // The current user always has apps. An empty list means the system is not ready
+                    // yet, and committing it would leave the drawer empty until the next reload.
+                    FileLog.d(TAG, "loadAllApps: no apps for the current user, aborting load");
+                    return allActivityList;
+                }
+                // Any other profile may legitimately expose nothing - a locked private space does.
+                // Skip it rather than abandoning the remaining profiles and the flags set below.
+                FileLog.d(TAG, "loadAllApps: no apps for profile " + user + ", skipping it");
+                continue;
             }
             // Create the ApplicationInfos
             for (int i = 0; i < apps.size(); i++) {

--- a/src/com/android/launcher3/model/PackageUpdatedTask.java
+++ b/src/com/android/launcher3/model/PackageUpdatedTask.java
@@ -207,7 +207,7 @@ public class PackageUpdatedTask implements ModelUpdateTask {
             case OP_USER_AVAILABILITY_CHANGE: {
                 UserManagerState ums = new UserManagerState();
                 UserManager userManager = context.getSystemService(UserManager.class);
-                ums.init(UserCache.INSTANCE.get(context), userManager);
+                ums.init(UserCache.INSTANCE.get(context), userManager, context);
                 boolean isUserQuiet =  ums.isUserQuiet(mUser);
                 flagOp = FlagOp.NO_OP.setFlag(
                         WorkspaceItemInfo.FLAG_DISABLED_QUIET_USER, isUserQuiet);

--- a/src/com/android/launcher3/model/PrivateSpacePlacement.kt
+++ b/src/com/android/launcher3/model/PrivateSpacePlacement.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android.launcher3.model
+
+import android.content.ContentValues
+import android.provider.BaseColumns
+import android.util.LongSparseArray
+import android.widget.Toast
+import app.lawnchair.util.PrivateSpaceUtils
+import com.android.launcher3.LauncherAppState
+import com.android.launcher3.LauncherSettings.Favorites
+import com.android.launcher3.R
+import com.android.launcher3.logging.FileLog
+import com.android.launcher3.model.data.ItemInfo
+import com.android.launcher3.util.Executors.MAIN_EXECUTOR
+import com.android.launcher3.util.IntArray as LauncherIntArray
+
+/**
+ * Workspace placement for private space items, kept out of [LoaderTask] so that the loader carries
+ * only the call sites.
+ *
+ * While the private space is locked its pinned icons are not shown, so their cells look empty and
+ * the user may drop something onto one. Two rows then name the same cell, and the loader's ordinary
+ * overlap handling would delete whichever it reached second - by cursor order, that is usually the
+ * item the user just placed. So private items claim no cell during the cursor pass; they are placed
+ * here afterwards, once every visible item has settled, and relocated rather than deleted when their
+ * cell has gone.
+ */
+object PrivateSpacePlacement {
+
+    private const val TAG = "PrivateSpacePlacement"
+
+    /**
+     * Gives a final position to items that were read without claiming a cell.
+     *
+     * An item keeps its stored cell whenever that cell is still free; otherwise it moves to the
+     * first free one and the move is written back so it survives the next load. Deleting instead
+     * would be unrecoverable, as the app cannot be re-pinned until the space is unlocked.
+     */
+    @JvmStatic
+    fun placeDeferredItems(app: LauncherAppState, dataModel: BgDataModel, c: LoaderCursor) {
+        val deferred = c.deferredPlacements
+        if (deferred.isEmpty()) return
+
+        val firstPagePinned = dataModel.isFirstPagePinnedItemEnabled
+        val screens = dataModel.collectWorkspaceScreens()
+        val addedScreens = LauncherIntArray()
+        val spaceFinder = WorkspaceItemSpaceFinder()
+        val relocated = mutableListOf<CharSequence>()
+
+        for (info in deferred) {
+            // The whole body is guarded: this runs per item during the workspace load, and letting
+            // anything escape would abort the load rather than lose a single icon.
+            try {
+                if (c.checkItemPlacement(info, firstPagePinned)) continue
+                val coords = spaceFinder.findSpaceForItem(
+                    app, dataModel, screens, addedScreens, info.spanX, info.spanY,
+                )
+                FileLog.d(
+                    TAG,
+                    "relocating id=${info.id}" +
+                        " from (${info.screenId}:${info.cellX},${info.cellY})" +
+                        " to (${coords[0]}:${coords[1]},${coords[2]})",
+                )
+                info.container = Favorites.CONTAINER_DESKTOP
+                info.screenId = coords[0]
+                info.cellX = coords[1]
+                info.cellY = coords[2]
+                c.checkItemPlacement(info, firstPagePinned)
+                persistPosition(app, info)
+
+                // Only name an item the user can actually see. While the space is locked this icon
+                // is not on the workspace at all, and announcing "moved <private app>" would hand
+                // its name to whoever is holding the phone - the exact disclosure that hiding it is
+                // meant to prevent, and one provokable at will by dropping icons on empty cells.
+                val title = info.title
+                if (title != null &&
+                    !PrivateSpaceUtils.isHiddenWhileLocked(app.context, info)
+                ) {
+                    relocated.add(title)
+                }
+            } catch (t: Throwable) {
+                // findSpaceForItem throws when not even a fresh screen fits the item, which is
+                // effectively unreachable for an app icon. The row is left alone and gets another
+                // chance next load; if it stays overlapping and later becomes visible, bind-time
+                // collision handling removes it.
+                FileLog.e(TAG, "could not place id=${info.id}, $t")
+            }
+        }
+        notifyRelocated(app, relocated)
+    }
+
+    private fun persistPosition(app: LauncherAppState, info: ItemInfo) {
+        val values = ContentValues().apply {
+            put(Favorites.CONTAINER, info.container)
+            put(Favorites.SCREEN, info.screenId)
+            put(Favorites.CELLX, info.cellX)
+            put(Favorites.CELLY, info.cellY)
+        }
+        app.model.modelDbController.update(
+            Favorites.TABLE_NAME,
+            values,
+            "${BaseColumns._ID}= ?",
+            arrayOf(info.id.toString()),
+        )
+    }
+
+    /** Tells the user which icons had to move, so a shifted home screen is not a mystery. */
+    private fun notifyRelocated(app: LauncherAppState, relocated: List<CharSequence>) {
+        if (relocated.isEmpty()) return
+        val context = app.context
+        val message = if (relocated.size == 1) {
+            context.getString(R.string.private_space_item_relocated, relocated[0])
+        } else {
+            context.getString(R.string.private_space_items_relocated, relocated.size)
+        }
+        MAIN_EXECUTOR.execute { Toast.makeText(context, message, Toast.LENGTH_LONG).show() }
+    }
+
+    /**
+     * Records every profile the loader knows about but could not query as locked.
+     *
+     * A hidden private profile is absent from [com.android.launcher3.pm.UserCache], so nothing else
+     * fills in its entry, and its pinned deep shortcuts would then read a missing value.
+     */
+    @JvmStatic
+    fun markUnreachableUsersLocked(
+        userManagerState: UserManagerState,
+        unlockedUsers: LongSparseArray<Boolean>,
+    ) {
+        val allUsers = userManagerState.allUsers
+        for (i in allUsers.size() - 1 downTo 0) {
+            val serialNo = allUsers.keyAt(i)
+            if (unlockedUsers.get(serialNo) == null) {
+                unlockedUsers.put(serialNo, false)
+            }
+        }
+    }
+}

--- a/src/com/android/launcher3/model/UserManagerState.java
+++ b/src/com/android/launcher3/model/UserManagerState.java
@@ -15,13 +15,17 @@
  */
 package com.android.launcher3.model;
 
+import android.content.Context;
 import android.os.UserHandle;
 import android.os.UserManager;
 import android.util.Log;
 import android.util.LongSparseArray;
 import android.util.SparseBooleanArray;
 
+import androidx.annotation.Nullable;
+
 import com.android.launcher3.pm.UserCache;
+import com.android.launcher3.util.PrivateProfileTracker;
 
 /**
  * Utility class to manager store and user manager state at any particular time
@@ -39,6 +43,14 @@ public class UserManagerState {
      * Initialises the state values for all users
      */
     public void init(UserCache userCache, UserManager userManager) {
+        init(userCache, userManager, null);
+    }
+
+    /**
+     * @param context when non-null, a hidden private profile is restored into {@link #allUsers}
+     *                from its recorded identity. See {@link PrivateProfileTracker}.
+     */
+    public void init(UserCache userCache, UserManager userManager, @Nullable Context context) {
         for (UserHandle user : userManager.getUserProfiles()) {
             long serialNo = userCache.getSerialNumberForUser(user);
             boolean isUserQuiet = userManager.isQuietModeEnabled(user);
@@ -53,6 +65,23 @@ public class UserManagerState {
             mQuietUsersHashCodeMap.put(user.hashCode(), isUserQuiet);
             mQuietUsersSerialNoMap.put(serialNo, isUserQuiet);
         }
+        if (context != null) {
+            addHiddenPrivateProfile(context);
+        }
+    }
+
+    /** @see PrivateProfileTracker#getHiddenProfileToInject */
+    private void addHiddenPrivateProfile(Context context) {
+        UserHandle user = PrivateProfileTracker.getHiddenProfileToInject(context, allUsers);
+        if (user == null) {
+            return;
+        }
+        long serialNo = PrivateProfileTracker.getKnownPrivateProfileSerial(context);
+        Log.d(TAG, "Private profile is hidden; keeping serialNo=" + serialNo + " resolvable");
+        allUsers.put(serialNo, user);
+        // Necessarily quiet: were it reachable, the loop above would have found it.
+        mQuietUsersHashCodeMap.put(user.hashCode(), true);
+        mQuietUsersSerialNoMap.put(serialNo, true);
     }
 
     /**

--- a/src/com/android/launcher3/model/WorkspaceItemProcessor.kt
+++ b/src/com/android/launcher3/model/WorkspaceItemProcessor.kt
@@ -48,6 +48,7 @@ import com.android.launcher3.util.ApiWrapper
 import com.android.launcher3.util.ComponentKey
 import com.android.launcher3.util.PackageManagerHelper
 import com.android.launcher3.util.PackageUserKey
+import com.android.launcher3.util.PrivateProfileTracker
 import com.android.launcher3.widget.LauncherAppWidgetProviderInfo
 import com.android.launcher3.widget.WidgetInflater
 import com.android.launcher3.widget.util.WidgetSizes
@@ -155,6 +156,12 @@ class WorkspaceItemProcessor(
         }
         var validTarget = launcherApps.isPackageEnabled(targetPkg, c.user)
 
+        // A locked or hidden private profile reports every package as absent, which is
+        // indistinguishable from an uninstall. See PrivateProfileTracker.
+        val isInaccessiblePrivateItem =
+            !validTarget &&
+                PrivateProfileTracker.isInaccessiblePrivateProfile(app.context, c.serialNumber)
+
         // If it's a deep shortcut, we'll use pinned shortcuts to restore it
         if (cn != null && validTarget && (c.itemType != Favorites.ITEM_TYPE_DEEP_SHORTCUT)) {
             // If the apk is present and the shortcut points to a specific component.
@@ -194,6 +201,16 @@ class WorkspaceItemProcessor(
                 // Points to a valid app (superset of cn != null) but the apk
                 // is not available.
                 when {
+                    isInaccessiblePrivateItem -> {
+                        FileLog.d(
+                            TAG,
+                            "Keeping private space item while its profile is unavailable:" +
+                                " id=${c.id}, targetPkg=$targetPkg"
+                        )
+                        // Keep it, disabled, until the space is reachable again.
+                        disabledState = disabledState or WorkspaceItemInfo.FLAG_DISABLED_QUIET_USER
+                        allowMissingTarget = true
+                    }
                     c.restoreFlag != 0 -> {
                         // Package is not yet available but might be
                         // installed later.
@@ -367,7 +384,12 @@ class WorkspaceItemProcessor(
             } catch (t: Throwable) {
                 Log.e(TAG, "Error loading icon", t)
             }
-            c.checkAndAddItem(info, bgDataModel, memoryLogger)
+            if (userCache.getUserInfo(c.user).isPrivate) {
+                // See PrivateSpacePlacement.
+                c.addItemDeferringPlacement(info, bgDataModel, memoryLogger)
+            } else {
+                c.checkAndAddItem(info, bgDataModel, memoryLogger)
+            }
         } else {
             throw RuntimeException("Unexpected null WorkspaceItemInfo")
         }
@@ -413,7 +435,11 @@ class WorkspaceItemProcessor(
         }
 
         c.markRestored()
-        c.checkAndAddItem(collection, bgDataModel, memoryLogger)
+        // Deferred like private items: a collection's contents are not known until the whole cursor
+        // has been read, so whether it is one the user can see cannot be decided here. Placing it
+        // last costs nothing when its cell is free, and turns a contested cell into a relocation
+        // rather than the deletion an overlap would otherwise cause.
+        c.addItemDeferringPlacement(collection, bgDataModel, memoryLogger)
     }
 
     /**

--- a/src/com/android/launcher3/model/data/AppInfo.java
+++ b/src/com/android/launcher3/model/data/AppInfo.java
@@ -40,6 +40,8 @@ import com.android.launcher3.util.ApiWrapper;
 import com.android.launcher3.util.PackageManagerHelper;
 import com.android.launcher3.util.UserIconInfo;
 
+import app.lawnchair.util.PrivateSpaceUtils;
+
 import java.util.Comparator;
 
 /**
@@ -217,7 +219,8 @@ public class AppInfo extends ItemInfoWithIcon implements WorkspaceItemFactory {
                 : FLAG_SYSTEM_YES;
 
         if (Flags.privateSpaceRestrictAccessibilityDrag()) {
-            if (userIconInfo.isPrivate()) {
+            if (userIconInfo.isPrivate()
+                    && !PrivateSpaceUtils.isPinningAllowed()) {
                 info.runtimeStatusFlags |= FLAG_NOT_PINNABLE;
             } else {
                 info.runtimeStatusFlags &= ~FLAG_NOT_PINNABLE;

--- a/src/com/android/launcher3/model/data/ItemInfoWithIcon.java
+++ b/src/com/android/launcher3/model/data/ItemInfoWithIcon.java
@@ -30,6 +30,7 @@ import com.android.launcher3.pm.PackageInstallInfo;
 import com.android.launcher3.util.ApiWrapper;
 
 import app.lawnchair.preferences.PreferenceManager;
+import app.lawnchair.util.PrivateSpaceUtils;
 
 /**
  * Represents an ItemInfo which also holds an icon.
@@ -330,6 +331,12 @@ public abstract class ItemInfoWithIcon extends ItemInfo {
     public FastBitmapDrawable newIcon(Context context, @BitmapInfo.DrawableCreationFlags int creationFlags) {
         FastBitmapDrawable drawable = (creationFlags & BitmapInfo.FLAG_THEMED) != 0 ? bitmap.newThemedIcon(context) : bitmap.newIcon(context, creationFlags);
         drawable.setIsDisabled(isDisabled());
+        if (PrivateSpaceUtils.shouldHideBadge(context, this)) {
+            // Strip the badge after the fact rather than passing FLAG_SKIP_USER_BADGE: the themed
+            // branch above discards creation flags entirely, so the flag would silently do nothing
+            // whenever themed icons are on. Clearing it here covers every path.
+            drawable.setBadge(null);
+        }
         return drawable;
     }
 

--- a/src/com/android/launcher3/model/data/WorkspaceItemInfo.java
+++ b/src/com/android/launcher3/model/data/WorkspaceItemInfo.java
@@ -36,6 +36,8 @@ import com.android.launcher3.shortcuts.ShortcutKey;
 import com.android.launcher3.util.ApiWrapper;
 import com.android.launcher3.util.ContentWriter;
 
+import app.lawnchair.util.PrivateSpaceUtils;
+
 import java.util.Arrays;
 
 /**
@@ -129,7 +131,8 @@ public class WorkspaceItemInfo extends ItemInfoWithIcon {
         user = shortcutInfo.getUserHandle();
         itemType = Favorites.ITEM_TYPE_DEEP_SHORTCUT;
         if (Flags.privateSpaceRestrictAccessibilityDrag()) {
-            if (UserCache.INSTANCE.get(context).getUserInfo(user).isPrivate()) {
+            if (UserCache.INSTANCE.get(context).getUserInfo(user).isPrivate()
+                    && !PrivateSpaceUtils.isPinningAllowed(context)) {
                 runtimeStatusFlags |= FLAG_NOT_PINNABLE;
             }
         }

--- a/src/com/android/launcher3/pm/UserCache.java
+++ b/src/com/android/launcher3/pm/UserCache.java
@@ -37,6 +37,7 @@ import com.android.launcher3.icons.UserBadgeDrawable;
 import com.android.launcher3.util.ApiWrapper;
 import com.android.launcher3.util.FlagOp;
 import com.android.launcher3.util.MainThreadInitializedObject;
+import com.android.launcher3.util.PrivateProfileTracker;
 import com.android.launcher3.util.SafeCloseable;
 import com.android.launcher3.util.SimpleBroadcastReceiver;
 import com.android.launcher3.util.UserIconInfo;
@@ -45,6 +46,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 
 /**
@@ -87,6 +89,13 @@ public class UserCache implements SafeCloseable {
     @NonNull
     private Map<UserHandle, List<String>> mUserToPreInstallAppMap;
 
+    /** Memoizes lookups for users missing from {@link #mUserToSerialMap}, e.g. a hidden profile. */
+    @NonNull
+    private final Map<UserHandle, UserIconInfo> mFallbackUserInfoMap = new ConcurrentHashMap<>();
+
+    /** Serial of the last observed private profile, refreshed with the cache. */
+    private volatile long mKnownPrivateSerial = PrivateProfileTracker.INVALID_SERIAL;
+
     private UserCache(Context context) {
         mContext = context;
         mUserToSerialMap = Collections.emptyMap();
@@ -128,6 +137,10 @@ public class UserCache implements SafeCloseable {
     private void updateCache() {
         mUserToSerialMap = ApiWrapper.INSTANCE.get(mContext).queryAllUsers();
         mUserToPreInstallAppMap = fetchPreInstallApps();
+        mFallbackUserInfoMap.clear();
+        PrivateProfileTracker.onUserCacheUpdated(mContext, this);
+        // Read once, not per lookup: that path runs on the model thread under the data model lock.
+        mKnownPrivateSerial = PrivateProfileTracker.getKnownPrivateProfileSerial(mContext);
     }
 
     @WorkerThread
@@ -164,7 +177,20 @@ public class UserCache implements SafeCloseable {
     @NonNull
     public UserIconInfo getUserInfo(UserHandle user) {
         UserIconInfo info = mUserToSerialMap.get(user);
-        return info == null ? new UserIconInfo(user, UserIconInfo.TYPE_MAIN) : info;
+        return info == null ? getFallbackUserInfo(user) : info;
+    }
+
+    /** @see PrivateProfileTracker#resolveUnknownUser */
+    @NonNull
+    private UserIconInfo getFallbackUserInfo(UserHandle user) {
+        UserIconInfo cached = mFallbackUserInfoMap.get(user);
+        if (cached != null) {
+            return cached;
+        }
+        UserIconInfo info = PrivateProfileTracker.resolveUnknownUser(
+                mContext, user, mKnownPrivateSerial);
+        mFallbackUserInfoMap.put(user, info);
+        return info;
     }
 
     /**

--- a/src/com/android/launcher3/provider/RestoreDbTask.java
+++ b/src/com/android/launcher3/provider/RestoreDbTask.java
@@ -76,6 +76,7 @@ import com.android.launcher3.util.ApiWrapper;
 import com.android.launcher3.util.ContentWriter;
 import com.android.launcher3.util.IntArray;
 import com.android.launcher3.util.LogConfig;
+import com.android.launcher3.util.PrivateProfileTracker;
 
 import java.io.File;
 import java.io.InvalidObjectException;
@@ -253,6 +254,15 @@ public class RestoreDbTask {
                 profileMapping.put(oldManagedProfileId, newManagedProfileId);
                 FileLog.d(TAG, "sanitizeDB: managed profile id=" + oldManagedProfileId
                         + " should be mapped to new id=" + newManagedProfileId);
+            } else if (PrivateProfileTracker.isRestorablePrivateProfileSerial(
+                    context, oldManagedProfileId)) {
+                // Private profiles are never part of backup & restore, so BackupManager cannot map
+                // them and every private space item would be deleted below. When the serial still
+                // belongs to a private profile on this device - always the case for a local
+                // Lawnchair backup - the rows are still valid, so map the id to itself.
+                profileMapping.put(oldManagedProfileId, oldManagedProfileId);
+                FileLog.d(TAG, "sanitizeDB: keeping items of private profile id="
+                        + oldManagedProfileId);
             } else {
                 FileLog.e(TAG, "sanitizeDB: No User found for old profileId, Ancestral Serial "
                         + "Number: " + oldManagedProfileId);

--- a/src/com/android/launcher3/touch/ItemClickHandler.java
+++ b/src/com/android/launcher3/touch/ItemClickHandler.java
@@ -75,6 +75,8 @@ import com.android.launcher3.widget.PendingAppWidgetHostView;
 import com.android.launcher3.widget.WidgetAddFlowHandler;
 import com.android.launcher3.widget.WidgetManagerHelper;
 
+import app.lawnchair.util.PrivateSpaceUtils;
+
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
@@ -292,6 +294,15 @@ public class ItemClickHandler {
         // Handle the case where the disabled reason is DISABLED_REASON_VERSION_LOWER.
         // Show an AlertDialog for the user to choose either updating the app or cancel the launch.
         if (maybeCreateAlertDialogForShortcut(shortcut, context)) {
+            return true;
+        }
+
+        // A pinned private space app whose only problem is that the space is locked: unlocking is
+        // the action the user is asking for. Launching would fail, and a toast would be a dead end.
+        if ((disabledFlags & ~FLAG_DISABLED_QUIET_USER) == 0
+                && (disabledFlags & FLAG_DISABLED_QUIET_USER) != 0
+                && PrivateSpaceUtils.isPrivateSpaceItem(context, shortcut)) {
+            PrivateSpaceUtils.requestUnlock(context, shortcut.user);
             return true;
         }
 

--- a/src/com/android/launcher3/util/PrivateProfileTracker.kt
+++ b/src/com/android/launcher3/util/PrivateProfileTracker.kt
@@ -1,0 +1,294 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android.launcher3.util
+
+import android.content.Context
+import android.os.UserHandle
+import android.os.UserManager
+import android.util.LongSparseArray
+import com.android.launcher3.EncryptionType
+import com.android.launcher3.LauncherPrefs
+import com.android.launcher3.logging.FileLog
+import com.android.launcher3.pm.UserCache
+import com.android.launcher3.util.UserIconInfo
+
+/**
+ * Remembers the private profile across periods where it is not visible to Launcher.
+ *
+ * Access to the private profile is granted by `ACCESS_HIDDEN_PROFILES`, an appop permission that is
+ * only held while this app holds the home role. Losing the home role - or simply locking the private
+ * space - therefore makes the profile disappear from [UserCache] and from `LauncherApps`, which is
+ * indistinguishable from the profile having been deleted. Without a record of the profile, the model
+ * loader treats every private-space workspace item as belonging to a deleted user or to an
+ * uninstalled app, and deletes the rows permanently.
+ *
+ * The recorded serial number lets those rows be recognised and preserved. It is cleared only on an
+ * explicit profile-removed broadcast, never by mere absence, because absence is exactly the
+ * ambiguous signal this class exists to work around.
+ */
+object PrivateProfileTracker {
+
+    private const val TAG = "PrivateProfileTracker"
+
+    const val INVALID_SERIAL = -1L
+
+    const val INVALID_USER_ID = -1
+
+    /**
+     * Serial number of the last private profile we were able to observe, or [INVALID_SERIAL].
+     *
+     * Not backed up: a serial number is only meaningful on the device that issued it, and restoring
+     * a foreign one would make this device's rows look like they belong to a private profile.
+     */
+    @JvmField
+    val KNOWN_PRIVATE_PROFILE_SERIAL =
+        LauncherPrefs.nonRestorableItem(
+            "private_profile_serial",
+            INVALID_SERIAL,
+            EncryptionType.DEVICE_PROTECTED
+        )
+
+    /**
+     * User id of the same profile, kept alongside the serial so that a [UserHandle] can be rebuilt
+     * while the profile is invisible. Without it the loader cannot resolve the owning user of a
+     * private-space row and has to treat it as belonging to a deleted user.
+     */
+    @JvmField
+    val KNOWN_PRIVATE_PROFILE_USER_ID =
+        LauncherPrefs.nonRestorableItem(
+            "private_profile_user_id",
+            INVALID_USER_ID,
+            EncryptionType.DEVICE_PROTECTED
+        )
+
+    /**
+     * Records the private profile's serial number whenever one is visible.
+     *
+     * Deliberately does nothing when no private profile is visible: that state also occurs while the
+     * space is locked or while another launcher holds the home role, and forgetting the serial there
+     * would let the loader delete the very items this class protects.
+     */
+    @JvmStatic
+    fun onUserCacheUpdated(context: Context, userCache: UserCache) {
+        val user =
+            userCache.userProfiles.firstOrNull { userCache.getUserInfo(it).isPrivate } ?: return
+        val serial = userCache.getSerialNumberForUser(user)
+        val userId = try {
+            user.identifier
+        } catch (t: Throwable) {
+            // Also a hidden API. UserHandle.hashCode returns the same user id, so it is a safe
+            // fallback rather than a reason to give up recording the profile.
+            user.hashCode()
+        }
+        val prefs = LauncherPrefs.get(context)
+        if (
+            prefs.get(KNOWN_PRIVATE_PROFILE_SERIAL) != serial ||
+                prefs.get(KNOWN_PRIVATE_PROFILE_USER_ID) != userId
+        ) {
+            FileLog.d(TAG, "Recording private profile serial=$serial userId=$userId")
+            prefs.put(KNOWN_PRIVATE_PROFILE_SERIAL, serial)
+            prefs.put(KNOWN_PRIVATE_PROFILE_USER_ID, userId)
+        }
+    }
+
+    /**
+     * Forgets the recorded profile when that profile is genuinely removed. This is the only signal
+     * that reliably distinguishes deletion from invisibility, and it is what allows the items of a
+     * deleted private space to be cleaned up on the next load.
+     */
+    @JvmStatic
+    fun onProfileRemoved(context: Context, user: UserHandle) {
+        val prefs = LauncherPrefs.get(context)
+        val known = prefs.get(KNOWN_PRIVATE_PROFILE_SERIAL)
+        if (known == INVALID_SERIAL) return
+        // UserCache refreshes asynchronously, so the removed user is usually still resolvable here.
+        // Its fallback path also reports a user carrying the recorded serial as private, which
+        // covers the case where the cache has already dropped it.
+        val info = UserCache.getInstance(context).getUserInfo(user)
+        if (info.isPrivate || info.userSerial == known) {
+            FileLog.d(TAG, "Private profile removed, forgetting serial=$known")
+            prefs.put(KNOWN_PRIVATE_PROFILE_SERIAL, INVALID_SERIAL)
+            prefs.put(KNOWN_PRIVATE_PROFILE_USER_ID, INVALID_USER_ID)
+        }
+    }
+
+    /**
+     * Whether the profile we recorded still exists on this device.
+     *
+     * This is the distinction the rest of this class is built around, and it turns out the platform
+     * will answer it. [UserManager.getSerialNumberForUser] resolves a user id straight through
+     * UserManagerService, which is a different question from whether `LauncherApps` will show us the
+     * profile: a private space that is merely locked, or hidden because another launcher holds the
+     * home role, still reports its serial, while one that has actually been deleted reports -1.
+     *
+     * Returns true when the query fails, so nothing is ever deleted on the strength of an error.
+     */
+    @JvmStatic
+    fun isRecordedProfileStillPresent(context: Context): Boolean {
+        val serial = LauncherPrefs.get(context).get(KNOWN_PRIVATE_PROFILE_SERIAL)
+        if (serial == INVALID_SERIAL) return false
+        val user = getKnownPrivateProfileUser(context) ?: return false
+        return try {
+            context.getSystemService(UserManager::class.java)
+                ?.getSerialNumberForUser(user) == serial
+        } catch (t: Throwable) {
+            true
+        }
+    }
+
+    /** Drops the recorded identity. Used once the profile is known to be gone. */
+    @JvmStatic
+    fun forgetRecordedProfile(context: Context) {
+        val prefs = LauncherPrefs.get(context)
+        if (prefs.get(KNOWN_PRIVATE_PROFILE_SERIAL) == INVALID_SERIAL) return
+        FileLog.d(TAG, "Recorded private profile no longer exists; forgetting it")
+        prefs.put(KNOWN_PRIVATE_PROFILE_SERIAL, INVALID_SERIAL)
+        prefs.put(KNOWN_PRIVATE_PROFILE_USER_ID, INVALID_USER_ID)
+    }
+
+    /**
+     * The profile to add to a loader's user table when the platform did not enumerate it, or null.
+     *
+     * A private space that is merely locked, or hidden because another launcher holds the home role,
+     * has to stay resolvable or every one of its workspace rows reads as belonging to a deleted user
+     * and is removed. When the recorded profile turns out to be genuinely gone the record is dropped
+     * here instead, before the workspace is read, so this load clears those leftover rows normally.
+     */
+    @JvmStatic
+    fun getHiddenProfileToInject(context: Context, alreadyKnown: LongSparseArray<UserHandle>):
+        UserHandle? {
+        val serialNo = getKnownPrivateProfileSerial(context)
+        if (serialNo == INVALID_SERIAL || alreadyKnown.get(serialNo) != null) return null
+        if (!isRecordedProfileStillPresent(context)) {
+            forgetRecordedProfile(context)
+            return null
+        }
+        return getKnownPrivateProfileUser(context)
+    }
+
+    /**
+     * Resolves a user that [UserCache] does not know about, which happens while a profile is hidden
+     * from us - a locked private space, or any private space while another launcher holds the home
+     * role.
+     *
+     * The two-argument [UserIconInfo] constructor derives the serial number from
+     * [UserHandle.hashCode], i.e. the user id. That is correct for the main user and wrong for every
+     * other profile, so items would silently be attributed to the wrong profileId. Ask [UserManager]
+     * for the real serial instead, and recognise a hidden private profile by [knownSerial] so its
+     * icons keep their badge.
+     */
+    @JvmStatic
+    fun resolveUnknownUser(context: Context, user: UserHandle, knownSerial: Long): UserIconInfo {
+        val serial = try {
+            context.getSystemService(UserManager::class.java)?.getSerialNumberForUser(user)
+                ?: INVALID_SERIAL
+        } catch (t: Throwable) {
+            INVALID_SERIAL
+        }
+        if (serial == INVALID_SERIAL) {
+            // Nothing better available; keep the historic behaviour rather than inventing a serial.
+            return UserIconInfo(user, UserIconInfo.TYPE_MAIN)
+        }
+        val type =
+            if (serial == knownSerial) UserIconInfo.TYPE_PRIVATE else UserIconInfo.TYPE_MAIN
+        return UserIconInfo(user, type, serial)
+    }
+
+    /**
+     * Whether [serial] identifies a private profile that exists on this device, for deciding whether
+     * restored rows carrying that profileId may be kept.
+     *
+     * Deliberately narrow: matching on the serial alone would let a backup from another device hand
+     * its private space items to whichever profile happened to be issued the same serial here. The
+     * recorded identity is accepted only when it still resolves, because Lawnchair's own backup
+     * copies the preference files verbatim and so imports the other device's record along with them.
+     */
+    @JvmStatic
+    fun isRestorablePrivateProfileSerial(context: Context, serial: Long): Boolean {
+        if (serial == INVALID_SERIAL) return false
+        val userCache = UserCache.getInstance(context)
+        if (userCache.userProfiles.any {
+                userCache.getSerialNumberForUser(it) == serial && userCache.getUserInfo(it).isPrivate
+            }
+        ) {
+            return true
+        }
+        return LauncherPrefs.get(context).get(KNOWN_PRIVATE_PROFILE_SERIAL) == serial &&
+            isRecordedProfileStillPresent(context)
+    }
+
+    /**
+     * The recorded private profile as a [UserHandle], or null when none was ever recorded.
+     *
+     * Used to keep private-space rows resolvable during a load that happens while the profile is
+     * hidden. The handle is rebuilt from the stored user id rather than queried, precisely because
+     * the platform will not enumerate the profile for us in that state.
+     */
+    @JvmStatic
+    fun getKnownPrivateProfileUser(context: Context): UserHandle? {
+        val prefs = LauncherPrefs.get(context)
+        if (prefs.get(KNOWN_PRIVATE_PROFILE_SERIAL) == INVALID_SERIAL) return null
+        val userId = prefs.get(KNOWN_PRIVATE_PROFILE_USER_ID)
+        if (userId == INVALID_USER_ID) return null
+        return try {
+            UserHandle.of(userId)
+        } catch (t: Throwable) {
+            // UserHandle.of is a hidden API. If it is ever unavailable the failure arrives as a
+            // LinkageError rather than an Exception, and this runs on every load - letting it
+            // escape would take the whole workspace down with it.
+            FileLog.e(TAG, "Unable to rebuild private profile handle for userId=$userId, $t")
+            null
+        }
+    }
+
+    /**
+     * Whether items stored against [serial] must be preserved rather than deleted when their target
+     * cannot be resolved.
+     *
+     * True when the serial belongs to a private profile that is currently inaccessible - either
+     * visible but in quiet mode, or not visible at all while still being the profile we last
+     * recorded. False for a visible, unlocked private profile, where a missing app really is
+     * missing and the normal cleanup should apply.
+     */
+    @JvmStatic
+    fun isInaccessiblePrivateProfile(context: Context, serial: Long): Boolean {
+        if (serial == INVALID_SERIAL) return false
+        val userCache = UserCache.getInstance(context)
+        val liveUser =
+            userCache.userProfiles.firstOrNull {
+                userCache.getUserInfo(it).isPrivate && userCache.getSerialNumberForUser(it) == serial
+            }
+        if (liveUser != null) {
+            return try {
+                context.getSystemService(UserManager::class.java)?.isQuietModeEnabled(liveUser)
+                    ?: false
+            } catch (t: Throwable) {
+                // Unable to tell; assume inaccessible so that nothing is destroyed.
+                true
+            }
+        }
+        return LauncherPrefs.get(context).get(KNOWN_PRIVATE_PROFILE_SERIAL) == serial &&
+            isRecordedProfileStillPresent(context)
+    }
+
+    /**
+     * The [UserHandle] recorded items should be attributed to while the profile is invisible, or
+     * null when the profile is currently visible or unknown.
+     */
+    @JvmStatic
+    fun getKnownPrivateProfileSerial(context: Context): Long =
+        LauncherPrefs.get(context).get(KNOWN_PRIVATE_PROFILE_SERIAL)
+}


### PR DESCRIPTION
### Description

This patch adds user opt-in pinning of apps in private space. When the private space is unlocked, apps and folders are shown. When the private space is locked, the apps are hidden and vice versa.

### Reasoning

Private space apps can normally not be pinned to the home screen due to being flagged FLAG_NOT_PINNABLE, and any app that (due to bugs) did end up in the homescreen were deleted whenever the private profile was not visible (looked like a deleted app so remove from screen) or could not be moved/dragged. Even if private space apps are meant to be kept separate and off the home-screen, it makes sense from a usability perspective to allow the user to pin such apps as well, or put them in folders. At the same time, the private properties should be preserved when the private space is locked.

Why they were being deleted

Access to the private profile comes from ACCESS_HIDDEN_PROFILES, an appop permission held only while this app has the home role. Losing that role - or simply locking the space - makes the profile disappear from UserCache and makes LauncherApps report every package in it as absent.  That is indistinguishable from the app having been uninstalled, so the loader deleted their database rows
- each pinned item is one row of the favorites table, holding its profile, position and intent. Switching launchers and back, or rebooting with the space locked, was enough to lose every pinned private app with no way to recover the positions.

PrivateProfileTracker records the profile's serial and user id while it is visible, so those database rows stay resolvable when it is not. The record is dropped only when the profile is genuinely gone, which UserManager can still confirm by serial even for a profile LauncherApps will not show.

Features

- Opt-in "Allow on home screen" preference (default off) that releases FLAG_NOT_PINNABLE for private space apps.
- Pinned private apps are hidden while the space is locked, keeping their database rows and reappearing on unlock.
- Tapping a pinned private app while locked asks the system to unlock the space rather than failing silently, prompting for the home role if we do not hold it.
- Optional "Hide app badge" preference to drop the private profile badge from these icons.
- Backups made while the space is unlocked restore pinned private apps in full.

Privacy considerations

Hiding an app is only as good as its least careful presentation, so every surface that reaches the model independently is filtered: the workspace, the taskbar, folder previews, app pairs, drawer folders and search. Both search algorithms enumerated the locked space by name, since all apps keeps private apps loaded across a lock and only the drawer adapter filtered them.

A folder or app pair is hidden whole when any of its contents is hidden, rather than having its contents filtered.

Filtering was tried first and produced a string of states the launcher never normally reaches. Launcher3 collapses a folder into a plain icon as soon as it holds one item, so a folder left showing a single app is an anomaly an observer can read as "something is hidden here" - as is an empty slot inside an open folder. Fixing each symptom took a separate patch in a separate file, and they interacted: moving one app out of a mixed folder made an unrelated normal app disappear, and whether a folder showed at all depended on how many private apps it held relative to normal ones. Hiding the container whole replaced all of it with one rule that also covers app pairs, and left three files untouched.

The trade is that a folder holding one private app and ten normal ones disappears entirely while the space is locked, where filtering would have shown the ten. That is worse for that case but predictable, and avoidable by not mixing private and normal apps in the same folder. The apps in a hidden folder remain reachable from the drawer.

Hidden icons are not bound at all rather than made invisible. The problem is that an invisible child still holds its cell and silently refuses drops, which would reveal how many private apps are pinned and where. Cells are left free instead, and an icon whose cell was taken while the space was locked is relocated on unlock - never deleted - with a toast naming it only when it is actually visible.

Backup export scrubs private rows from launcher.db when the space is locked, since the favorites table stores component names in plain text and the file leaves the device.


### Testing
Setup

  Install app, set it as default home app, then enable Home screen → Private space → Allow on home screen.

  The default-home step isn't optional since ACCESS_HIDDEN_PROFILES is granted only to the role holder, so without it every private app looks absent

  adb logcat -s PrivateProfileTracker PrivateSpacePlacement WorkspaceItemProcessor LoaderCursor PrivateSpaceUtils

  0. Locking survival

  Lock the space, force an app reload. Watch for PrivateProfileTracker saying the recorded profile no longer exists. That must
  appear only when you actually delete the private space. If it fires while merely locked, the patch deletes the database rows it exists to protect — which shouldnt happen.

  1. Reboot survival

  Pin two or three private apps, lock, reboot, unlock. All should return in place. Failure looks like
  WorkspaceItemProcessor logging "Invalid package removed". Drag and put in folder. Reboot and check again.

  2. Launcher switch
  
  Switch default home away and back. This causes the appop to be removed and reinstated. Apps should return in place as in step 1.

  3. Relocation 
  
  Note a private icon's cell. Lock (it disappears, cell becomes droppable). Drop a normal app there. Unlock.

  Expect: normal app keeps the cell, private app moved, toast informs. If the normal app vanishes instead, the deferral 
  ordering is backwards. Turn Allow overlap off first or this test does nothing.

  4. Grid size change

  Change grid size, locked and unlocked. Private icons must survive both — this was a separate bug from the reboot one.

  5. Privacy surfaces, with the space locked

  Each of these surfaces reaches the model independently, so check them separately: home screen, dock/taskbar, drawer search by name (must return nothing), and drawer folders.

  Folders — any folder containing a private app disappears whole while locked and
  returns intact on unlock. No single-app folders, no gaps inside open folders. If you see either, the rule isn't being
  applied where I think it is.

  6. Backup round trip

  Export locked → unzip and confirm launcher.db has no private rows. Export unlocked → restore → private pins return.

  7. Auto-add and the stuck-icon report

  Preference off: installing an app into the private space must not auto-add it, and existing private icons stay
  undraggable. Preference on: they become draggable on the next load.

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
:white_check_mark: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Android 15+ Private Space settings for app pinning and hiding Private Space badges.
  * Private Space apps can remain available on the home screen when configured, with automatic relocation notices when needed.
  * Locked Private Space apps can prompt profile unlocking when selected.
* **Bug Fixes**
  * Locked Private Space apps are hidden from app drawers, taskbars, and search results.
  * Private Space apps and data are better preserved during backup, restore, and launcher grid migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->