### PR TITLE
fix: Show background for QSB preview

### DIFF
--- a/lawnchair/src/app/lawnchair/ui/preferences/components/search/DockSearchPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/search/DockSearchPreferences.kt
@@ -1,11 +1,14 @@
 package app.lawnchair.ui.preferences.components.search
 
 import androidx.compose.animation.Crossfade
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.TipsAndUpdates
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -50,6 +53,7 @@ import app.lawnchair.ui.preferences.components.layout.PreferenceGroup
 import app.lawnchair.ui.preferences.components.layout.PreferenceTemplate
 import app.lawnchair.ui.preferences.navigation.DockSearchProvider
 import app.lawnchair.ui.theme.isSelectedThemeDark
+import app.lawnchair.ui.theme.preferenceGroupColor
 import com.android.launcher3.R
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
@@ -190,8 +194,10 @@ private fun DockSearchBarPreview(
     ) {
         Box(
             modifier = modifier
-                .padding(horizontal = 16.dp)
                 .fillMaxWidth()
+                .background(color = preferenceGroupColor(), shape = MaterialTheme.shapes.large)
+                .padding(horizontal = 16.dp)
+                .width(IntrinsicSize.Max)
                 .height(dimensionResource(id = R.dimen.qsb_widget_height) + 24.dp),
             contentAlignment = Alignment.Center,
         ) {


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Fix the display the background use for placing QSB in a preview box

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->


### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Enhanced the dock search preview with themed background styling, improved spacing, and a shaped appearance.
  * Updated the preview layout to use available space while respecting an intrinsic maximum width.
  * Added support for preference-group colors in the preview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->