### PR TITLE
fix: Adjust dock preview sizing to show item with 2 hotseat rows

### DIFF
--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/DockPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/DockPreferences.kt
@@ -198,11 +198,13 @@ fun ColumnScope.DockPreferencesPreview(modifier: Modifier = Modifier) {
         val prefs = preferenceManager()
         val prefs2 = preferenceManager2()
 
+        val hotseatRows = prefs.hotseatRows
+
         val adapters = listOf(
             prefs2.hotseatMode.getAdapter(),
             prefs.hotseatColumns.getAdapter(),
             prefs.hotseatColumnsUnfolded.getAdapter(),
-            prefs.hotseatRows.getAdapter(),
+            hotseatRows.getAdapter(),
             prefs2.themedHotseatQsb.getAdapter(),
             prefs.hotseatQsbCornerRadius.getAdapter(),
             prefs.hotseatQsbAlpha.getAdapter(),
@@ -232,7 +234,7 @@ fun ColumnScope.DockPreferencesPreview(modifier: Modifier = Modifier) {
                         .weight(1f)
                         .align(Alignment.CenterHorizontally)
                         .clip(MaterialTheme.shapes.large)
-                        .clipToBottomPercentage(0.3f),
+                        .clipToBottomPercentage(if (hotseatRows.getAdapter().state.value >= 2) .4f else .3f),
                 ) {
                     WallpaperPreview(
                         wallpaper = wallpaper,


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Adjust dock preview sizing to show item with 2 hotseat rows, before displaying 2 hotseat rows will cut the entire second row of hotseat row off of the preview.

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Visual test

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the dock preview’s bottom clipping for configurations with multiple hotseat rows.
  * Ensured the preview consistently reflects the configured number of hotseat rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->