### PR TITLE
fix: Misalign app preview list on selecting app in folder

### DIFF
--- a/lawnchair/src/app/lawnchair/ui/preferences/components/AppItem.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/AppItem.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.unit.dp
@@ -140,7 +141,7 @@ private fun AppItemLayout(
         title = title,
         modifier = modifier,
         startWidget = {
-            Row {
+            Row(verticalAlignment = Alignment.CenterVertically) {
                 widget?.let {
                     it()
                     Spacer(modifier = Modifier.requiredWidth(16.dp))


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Fix misaligned app preview items when selecting app for app drawer folder where the preview would go off centered or more accurately, slightly above the center.

This PR align it back to the center by well... align it to the center.

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Visual test on pixel 7

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Vertically centered app icons and leading widgets in the preferences list for improved visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->