### PR TITLE
fix: drawer folder crashes

### DIFF
--- a/src/com/android/launcher3/folder/Folder.java
+++ b/src/com/android/launcher3/folder/Folder.java
@@ -1171,7 +1171,9 @@ public class Folder extends AbstractFloatingView implements ClipPathView, DragSo
 
     @Override
     public boolean acceptDrop(DragObject d) {
-        return willAcceptItemType(d.dragInfo.itemType);
+        // LC: App drawer folders are not backed by the launcher model, so dropping
+        // into them would write through ModelWriter and crash (#7127).
+        return !isInAppDrawer() && willAcceptItemType(d.dragInfo.itemType);
     }
 
     public void onDragEnter(DragObject d) {
@@ -1404,7 +1406,7 @@ public class Folder extends AbstractFloatingView implements ClipPathView, DragSo
     }
 
     public boolean isDropEnabled() {
-        return mState != STATE_ANIMATING;
+        return mState != STATE_ANIMATING && !isInAppDrawer();
     }
 
     private void centerAboutIcon() {

--- a/src/com/android/launcher3/folder/Folder.java
+++ b/src/com/android/launcher3/folder/Folder.java
@@ -108,6 +108,7 @@ import com.android.launcher3.logger.LauncherAtom.FromState;
 import com.android.launcher3.logger.LauncherAtom.ToState;
 import com.android.launcher3.logging.StatsLogManager;
 import com.android.launcher3.logging.StatsLogManager.StatsLogger;
+import com.android.launcher3.model.ModelWriter;
 import com.android.launcher3.model.data.FolderInfo;
 import com.android.launcher3.model.data.ItemInfo;
 import com.android.launcher3.model.data.WorkspaceItemFactory;
@@ -531,6 +532,17 @@ public class Folder extends AbstractFloatingView implements ClipPathView, DragSo
         return mInfo.container == ItemInfo.NO_ID;
     }
 
+    /**
+     * LC: App drawer folders live in Lawnchair's own database and are not part of the
+     * launcher model, so writing them through ModelWriter can collide with an unrelated
+     * workspace item sharing the same id and crash in checkItemInfoLocked (#7127).
+     * Returns null for drawer folders so callers only update the in-memory state.
+     */
+    @Nullable
+    private ModelWriter getModelWriter() {
+        return isInAppDrawer() ? null : mActivityContext.getModelWriter();
+    }
+
     @Override
     public void onDragEnd() {
         if (mIsExternalDrag && mIsDragInProgress) {
@@ -554,7 +566,7 @@ public class Folder extends AbstractFloatingView implements ClipPathView, DragSo
         if (DEBUG) {
             Log.d(TAG, "onBackKey newTitle=" + newTitle);
         }
-        mInfo.setTitle(newTitle, mActivityContext.getModelWriter());
+        mInfo.setTitle(newTitle, getModelWriter());
         mFolderIcon.onTitleChanged(newTitle);
 
         if (TextUtils.isEmpty(mInfo.title)) {
@@ -918,7 +930,7 @@ public class Folder extends AbstractFloatingView implements ClipPathView, DragSo
 
                     if (updateAnimationFlag) {
                         mInfo.setOption(FolderInfo.FLAG_MULTI_PAGE_ANIMATION, true,
-                                mActivityContext.getModelWriter());
+                                getModelWriter());
                     }
                 }
             });
@@ -1357,7 +1369,7 @@ public class Folder extends AbstractFloatingView implements ClipPathView, DragSo
         if (getItemCount() <= mContent.itemsPerPage()) {
             // Show the animation, next time something is added to the folder.
             mInfo.setOption(FolderInfo.FLAG_MULTI_PAGE_ANIMATION, false,
-                    mActivityContext.getModelWriter());
+                    getModelWriter());
         }
     }
 
@@ -1375,7 +1387,7 @@ public class Folder extends AbstractFloatingView implements ClipPathView, DragSo
             }
         }
 
-        if (!items.isEmpty()) {
+        if (!items.isEmpty() && !isInAppDrawer()) {
             mActivityContext.getModelWriter().moveItemsInDatabase(items, mInfo.id, 0);
         }
         if (!isBind && total > 1 /* no need to update if there's one icon */) {
@@ -1656,7 +1668,7 @@ public class Folder extends AbstractFloatingView implements ClipPathView, DragSo
         if (mContent.getPageCount() > 1) {
             // The animation has already been shown while opening the folder.
             mInfo.setOption(FolderInfo.FLAG_MULTI_PAGE_ANIMATION, true,
-                    mActivityContext.getModelWriter());
+                    getModelWriter());
         }
 
         if (!launcher.isInState(EDIT_MODE)) {


### PR DESCRIPTION
### Description

Fixes a fatal crash when opening a multi-page folder in the app drawer. Drawer folders are Lawnchair-specific `FolderInfo` objects persisted in Lawnchair's own Room database — they are never registered in the launcher model (`BgDataModel.itemsIdMap`), and their Room primary key can collide with an unrelated workspace item's id. When such a folder spanned multiple pages, opening it triggered `FolderInfo.setOption(FLAG_MULTI_PAGE_ANIMATION, ...)` with the workspace `ModelWriter`, which failed `ModelWriter.checkItemInfoLocked` (`ItemInfo passed to checkItemInfo doesn't match original`) and crashed the launcher. `Folder` now routes these writes through a helper that returns a `null` writer for drawer folders (`isInAppDrawer()`), so only in-memory state is updated, and `updateItemLocationsInDatabaseBatch` skips `moveItemsInDatabase` for drawer folders. Drawer folder titles and contents are still persisted through Lawnchair's `FolderService` as before.

- Closes: #7127

### Reasoning

Drawer folders should never write through `ModelWriter`, which targets the workspace favorites database. Beyond the crash, a successful write would corrupt whatever favorites row shares the colliding id. `Folder` already guards drag paths with `isInAppDrawer()`; this extends the same principle to the remaining unguarded write paths (`setOption`, `setTitle`, and the batch location update in `bind()`). Both `FolderInfo.setOption` and `setTitle` already accept a `null` writer and update in-memory state only, so no launcher3 model code needed changes.

### Testing

1. Enable app drawer folders and create a folder with enough apps to span multiple pages (more than one page of items).
2. Ensure a workspace item exists whose favorites id matches the drawer folder's Room id (this happens naturally on affected setups; the crash was device/data-specific).
3. Open the app drawer and tap the folder — previously the launcher crashed with `ItemInfo passed to checkItemInfo doesn't match original`; now it opens normally.
4. Rename a drawer folder via Preferences and verify the title still persists (drawer folder persistence goes through `FolderService`, unaffected by this change).
5. Verify workspace folders still behave as before: multi-page animation flag persists, rename persists, and item reordering saves correctly.

### Type of change

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
:x: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved folder management to prevent unintended persistence of app-drawer folder changes.
  * Folder title updates, animations, and item movements now behave correctly without affecting launcher data.
  * App-drawer folders no longer accept item drops and correctly indicate that dropping items is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->