### PR TITLE
fix: Crash on Android O, O_MR1, Q

### DIFF
--- a/quickstep/src/com/android/quickstep/TopTaskTracker.java
+++ b/quickstep/src/com/android/quickstep/TopTaskTracker.java
@@ -141,7 +141,12 @@ public class TopTaskTracker extends ISplitScreenListener.Stub implements TaskSta
 
     @Override
     public void onTaskMovedToFront(RunningTaskInfo taskInfo) {
-        handleTaskMovedToFront(taskInfo);
+        if (LawnchairQuickstepCompat.ATLEAST_Q) {
+            // LC-Note: RunningTaskInfo did not extend TaskInfo before Android Q. 
+            // The Object cast prevents bytecode verifier from treating this as an unconditional 
+            // upcast (VerifyError)
+            handleTaskMovedToFront((TaskInfo) (Object) taskInfo);
+        }
     }
 
     void handleTaskMovedToFront(TaskInfo taskInfo) {

--- a/src/com/android/launcher3/util/LifecycleHelper.kt
+++ b/src/com/android/launcher3/util/LifecycleHelper.kt
@@ -24,6 +24,7 @@ import androidx.lifecycle.setViewTreeLifecycleOwner
 import androidx.savedstate.SavedStateRegistryController
 import androidx.savedstate.SavedStateRegistryOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
+import com.android.launcher3.Utilities
 
 /** Utility class for triggering various lifecycle events based on activity callbacks */
 class LifecycleHelper(
@@ -31,6 +32,45 @@ class LifecycleHelper(
     private val savedStateRegistryController: SavedStateRegistryController,
     private val lifecycleRegistry: LifecycleRegistry,
 ) : ActivityLifecycleCallbacksAdapter {
+
+    // LC-Note: Fix lifecycle crash on Android O + O_MR1, and Q
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+        if (Utilities.ATLEAST_Q) return
+        savedStateRegistryController.performRestore(savedInstanceState)
+        activity.window.decorView.setViewTreeLifecycleOwner(owner)
+        activity.window.decorView.setViewTreeSavedStateRegistryOwner(owner)
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+    }
+
+    // LC-Note: Fix lifecycle crash on Android O + O_MR1, and Q
+    override fun onActivityStarted(activity: Activity) {
+        if (Utilities.ATLEAST_Q) return
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_START)
+    }
+
+    // LC-Note: Fix lifecycle crash on Android O + O_MR1, and Q
+    override fun onActivityResumed(activity: Activity) {
+        if (Utilities.ATLEAST_Q) return
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+    }
+
+    // LC-Note: Fix lifecycle crash on Android O + O_MR1, and Q
+    override fun onActivityPaused(activity: Activity) {
+        if (Utilities.ATLEAST_Q) return
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+    }
+
+    // LC-Note: Fix lifecycle crash on Android O + O_MR1, and Q
+    override fun onActivityStopped(activity: Activity) {
+        if (Utilities.ATLEAST_Q) return
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+    }
+
+    // LC-Note: Fix lifecycle crash on Android O + O_MR1, and Q
+    override fun onActivityDestroyed(activity: Activity) {
+        if (Utilities.ATLEAST_Q) return
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+    }
 
     override fun onActivityPreCreated(activity: Activity, savedInstanceState: Bundle?) {
         savedStateRegistryController.performRestore(savedInstanceState)


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Fixes lifecycle issue in Android O, O_MR1, and Q

And Java VerifyError in TopTaskTracker

Fixes #7088 
Fixes #6982 

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Verified in https://github.com/LawnchairLauncher/lawnchair/issues/7088

Dev verified using Firebase (paid) SHARP AQUOS sense2 SH-01L, Android 9

Dev verified using Firebase (paid) FUJITSU F-01L, Android 8.x

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved activity lifecycle handling on older Android versions.
  * Preserved saved state, view hierarchy, and lifecycle behavior for legacy devices.
  * Improved task transition handling across supported Android versions.
  * Avoided duplicate lifecycle and task processing on Android Q and newer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->