### PR TITLE
fix: Stale Live information announcement cache

### DIFF
--- a/lawnchair/src/app/lawnchair/ui/preferences/components/AnnouncementPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/AnnouncementPreference.kt
@@ -70,7 +70,9 @@ fun AnnouncementPreference() {
     val dismissedAnnouncementIds by liveInformationManager.dismissedAnnouncementIds.asState()
     val liveInformation by liveInformationManager.liveInformation.asState()
 
-    val announcements = remember { liveInformation.announcements.filter { it.id !in dismissedAnnouncementIds } }
+    val announcements = remember(liveInformation, dismissedAnnouncementIds) {
+        liveInformation.announcements.filter { it.id !in dismissedAnnouncementIds }
+    }
 
     if (enabled && showAnnouncements) {
         AnnouncementPreference(


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Fix Live information announcement not displaying because the cache is stale.

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Visual test with pixel 7 on preference UI

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Announcement filtering now refreshes correctly when live announcement information or dismissed announcement selections change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->