### PR TITLE
feat: Customisable hotseat bg corner radius

### DIFF
--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -774,6 +774,7 @@
     <string name="hotseat_bg_vertical_inset_top">Top margin</string>
     <string name="hotseat_bg_vertical_inset_bottom">Bottom margin</string>
     <string name="hotseat_bg_color_label">Background color</string>
+    <string name="hotseat_bg_corner_radius">Background corner radius</string>
     <string name="hotseat_bg_alpha">Background opacity</string>
 
 

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
@@ -219,6 +219,13 @@ class PreferenceManager2 @Inject constructor(
         defaultValue = ColorOption.fromString(context.getString(R.string.config_default_hotseat_bg_color)),
     )
 
+    val hotseatBackgroundCornerRadius = preference(
+        key = floatPreferencesKey(name = "hotseat_bg_corner_radius"),
+        defaultValue = context.resources.getDimension(R.dimen.bg_round_rect_radius) /
+            context.resources.displayMetrics.density, // This should hopefully match corner of all devices
+        onSet = { reloadHelper.recreate() },
+    )
+
     val appDrawerBackgroundColor = preference(
         key = stringPreferencesKey(name = "app_drawer_bg_color"),
         parse = ColorOption::fromString,

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/DockPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/DockPreferences.kt
@@ -96,6 +96,13 @@ fun HotseatBackgroundSettings(prefs: PreferenceManager, prefs2: PreferenceManage
     DividerColumn {
         ColorPreference(preference = prefs2.hotseatBackgroundColor)
         SliderPreference(
+            label = stringResource(id = R.string.hotseat_bg_corner_radius),
+            adapter = prefs2.hotseatBackgroundCornerRadius.getAdapter(),
+            step = 1f,
+            valueRange = 0f..100f,
+            showUnit = "dp",
+        )
+        SliderPreference(
             label = stringResource(id = R.string.hotseat_bg_alpha),
             adapter = prefs.hotseatBGAlpha.getAdapter(),
             step = 5,
@@ -228,6 +235,7 @@ fun ColumnScope.DockPreferencesPreview(modifier: Modifier = Modifier) {
             prefs.hotseatBGVerticalInsetBottom.getAdapter(),
             prefs2.pageIndicatorHeightFactor.getAdapter(),
             prefs2.hotseatBackgroundColor.getAdapter(),
+            prefs2.hotseatBackgroundCornerRadius.getAdapter(),
             prefs.hotseatBGAlpha.getAdapter(),
         )
 

--- a/src/com/android/launcher3/Hotseat.java
+++ b/src/com/android/launcher3/Hotseat.java
@@ -29,8 +29,10 @@ import android.animation.ValueAnimator;
 import android.content.Context;
 import android.graphics.Color;
 import android.graphics.Rect;
+import android.graphics.drawable.GradientDrawable;
 import android.graphics.drawable.InsetDrawable;
 import android.util.AttributeSet;
+import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
@@ -63,7 +65,6 @@ import app.lawnchair.hotseat.LawnchairHotseat;
 import app.lawnchair.preferences.PreferenceManager;
 import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 import app.lawnchair.preferences2.PreferenceManager2;
-import app.lawnchair.theme.drawable.DrawableTokens;
 
 /**
  * View class that represents the bottom dock of the home screen.
@@ -212,9 +213,17 @@ public class Hotseat extends FrameLayout implements Insettable {
         int insetHorizontalRight = preferenceManager.getHotseatBGHorizontalInsetRight().get();
         int insetVerticalTop = preferenceManager.getHotseatBGVerticalInsetTop().get();
         int insetVerticalBottom = preferenceManager.getHotseatBGVerticalInsetBottom().get();
-        InsetDrawable bg = new InsetDrawable(DrawableTokens.BgCellLayout.resolve(getContext()),
-            insetHorizontalLeft, insetVerticalTop, insetHorizontalRight, insetVerticalBottom);
-        bg.setTint(finalColor);
+        float cornerRadiusDp = PreferenceCacheExtensionsKt.firstCached(
+                preferenceManager2.getHotseatBackgroundCornerRadius());
+        float cornerRadius = TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_DIP,
+                cornerRadiusDp,
+                getResources().getDisplayMetrics());
+        GradientDrawable background = new GradientDrawable();
+        background.setColor(finalColor);
+        background.setCornerRadius(cornerRadius);
+        InsetDrawable bg = new InsetDrawable(background,
+                insetHorizontalLeft, insetVerticalTop, insetHorizontalRight, insetVerticalBottom);
         setBackground(bg);
     }
 


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Allow user to adjust their dock's background's corner radius.

Additionally this fix hotseat on some device to not match the corner of their device although the starting default corner will be smaller or larger than previous behaviour depending on the display density of your device. (Although although, technically it should just be 8dp min-max)

Fixes #5705

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Visual test on pixel 7

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **New feature** (A non-breaking change that adds functionality)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dock preference to adjust the hotseat background corner radius.
  * Introduced a 0–100 dp slider with 1 dp increments.
  * Hotseat background corners now update according to the selected radius while preserving configured color, transparency, and insets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->