### PR TITLE
fix: Make search result padding depends on exact text padding

### DIFF
--- a/lawnchair/res/layout/search_result_icon_right_left.xml
+++ b/lawnchair/res/layout/search_result_icon_right_left.xml
@@ -39,10 +39,10 @@
         android:layout_gravity="center_vertical"
         android:layout_weight="1.0"
         android:orientation="horizontal"
-        android:paddingStart="@dimen/dynamic_grid_edge_margin"
-        android:paddingTop="@dimen/dynamic_grid_edge_margin"
-        android:paddingEnd="@dimen/dynamic_grid_edge_margin"
-        android:paddingBottom="@dimen/dynamic_grid_edge_margin"
+        android:paddingStart="@dimen/search_result_text_padding"
+        android:paddingTop="@dimen/search_result_text_padding"
+        android:paddingEnd="@dimen/search_result_text_padding"
+        android:paddingBottom="@dimen/search_result_text_padding"
         android:singleLine="true">
 
         <TextView

--- a/lawnchair/res/layout/search_result_small_icon_right_left.xml
+++ b/lawnchair/res/layout/search_result_small_icon_right_left.xml
@@ -39,10 +39,10 @@
         android:layout_gravity="center_vertical"
         android:layout_weight="1.0"
         android:orientation="horizontal"
-        android:paddingStart="@dimen/dynamic_grid_edge_margin"
-        android:paddingTop="@dimen/dynamic_grid_edge_margin"
-        android:paddingEnd="@dimen/dynamic_grid_edge_margin"
-        android:paddingBottom="@dimen/dynamic_grid_edge_margin"
+        android:paddingStart="@dimen/search_result_text_padding"
+        android:paddingTop="@dimen/search_result_text_padding"
+        android:paddingEnd="@dimen/search_result_text_padding"
+        android:paddingBottom="@dimen/search_result_text_padding"
         android:singleLine="true">
 
         <TextView

--- a/lawnchair/res/layout/search_result_small_icon_row.xml
+++ b/lawnchair/res/layout/search_result_small_icon_row.xml
@@ -27,10 +27,10 @@
         android:layout_gravity="center_vertical"
         android:layout_weight="1.0"
         android:orientation="horizontal"
-        android:paddingStart="@dimen/dynamic_grid_edge_margin"
-        android:paddingTop="@dimen/dynamic_grid_edge_margin"
-        android:paddingEnd="@dimen/dynamic_grid_edge_margin"
-        android:paddingBottom="@dimen/dynamic_grid_edge_margin"
+        android:paddingStart="@dimen/search_result_text_padding"
+        android:paddingTop="@dimen/search_result_text_padding"
+        android:paddingEnd="@dimen/search_result_text_padding"
+        android:paddingBottom="@dimen/search_result_text_padding"
         android:singleLine="true">
 
         <TextView

--- a/lawnchair/res/layout/search_result_text_header.xml
+++ b/lawnchair/res/layout/search_result_text_header.xml
@@ -15,8 +15,8 @@
         android:layout_gravity="center_vertical"
         android:layout_weight="1.0"
         android:orientation="horizontal"
-        android:paddingTop="@dimen/dynamic_grid_edge_margin"
-        android:paddingBottom="@dimen/dynamic_grid_edge_margin"
+        android:paddingTop="@dimen/search_result_text_padding"
+        android:paddingBottom="@dimen/search_result_text_padding"
         android:singleLine="true">
         <TextView
             android:id="@+id/title"

--- a/lawnchair/res/values-sw600dp/dimens.xml
+++ b/lawnchair/res/values-sw600dp/dimens.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <dimen name="search_result_small_row_height">82dp</dimen>
-    <dimen name="search_result_row_medium_height">96dp</dimen>
-    <dimen name="search_result_row_height">112dp</dimen>
-    <dimen name="search_result_text_height">72dp</dimen>
-    <dimen name="search_result_files_row_height">120dp</dimen>
-
     <dimen name="all_apps_search_bar_content_overlap">0dp</dimen>
     <dimen name="allset_page_allset_text_size">38sp</dimen>
     <dimen name="allset_page_margin_horizontal">120dp</dimen>

--- a/lawnchair/res/values/dimens.xml
+++ b/lawnchair/res/values/dimens.xml
@@ -59,6 +59,7 @@
     <dimen name="search_result_margin">8dp</dimen>
     <dimen name="search_result_padding">16dp</dimen>
     <dimen name="search_result_padding_medium">12dp</dimen>
+    <dimen name="search_result_text_padding">12dp</dimen>
     <dimen name="search_result_radius">4dp</dimen>
     <dimen name="search_result_row_height">92dp</dimen>
     <dimen name="search_result_row_medium_height">76dp</dimen>

--- a/lawnchair/src/app/lawnchair/allapps/views/SearchResultRightLeftIcon.kt
+++ b/lawnchair/src/app/lawnchair/allapps/views/SearchResultRightLeftIcon.kt
@@ -73,11 +73,10 @@ class SearchResultRightLeftIcon(context: Context, attrs: AttributeSet?) :
                 R.dimen.search_result_files_row_height,
             )
         }
-        val layoutParams = LayoutParams(
-            LayoutParams.MATCH_PARENT,
-            heightRes,
-        )
-        this.layoutParams = layoutParams
+        val params = this.layoutParams
+        params.width = LayoutParams.MATCH_PARENT
+        params.height = heightRes
+        this.layoutParams = params
     }
 
     override val isQuickLaunch: Boolean

--- a/lawnchair/src/app/lawnchair/allapps/views/SearchResultText.kt
+++ b/lawnchair/src/app/lawnchair/allapps/views/SearchResultText.kt
@@ -45,14 +45,15 @@ class SearchResultText(context: Context, attrs: AttributeSet?) :
             SPACE_MINI -> resources.getDimensionPixelSize(R.dimen.space_layout_mini_height)
             else -> resources.getDimensionPixelSize(R.dimen.search_result_text_height)
         }
+        val params = this.layoutParams
+        params.width = LayoutParams.MATCH_PARENT
         if (titleText == SPACE || titleText == SPACE_MINI) {
-            val layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, res)
-            this.layoutParams = layoutParams
+            params.height = res
             minimumHeight = 0
         } else {
-            val layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
-            this.layoutParams = layoutParams
+            params.height = LayoutParams.WRAP_CONTENT
             minimumHeight = res
         }
+        this.layoutParams = params
     }
 }


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Fix search result on landscape for tablet being too wide, and make everything adaptive, yay consistent search result sizing everywhere

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Firebase (paid) Pixel Tablet, Android 13 (tested on portrait and landscape)

<img width="1187" height="875" alt="image" src="https://github.com/user-attachments/assets/a8f6e9ef-355b-47df-b220-2e0afaddfdac" />

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spacing and padding consistency across search-result layouts.
  * Search-result rows now maintain more reliable sizing when displaying different content types.
  * Standardized search-result dimensions across larger-screen configurations for a more consistent appearance.
* **Refactor**
  * Simplified layout sizing behavior without changing search functionality or result content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->