### PR TITLE
fix: Apply launcher colour on widget dynamic theming

### DIFF
--- a/src/com/android/launcher3/widget/LauncherAppWidgetHostView.java
+++ b/src/com/android/launcher3/widget/LauncherAppWidgetHostView.java
@@ -107,11 +107,19 @@ public class LauncherAppWidgetHostView extends BaseLauncherAppWidgetHostView
 
     @Override
     public void setColorResources(@Nullable SparseIntArray colors) {
-        if (colors == null) {
+        if (colors == null || colors.size() == 0) {
             resetColorResources();
-        } else {
-            super.setColorResources(colors);
+            return;
         }
+
+        // LC-Note: Yes, this exist (in framework 16), don't get fool by your language processor.
+        // https://cs.android.com/android/platform/superproject/+/android-latest-release:frameworks/base/core/java/android/widget/RemoteViews.java;l=9162;bpv=1?q=RemoteViews.ColorResources&ss=android%2Fplatform%2Fsuperproject
+        RemoteViews.ColorResources colorResources = RemoteViews.ColorResources.create(getContext(), colors);
+        if (colorResources == null) {
+            resetColorResources();
+            return;
+        }
+        super.setColorResources(colorResources);
     }
 
     @Override

--- a/src/com/android/launcher3/widget/LauncherAppWidgetHostView.java
+++ b/src/com/android/launcher3/widget/LauncherAppWidgetHostView.java
@@ -112,7 +112,7 @@ public class LauncherAppWidgetHostView extends BaseLauncherAppWidgetHostView
             return;
         }
 
-        // LC-Note: Yes, this exist (in framework 16), don't get fool by your language processor.
+        // LC-Note: Yes, this exist, don't get fool by your language processor.
         // https://cs.android.com/android/platform/superproject/+/android-latest-release:frameworks/base/core/java/android/widget/RemoteViews.java;l=9162;bpv=1?q=RemoteViews.ColorResources&ss=android%2Fplatform%2Fsuperproject
         RemoteViews.ColorResources colorResources = RemoteViews.ColorResources.create(getContext(), colors);
         if (colorResources == null) {


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Make widget follow launcher specific custom colour instead of device monet accent.

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Visual test on pixel 7 with custom colour accent

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved widget color resource handling when color data is missing, empty, or invalid.
  * Ensured widget colors reset correctly and valid color resources are applied consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->