### PR TITLE
feat: ignore diacritics in app search

### DIFF
--- a/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/apps/AppSearchProvider.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/apps/AppSearchProvider.kt
@@ -8,6 +8,7 @@ import app.lawnchair.search.algorithms.filterHiddenApps
 import com.android.launcher3.model.AllAppsList
 import com.android.launcher3.model.data.AppInfo
 import com.android.launcher3.search.StringMatcherUtility
+import java.text.Normalizer
 import java.util.Locale
 
 object AppSearchProvider {
@@ -19,10 +20,12 @@ object AppSearchProvider {
         val maxAppResults = prefs.maxAppSearchResultCount.firstCached()
         val enableFuzzySearch = prefs.enableFuzzySearch.firstCached()
 
+        val queryNormalized = stripDiacritics(query).lowercase(Locale.getDefault())
+
         val appResults = if (enableFuzzySearch) {
-            fuzzySearch(allApps.data, query, maxAppResults, hiddenApps, hiddenAppsInSearch)
+            fuzzySearch(allApps.data, queryNormalized, maxAppResults, hiddenApps, hiddenAppsInSearch)
         } else {
-            normalSearch(allApps.data, query, maxAppResults, hiddenApps, hiddenAppsInSearch)
+            normalSearch(allApps.data, queryNormalized, maxAppResults, hiddenApps, hiddenAppsInSearch)
         }
 
         return appResults.map { SearchResult.App(data = it) }
@@ -31,24 +34,22 @@ object AppSearchProvider {
     private fun normalSearch(apps: List<AppInfo>, query: String, maxResultsCount: Int, hiddenApps: Set<String>, hiddenAppsInSearch: String): List<AppInfo> {
         // Do an intersection of the words in the query and each title, and filter out all the
         // apps that don't match all of the words in the query.
-        val queryTextLower = query.lowercase(Locale.getDefault())
         val matcher = StringMatcherUtility.StringMatcher.getInstance()
         return apps.asSequence()
-            .filter { StringMatcherUtility.matches(queryTextLower, it.title.toString(), matcher) }
-            .filterHiddenApps(queryTextLower, hiddenApps, hiddenAppsInSearch)
+            .filter { StringMatcherUtility.matches(query, stripDiacritics(it.title.toString()), matcher) }
+            .filterHiddenApps(query, hiddenApps, hiddenAppsInSearch)
             .take(maxResultsCount)
             .toList()
     }
 
     private fun fuzzySearch(apps: List<AppInfo>, query: String, maxResultsCount: Int, hiddenApps: Set<String>, hiddenAppsInSearch: String): List<AppInfo> {
-        val queryTextLower = query.lowercase(Locale.getDefault())
         val filteredApps = apps.asSequence()
-            .filterHiddenApps(queryTextLower, hiddenApps, hiddenAppsInSearch)
+            .filterHiddenApps(query, hiddenApps, hiddenAppsInSearch)
             .toList()
 
         return filteredApps
             .mapNotNull { app ->
-                val matchResult = AppMatcher.match(app.title.toString(), queryTextLower)
+                val matchResult = AppMatcher.match(stripDiacritics(app.title.toString()), query)
                 if (matchResult.type == MatchType.NO_MATCH) null else Pair(app, matchResult)
             }
             .sortedWith(
@@ -59,5 +60,10 @@ object AppSearchProvider {
             )
             .map { it.first }
             .take(maxResultsCount)
+    }
+
+    private fun stripDiacritics(input: String): String {
+        return Normalizer.normalize(input, Normalizer.Form.NFKD)
+            .replace("\\p{M}", "")
     }
 }

--- a/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/apps/AppSearchProvider.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/engine/provider/apps/AppSearchProvider.kt
@@ -13,6 +13,8 @@ import java.util.Locale
 
 object AppSearchProvider {
 
+    private val DIACRITICS_REMOVE_PATTERN = "\\p{M}+".toRegex()
+
     fun search(context: Context, query: String, allApps: AllAppsList): List<SearchResult.App> {
         val prefs = PreferenceManager2.getInstance(context)
         val hiddenApps = prefs.hiddenApps.firstCached()
@@ -64,6 +66,6 @@ object AppSearchProvider {
 
     private fun stripDiacritics(input: String): String {
         return Normalizer.normalize(input, Normalizer.Form.NFKD)
-            .replace("\\p{M}", "")
+            .replace(DIACRITICS_REMOVE_PATTERN, "")
     }
 }


### PR DESCRIPTION
### Description

This PR makes it so the app search ignores (strips) diacritics and converts other non-ASCII character to their ASCII base characters.

### Reasoning

This is useful because typing a letter with a diacritic is usually slower, as it requires holding down the key, navigating to the right character etc.

As an example for how that applies in real life: I often want to open the app for the most common polish corner store chain - "żappka", usually this happens when the cashier has already scanned my daily Monster and a line of people behind me is inpatiently waiting on me to leave. Typing quickly, I often just type "z" instead of "ż", because that's what I'm used to and it's faster. Without this change, this sometimes led to situations where I had to clear the search field and type the name again, this time with "ż", which takes its time.

### Type of change

:x: **Bug fix** (A non-breaking change that fixes an issue)
:white_check_mark: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app search to match queries and app names regardless of accents or diacritical marks.
  * Applied consistent matching behavior across standard and fuzzy search.
  * Preserved hidden-app filtering while improving search accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->