### PR TITLE
fix: Disable App Prediction for pre Q device

### DIFF
--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -264,6 +264,7 @@
     <string name="global_predictions_label">Show suggestion features</string>
     <string name="app_predictions_label">App suggestions</string>
     <string name="prediction_mode_label">Suggestions provider</string>
+    <string name="app_predictions_disable_reason_pre_q_description">This feature requires at least Android 10 or higher</string>
     <string name="prediction_mode_system">System</string>
     <string name="prediction_mode_lawnchair" translatable="false">Lawnchair</string>
     <string name="prediction_mode_none">Off</string>

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -264,7 +264,7 @@
     <string name="global_predictions_label">Show suggestion features</string>
     <string name="app_predictions_label">App suggestions</string>
     <string name="prediction_mode_label">Suggestions provider</string>
-    <string name="app_predictions_disable_reason_pre_q_description">This feature requires at least Android 10 or higher</string>
+    <string name="app_predictions_disable_reason_pre_q_description">This feature requires Android 10 or higher</string>
     <string name="prediction_mode_system">System</string>
     <string name="prediction_mode_lawnchair" translatable="false">Lawnchair</string>
     <string name="prediction_mode_none">Off</string>

--- a/lawnchair/src/app/lawnchair/predictions/LawnchairAppPredictor.kt
+++ b/lawnchair/src/app/lawnchair/predictions/LawnchairAppPredictor.kt
@@ -2,6 +2,8 @@ package app.lawnchair.predictions
 
 import android.content.Context
 import android.content.pm.PackageManager
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.annotation.WorkerThread
 import com.android.launcher3.InvariantDeviceProfile
 import com.android.launcher3.LauncherModel
@@ -92,11 +94,13 @@ class LawnchairAppPredictor(private val context: Context) : StatsLogCompatManage
     }
 
     @WorkerThread
+    @RequiresApi(Build.VERSION_CODES.Q)
     override fun consume(event: EventEnum?, atomInfo: ItemInfo?) {
         MODEL_EXECUTOR.execute { handleEvent(event, atomInfo) }
     }
 
     @WorkerThread
+    @RequiresApi(Build.VERSION_CODES.Q)
     private fun handleEvent(event: EventEnum?, atomInfo: ItemInfo?) {
         val resolvedEvent = eventResolver.resolve(atomInfo)
 
@@ -122,6 +126,7 @@ class LawnchairAppPredictor(private val context: Context) : StatsLogCompatManage
     }
 
     @WorkerThread
+    @RequiresApi(Build.VERSION_CODES.Q)
     fun updates(
         model: LauncherModel,
         dataModel: BgDataModel,

--- a/lawnchair/src/app/lawnchair/predictions/LawnchairModelDelegate.kt
+++ b/lawnchair/src/app/lawnchair/predictions/LawnchairModelDelegate.kt
@@ -66,9 +66,12 @@ class LawnchairModelDelegate @Inject constructor(
         lawnchairPredictor.unregister()
         when (currentPredictionMode()) {
             SystemPredictor -> super.recreatePredictors()
+
             LawnchairPredictor -> if (Utilities.ATLEAST_Q) {
                 activateLawnchairPredictor()
-            } else clearPredictions()
+            } else {
+                clearPredictions()
+            }
 
             NoPredictor -> clearPredictions()
         }
@@ -90,7 +93,9 @@ class LawnchairModelDelegate @Inject constructor(
 
             LawnchairPredictor -> if (Utilities.ATLEAST_Q) {
                 updateLawnchairPredictions()
-            } else clearPredictions()
+            } else {
+                clearPredictions()
+            }
 
             NoPredictor -> clearPredictions()
         }

--- a/lawnchair/src/app/lawnchair/predictions/LawnchairModelDelegate.kt
+++ b/lawnchair/src/app/lawnchair/predictions/LawnchairModelDelegate.kt
@@ -1,10 +1,13 @@
 package app.lawnchair.predictions
 
 import android.content.Context
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.annotation.WorkerThread
 import app.lawnchair.preferences2.PreferenceManager2
 import app.lawnchair.preferences2.firstCached
 import com.android.launcher3.InvariantDeviceProfile
+import com.android.launcher3.Utilities
 import com.android.launcher3.dagger.ApplicationContext
 import com.android.launcher3.model.PredictedItemFactory
 import com.android.launcher3.model.QuickstepModelDelegate
@@ -63,7 +66,10 @@ class LawnchairModelDelegate @Inject constructor(
         lawnchairPredictor.unregister()
         when (currentPredictionMode()) {
             SystemPredictor -> super.recreatePredictors()
-            LawnchairPredictor -> activateLawnchairPredictor()
+            LawnchairPredictor -> if (Utilities.ATLEAST_Q) {
+                activateLawnchairPredictor()
+            } else clearPredictions()
+
             NoPredictor -> clearPredictions()
         }
     }
@@ -82,14 +88,17 @@ class LawnchairModelDelegate @Inject constructor(
                 mWidgetsRecommendationState.requestPredictionUpdate()
             }
 
-            LawnchairPredictor -> updateLawnchairPredictions()
+            LawnchairPredictor -> if (Utilities.ATLEAST_Q) {
+                updateLawnchairPredictions()
+            } else clearPredictions()
 
             NoPredictor -> clearPredictions()
         }
     }
 
     private fun currentPredictionMode(): PredictionMode {
-        if (!prefs2.enableGlobalPrediction.firstCached()) {
+        // All predictor targets can't be run on device older than Q
+        if (!Utilities.ATLEAST_Q || !prefs2.enableGlobalPrediction.firstCached()) {
             return NoPredictor
         }
         return prefs2.predictionMode.firstCached()
@@ -101,6 +110,7 @@ class LawnchairModelDelegate @Inject constructor(
         mWidgetsRecommendationState.destroyPredictor()
     }
 
+    @RequiresApi(Build.VERSION_CODES.Q)
     private fun activateLawnchairPredictor() {
         destroyPredictors()
         if (!mActive) return
@@ -116,6 +126,7 @@ class LawnchairModelDelegate @Inject constructor(
         updateLawnchairPredictions()
     }
 
+    @RequiresApi(Build.VERSION_CODES.Q)
     private fun updateLawnchairPredictions() {
         lawnchairPredictor.updates(
             model = mModel,

--- a/lawnchair/src/app/lawnchair/predictions/LawnchairPredictionEngine.kt
+++ b/lawnchair/src/app/lawnchair/predictions/LawnchairPredictionEngine.kt
@@ -6,12 +6,15 @@ import android.app.prediction.AppTargetId
 import android.content.ComponentName
 import android.content.Context
 import android.content.pm.LauncherApps
+import android.os.Build
 import android.os.Process
 import android.os.UserHandle
+import androidx.annotation.RequiresApi
 import app.lawnchair.preferences2.PreferenceManager2
 import app.lawnchair.preferences2.firstCached
 import com.android.launcher3.AppFilter
 import com.android.launcher3.LauncherSettings.Favorites.CONTAINER_HOTSEAT
+import com.android.launcher3.Utilities
 import com.android.launcher3.model.BgDataModel
 import com.android.launcher3.model.WidgetItem
 import com.android.launcher3.pm.UserCache
@@ -35,6 +38,7 @@ class LawnchairPredictionEngine(
      * @param count Maximum number of targets to return.
      * @param excludedKeys Store keys that should be skipped (e.g. occupied hotseat slots).
      */
+    @RequiresApi(Build.VERSION_CODES.Q)
     fun compileAppTargets(
         ranked: List<String>,
         count: Int,
@@ -75,6 +79,7 @@ class LawnchairPredictionEngine(
      * Compiles a ranked list of store keys into widget [AppTarget] entries by matching packages to
      * available widget providers.
      */
+    @RequiresApi(Build.VERSION_CODES.Q)
     fun compileWidgetTargets(
         ranked: List<String>,
         dataModel: BgDataModel,
@@ -234,6 +239,7 @@ class LawnchairPredictionEngine(
         }
     }
 
+    @RequiresApi(Build.VERSION_CODES.Q)
     private fun createAppTarget(
         prefix: String,
         componentName: ComponentName,

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/PredictionsPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/PredictionsPreferences.kt
@@ -44,6 +44,7 @@ import app.lawnchair.ui.preferences.components.layout.PreferenceLayout
 import app.lawnchair.ui.preferences.navigation.DismissedPredictionApps
 import app.lawnchair.util.lifecycleState
 import com.android.launcher3.R
+import com.android.launcher3.Utilities
 
 @Composable
 fun PredictionsPreferences(
@@ -100,6 +101,8 @@ private fun AppPredictionsFeature(
         dismissedPredictionAppsCount,
     )
 
+    val canUseAppPrediction = Utilities.ATLEAST_Q
+
     PreferenceGroup(
         heading = stringResource(R.string.app_predictions_label),
     ) {
@@ -107,6 +110,8 @@ private fun AppPredictionsFeature(
             adapter = predictionModeAdapter,
             entries = predictionModeEntries,
             label = stringResource(R.string.prediction_mode_label),
+            description = if (canUseAppPrediction) null else stringResource(R.string.app_predictions_disable_reason_pre_q_description),
+            enabled = canUseAppPrediction
         )
         when (predictionModeAdapter.state.value) {
             SystemPredictor -> SystemSuggestionsPreference()

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/PredictionsPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/PredictionsPreferences.kt
@@ -111,7 +111,7 @@ private fun AppPredictionsFeature(
             entries = predictionModeEntries,
             label = stringResource(R.string.prediction_mode_label),
             description = if (canUseAppPrediction) null else stringResource(R.string.app_predictions_disable_reason_pre_q_description),
-            enabled = canUseAppPrediction
+            enabled = canUseAppPrediction,
         )
         when (predictionModeAdapter.state.value) {
             SystemPredictor -> SystemSuggestionsPreference()


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Disable app prediction feature for Android 10, fix crash on AppTarget when attempting to use predictor.

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->

The method we call is only available in Android 10

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->


### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a clear explanation that app predictions require Android 10 or newer.
  * Prediction settings now indicate when the feature is unavailable on older Android versions.

* **Bug Fixes**
  * Prevented unsupported prediction functionality from running on devices below Android 10.
  * Automatically clears prediction data when predictions are unavailable or disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->