### PR TITLE
fix: Slider preference crash with VibrationAttributes

### DIFF
--- a/lawnchair/src/app/lawnchair/ui/preferences/components/controls/SliderHaptics.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/controls/SliderHaptics.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026, Lawnchair
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.lawnchair.ui.preferences.components.controls
+
+import android.os.Build
+import android.os.VibrationAttributes
+import androidx.annotation.Keep
+import androidx.annotation.RequiresApi
+import com.android.launcher3.util.MSDLPlayerWrapper
+import com.google.android.msdl.data.model.MSDLToken
+import com.google.android.msdl.domain.InteractionProperties
+
+@Keep
+@RequiresApi(Build.VERSION_CODES.S)
+internal fun playScaledSliderHaptic(
+    playerWrapper: MSDLPlayerWrapper,
+    token: MSDLToken,
+    scale: Float,
+) {
+    val properties = InteractionProperties.DynamicVibrationScale(
+        scale = scale,
+        vibrationAttributes = VibrationAttributes.Builder()
+            .setUsage(VibrationAttributes.USAGE_TOUCH)
+            .build(),
+    )
+    playerWrapper.playToken(token, properties)
+}

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/controls/SliderPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/controls/SliderPreference.kt
@@ -16,7 +16,6 @@
 
 package app.lawnchair.ui.preferences.components.controls
 
-import android.os.VibrationAttributes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -53,7 +52,6 @@ import com.android.launcher3.R
 import com.android.launcher3.Utilities
 import com.android.launcher3.util.MSDLPlayerWrapper
 import com.google.android.msdl.data.model.MSDLToken
-import com.google.android.msdl.domain.InteractionProperties
 import kotlin.math.roundToInt
 
 private enum class SliderThreshold {
@@ -133,15 +131,6 @@ private fun SliderPreference(
     var sliderValue by remember { mutableFloatStateOf(value) }
     var thresholdReached by remember { mutableStateOf<SliderThreshold?>(null) }
     val mMSDLPlayerWrapper = MSDLPlayerWrapper.INSTANCE.get(LocalContext.current)
-    val touchVibrationAttributes = remember {
-        if (Utilities.ATLEAST_S) {
-            VibrationAttributes.Builder()
-                .setUsage(VibrationAttributes.USAGE_TOUCH)
-                .build()
-        } else {
-            null
-        }
-    }
     val getAppropriateHaptic = if (step == 0f) {
         MSDLToken.DRAG_INDICATOR_CONTINUOUS
     } else {
@@ -212,19 +201,14 @@ private fun SliderPreference(
                         } else {
                             ((newValue - valueRange.start) / range).coerceIn(0f, 1f)
                         }
-                        val properties = touchVibrationAttributes?.let {
-                            InteractionProperties.DynamicVibrationScale(
-                                scale = scale,
-                                vibrationAttributes = it,
+                        if (Utilities.ATLEAST_S) {
+                            playScaledSliderHaptic(
+                                mMSDLPlayerWrapper,
+                                getAppropriateHaptic,
+                                scale,
                             )
-                        }
-                        if (properties == null) {
-                            mMSDLPlayerWrapper.playToken(getAppropriateHaptic)
                         } else {
-                            // Dynamic haptic scaling based on value,
-                            // the haptic goes from none/light to heavy depending on the value.
-                            // Supported on S+ platform
-                            mMSDLPlayerWrapper.playToken(getAppropriateHaptic, properties)
+                            mMSDLPlayerWrapper.playToken(getAppropriateHaptic)
                         }
                     }
                 },


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Fix crash on older device where VibrationAttributes does not exist at the time causing lawnchair settings to not open correctly.

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->


### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved slider haptic feedback on Android 12 and newer by supporting dynamic vibration intensity.
  * Preserved distinct haptic behavior for continuous and stepped sliders.

* **Bug Fixes**
  * Maintained standard slider vibration behavior on older Android versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->