### PR TITLE
fix: preserve foldable hotseat items across display changes

### DIFF
--- a/lawnchair/src/app/lawnchair/DeviceProfileOverrides.kt
+++ b/lawnchair/src/app/lawnchair/DeviceProfileOverrides.kt
@@ -136,14 +136,14 @@ class DeviceProfileOverrides @Inject constructor(
             numDockPages = prefs.dockPages.get().coerceIn(1, 5),
 
             foldableShownHotseatIcons = if (deviceType == InvariantDeviceProfile.TYPE_MULTI_DISPLAY) {
-                val folded = prefs.hotseatColumns.get()
-                val unfolded = previewOverrides.foldableDatabaseHotseatIcons ?: prefs.hotseatColumnsUnfolded.get()
-                folded.coerceAtMost(unfolded)
+                prefs.hotseatColumns.get()
             } else {
                 -1
             },
             foldableDatabaseHotseatIcons = if (deviceType == InvariantDeviceProfile.TYPE_MULTI_DISPLAY) {
-                previewOverrides.foldableDatabaseHotseatIcons ?: prefs.hotseatColumnsUnfolded.get()
+                val folded = prefs.hotseatColumns.get()
+                val unfolded = previewOverrides.foldableDatabaseHotseatIcons ?: prefs.hotseatColumnsUnfolded.get()
+                folded.coerceAtLeast(unfolded)
             } else {
                 -1
             },

--- a/lawnchair/src/app/lawnchair/DeviceProfileOverrides.kt
+++ b/lawnchair/src/app/lawnchair/DeviceProfileOverrides.kt
@@ -175,7 +175,7 @@ class DeviceProfileOverrides @Inject constructor(
             }
 
             // Ensure database can hold enough icons for multi-row / multi-page dock
-            val requiredSlots = idp.numShownHotseatIcons * numHotseatRows * numDockPages
+            val requiredSlots = idp.numDatabaseHotseatIcons * numHotseatRows * numDockPages
             if (idp.numDatabaseHotseatIcons < requiredSlots) {
                 idp.numDatabaseHotseatIcons = requiredSlots
             }


### PR DESCRIPTION
### Description

Prevents foldable hotseat items from disappearing when switching between folded and unfolded displays. The folded profile now keeps its configured icon count, while the shared hotseat database is sized for the larger of the folded and unfolded configurations.

### Reasoning

The Favorites database is shared across both foldable display states. During a display change, Launcher reloads the model and rejects hotseat ranks outside `numDatabaseHotseatIcons`; rejected items are then removed from the database. If the unfolded hotseat count was smaller than the folded count, unfolding reduced the database bound and permanently removed the remaining folded hotseat items.

Using the larger configured count for the database preserves every stored rank. Valid foldable configurations retain their separate folded and unfolded counts; an invalid smaller unfolded count is safely normalized at runtime instead of deleting items.

### Testing

Automated:
- `./gradlew spotlessCheck`
- `./gradlew assembleLawnWithQuickstepNightlyRelease`
- `./gradlew assembleLawnWithQuickstepGithubDebug`
- `./gradlew assembleLawnWithQuickstepPlayDebug`

Manual verification plan:
- Configure five folded dock icons and three unfolded dock icons; fold and unfold repeatedly and confirm all five items remain stored and visible after returning to the folded display.
- Configure five folded dock icons and six unfolded dock icons; confirm each display retains its configured count across repeated transitions.

### Type of change

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hotseat icon handling on multi-display foldable devices.
  * Updated database capacity calculations to reflect configured hotseat icons.
  * Preserved preview overrides while selecting the appropriate folded or unfolded icon count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->