### PR TITLE
fix: Use old widget theme implementation on Android 12 and lower

### DIFF
--- a/src/com/android/launcher3/widget/LauncherAppWidgetHostView.java
+++ b/src/com/android/launcher3/widget/LauncherAppWidgetHostView.java
@@ -43,6 +43,7 @@ import androidx.annotation.Nullable;
 import com.android.launcher3.CheckLongPressHelper;
 import com.android.launcher3.Flags;
 import com.android.launcher3.R;
+import com.android.launcher3.Utilities;
 import com.android.launcher3.model.data.ItemInfo;
 import com.android.launcher3.util.Themes;
 import com.android.launcher3.views.ActivityContext;
@@ -112,14 +113,20 @@ public class LauncherAppWidgetHostView extends BaseLauncherAppWidgetHostView
             return;
         }
 
-        // LC-Note: Yes, this exist, don't get fool by your language processor.
-        // https://cs.android.com/android/platform/superproject/+/android-latest-release:frameworks/base/core/java/android/widget/RemoteViews.java;l=9162;bpv=1?q=RemoteViews.ColorResources&ss=android%2Fplatform%2Fsuperproject
-        RemoteViews.ColorResources colorResources = RemoteViews.ColorResources.create(getContext(), colors);
-        if (colorResources == null) {
-            resetColorResources();
-            return;
+        // LC-Note: Fix widget idmap theming issue
+        if (Utilities.ATLEAST_T) {
+            // LC-Note: Yes, this exist, don't get fool by your language processor.
+            // https://cs.android.com/android/platform/superproject/+/android-latest-release:frameworks/base/core/java/android/widget/RemoteViews.java;l=9162;bpv=1?q=RemoteViews.ColorResources&ss=android%2Fplatform%2Fsuperproject
+            RemoteViews.ColorResources colorResources = RemoteViews.ColorResources.create(getContext(), colors);
+            if (colorResources == null) {
+                resetColorResources();
+                return;
+            }
+            super.setColorResources(colorResources);
+        } else {
+            // LC-Note: Fall back for Android 12 impl
+            super.setColorResources(colors);
         }
-        super.setColorResources(colorResources);
     }
 
     @Override


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Fix regression in #7135 where older Android version will crash

Fixes #7146
Fixes #7144

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

1. Open the app
2. Test theming of the widget by setting custom home screen colour to custom or any other colour that isn't the same as system/wallpaper

Observe the result
* Lower than Android 11
	* Widget should use their older or unthemed design in respective to their API level without crashing
* Android 12.0 to Android 12.1
	* Widget should be themed correctly by the launcher without crashing
* Android 13 to Android 17 and beyond
	* Widget should be themed correctly by the launcher without erroring out sliently in logcat

Testing on these devices:

Firebase
* Google Pixel 5 - Android 11
* Google Pixel 6 - Android 12.0
* Google Pixel 6a - Android 12.1
* Motorola Moto G Play (2023) - Android 13
* Google Pixel 9 - Android 14

Local
* Huawei Honor 10 lite - Android 10 (Huawei software)
* Nothing Phone (3a)-series - Android 16 Initial (rooted) + Quickstep
* Google Pixel 7 - Android 17 QPR2 Beta 2 (identified as 37.2-beta1)

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved widget color resource handling across Android versions.
  * Widgets on Android 12 and earlier now apply color resources more reliably.
  * Preserved safe fallback behavior when color resource conversion fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->