### PR TITLE
fix: Blank QSB space being override by hotseat grid adjustment

### DIFF
--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
@@ -130,7 +130,6 @@ class PreferenceManager2 @Inject constructor(
         defaultValue = HotseatMode.fromString(context.getString(R.string.config_default_hotseat_mode)),
         parse = { HotseatMode.fromString(it) },
         save = { it.toString() },
-        onSet = { reloadHelper.restart() },
     )
 
     val iconShape = preference(
@@ -293,10 +292,6 @@ class PreferenceManager2 @Inject constructor(
     val isHotseatEnabled = preference(
         key = booleanPreferencesKey(name = "pref_show_hotseat"),
         defaultValue = context.resources.getBoolean(R.bool.config_default_show_hotseat),
-        onSet = {
-            reloadHelper.recreate()
-            reloadHelper.reloadGrid()
-        },
     )
 
     val hotseatQsbProvider = preference(
@@ -306,7 +301,6 @@ class PreferenceManager2 @Inject constructor(
         } ?: QsbSearchProvider.resolveDefault(context),
         parse = { QsbSearchProvider.fromId(it) },
         save = { it.id },
-        onSet = { reloadHelper.recreate() },
     )
 
     val hotseatQsbForceWebsite = preference(
@@ -814,7 +808,6 @@ class PreferenceManager2 @Inject constructor(
     val enableLabelInDock = preference(
         key = booleanPreferencesKey(name = "enable_label_dock"),
         defaultValue = false,
-        onSet = { reloadHelper.reloadGrid() },
     )
 
     val doubleTapGestureHandler = serializablePreference<GestureHandlerConfig>(
@@ -894,6 +887,33 @@ class PreferenceManager2 @Inject constructor(
                 L3ThemeManager.INSTANCE.get(context)
                 LauncherAppState.getInstance(context).model.reloadIfActive()
             }
+            .launchIn(scope)
+
+        hotseatMode.get()
+            .drop(1)
+            .distinctUntilChanged()
+            .onEach { reloadHelper.restart() }
+            .launchIn(scope)
+
+        isHotseatEnabled.get()
+            .drop(1)
+            .distinctUntilChanged()
+            .onEach {
+                reloadHelper.recreate()
+                reloadHelper.reloadGrid()
+            }
+            .launchIn(scope)
+
+        hotseatQsbProvider.get()
+            .drop(1)
+            .distinctUntilChanged()
+            .onEach { reloadHelper.recreate() }
+            .launchIn(scope)
+
+        enableLabelInDock.get()
+            .drop(1)
+            .distinctUntilChanged()
+            .onEach { reloadHelper.reloadGrid() }
             .launchIn(scope)
     }
 

--- a/src/com/android/launcher3/DeviceProfile.java
+++ b/src/com/android/launcher3/DeviceProfile.java
@@ -525,7 +525,7 @@ public class DeviceProfile {
 
         numShownAllAppsColumns = displayOptionSpec.numAllAppsColumns;
 
-        int hotseatBarBottomSpace = !isQsbEnable ? 0 : pxFromDp(inv.hotseatBarBottomSpace[mTypeIndex], mMetrics);
+        int hotseatBarBottomSpace = pxFromDp(inv.hotseatBarBottomSpace[mTypeIndex], mMetrics);
         int minQsbMargin = res.getDimensionPixelSize(R.dimen.min_qsb_margin);
 
         if (mIsResponsiveGrid) {
@@ -552,6 +552,7 @@ public class DeviceProfile {
         }
 
         if (!isQsbEnable) {
+            hotseatBarBottomSpace = 0;
             hotseatQsbSpace = 0;
         }
 


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Fix search bar dock couldn't be zero because the code get override by hotseat grid adjustment no matter what hence showing a blank space that was once a QSB but you couldn't put any app over it.

Fix Hotseat prefs read cached preference too early causing some DP changes to be dropped.

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Visual test on pixel 7

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected hotseat bottom spacing when the search bar is unavailable.
  * Ensured launcher layouts maintain consistent spacing across responsive and non-responsive configurations.
  * Improved hotseat preference updates so changes to hotseat mode, visibility, search provider, and labels are applied reliably without requiring inconsistent manual refreshes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->