### PR TITLE
fix: initialize window manager in grid previews

### DIFF
--- a/src/com/android/launcher3/InvariantDeviceProfile.java
+++ b/src/com/android/launcher3/InvariantDeviceProfile.java
@@ -343,11 +343,7 @@ public class InvariantDeviceProfile {
     }
 
     public InvariantDeviceProfile(Context context, DeviceProfileOverrides.DBGridInfo dbGridInfo) {
-        this.mPrefs = LauncherPrefs.get(context.getApplicationContext());
-        this.mThemeManager = ThemeManager.INSTANCE.get(context.getApplicationContext());
-        this.mDisplayController = DisplayController.INSTANCE.get(context.getApplicationContext());
-        String gridName = DeviceProfileOverrides.INSTANCE.get(context).getGridName(dbGridInfo);
-        initGrid(context, gridName, dbGridInfo, null);
+        this(context, dbGridInfo, null);
     }
 
     public InvariantDeviceProfile(Context context, DeviceProfileOverrides.DBGridInfo dbGridInfo,
@@ -355,6 +351,7 @@ public class InvariantDeviceProfile {
         this.mPrefs = LauncherPrefs.get(context.getApplicationContext());
         this.mThemeManager = ThemeManager.INSTANCE.get(context.getApplicationContext());
         this.mDisplayController = DisplayController.INSTANCE.get(context.getApplicationContext());
+        this.mWMProxy = WindowManagerProxy.INSTANCE.get(context.getApplicationContext());
         String gridName = DeviceProfileOverrides.INSTANCE.get(context).getGridName(dbGridInfo);
         initGrid(context, gridName, dbGridInfo, previewOverrides);
     }


### PR DESCRIPTION
## Summary

The preview `InvariantDeviceProfile` constructors did not initialize `mWMProxy`. On unfolded foldables using the tablet/two-panel profile, this caused a crash when `DeviceProfile` called `isTaskbarDrawnInProcess()`.

This change initializes `mWMProxy` through the app-scoped `WindowManagerProxy` instance and delegates the two-argument preview constructor to keep initialization consistent.

Fixes #7150

## Testing

- Verified Dock settings opens without crashing on an unfolded foldable (`1968 × 2184` inner display).
- Confirmed the previous `WindowManagerProxy.isTaskbarDrawnInProcess()` null-pointer crash no longer appears in logcat.
- `spotlessCheck` and all APK build variants passed.