### PR TITLE
fix: prevent crash when themed clock drawable is unavailable

### DIFF
--- a/lawnchair/src/app/lawnchair/icons/LawnchairIconProvider.kt
+++ b/lawnchair/src/app/lawnchair/icons/LawnchairIconProvider.kt
@@ -176,7 +176,7 @@ class LawnchairIconProvider @Inject constructor(
                     // the icon supports dynamic clock, use dynamic themed clock
                     themedIcon =
                         ClockDrawableWrapper.forPackage(mContext, mClock.packageName, iconDpi)
-                            .getMonochrome()
+                            ?.getMonochrome()
                 }
 
                 packageName == mClock.packageName -> {


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

This PR prevents Lawnchair from crashing when an icon pack provides dynamic clock metadata but the configured clock package cannot provide a themed clock drawable. This was reproducible when applying the OneYou Themed icon pack.

### Reasoning

`ClockDrawableWrapper.forPackage()` can return `null` when the clock package is unavailable, lacks the required metadata, or its drawable cannot be loaded. Lawnchair previously called `getMonochrome()` on this nullable result, causing a `NullPointerException` while loading the icon cache. Using a safe call allows the existing icon-pack or system icon fallback to be used instead.

### Testing

I built and installed the fixed build on my phone, set the icon pack to OneYou Themed, and saw that it didn't crash anymore.

### Type of change

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
:x: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for dynamic clock-themed icons when the clock icon provider is unavailable.
  * Prevented potential errors during monochrome icon lookup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->