### PR TITLE
fix: honor force monochrome icon preference

### DIFF
--- a/lawnchair/src/app/lawnchair/icons/LawnchairThemeManager.kt
+++ b/lawnchair/src/app/lawnchair/icons/LawnchairThemeManager.kt
@@ -13,6 +13,7 @@ import com.android.launcher3.concurrent.annotations.Ui
 import com.android.launcher3.dagger.ApplicationContext
 import com.android.launcher3.dagger.LauncherAppSingleton
 import com.android.launcher3.graphics.ThemeManager
+import com.android.launcher3.icons.mono.MonoIconThemeController
 import com.android.launcher3.util.DaggerSingletonTracker
 import com.android.launcher3.util.LooperExecutor
 import javax.inject.Inject
@@ -118,15 +119,26 @@ constructor(
                 PathShapeDelegate(currentFolderShape)
             }
 
+        val themeController = iconControllerFactory.createThemeController()?.let {
+            if (prefs1.forceIconMonochrome.get()) {
+                FORCED_MONO_THEME_CONTROLLER
+            } else {
+                MONO_THEME_CONTROLLER
+            }
+        }
+
         return IconState(
             iconMask = combinedKey,
             folderRadius = 1f,
             shapeRadius = 1f,
-            themeController = iconControllerFactory.createThemeController(),
+            themeController = themeController,
             iconShape = appShape,
             folderShape = folderShape,
         )
     }
 }
 
+// Reuse controllers to allow the equality check in verifyIconState.
+private val MONO_THEME_CONTROLLER = MonoIconThemeController()
+private val FORCED_MONO_THEME_CONTROLLER = MonoIconThemeController(shouldForceThemeIcon = true)
 private const val TAG = "LawnchairThemeManager"

--- a/tests/multivalentTests/src/app/lawnchair/icons/LawnchairThemeManagerTest.kt
+++ b/tests/multivalentTests/src/app/lawnchair/icons/LawnchairThemeManagerTest.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2026, Lawnchair
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.lawnchair.icons
+
+import android.graphics.Color
+import android.graphics.drawable.AdaptiveIconDrawable
+import android.graphics.drawable.ColorDrawable
+import android.platform.test.annotations.EnableFlags
+import android.platform.test.flag.junit.SetFlagsRule
+import android.util.DisplayMetrics
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SmallTest
+import app.lawnchair.preferences.PreferenceManager
+import com.android.launcher3.FakeLauncherPrefs
+import com.android.launcher3.Flags
+import com.android.launcher3.dagger.LauncherAppComponent
+import com.android.launcher3.dagger.LauncherAppSingleton
+import com.android.launcher3.graphics.ThemeManager
+import com.android.launcher3.icons.BaseIconFactory
+import com.android.launcher3.icons.BitmapInfo
+import com.android.launcher3.icons.mono.MonoIconThemeControllerTest.Companion.ensureBitmapSerializationSupported
+import com.android.launcher3.util.AllModulesForTest
+import com.android.launcher3.util.Executors.MAIN_EXECUTOR
+import com.android.launcher3.util.FakePrefsModule
+import com.android.launcher3.util.SandboxApplication
+import com.android.launcher3.util.TestUtil
+import com.google.common.truth.Truth.assertThat
+import dagger.Component
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@SmallTest
+@RunWith(AndroidJUnit4::class)
+class LawnchairThemeManagerTest {
+
+    @get:Rule val context = SandboxApplication()
+    @get:Rule val setFlagsRule = SetFlagsRule()
+
+    private lateinit var themeManager: ThemeManager
+    private lateinit var prefs: PreferenceManager
+
+    @Before
+    fun setUp() {
+        context.initDaggerComponent(DaggerLawnchairThemeManagerTestComponent.builder())
+        themeManager = ThemeManager.INSTANCE[context]
+        prefs = PreferenceManager.INSTANCE[context]
+        themeManager.isMonoThemeEnabled = false
+        prefs.forceIconMonochrome.set(false)
+        waitForPreferenceChanges()
+    }
+
+    @Test
+    @EnableFlags(Flags.FLAG_FORCE_MONOCHROME_APP_ICONS)
+    fun `force monochrome themes unsupported adaptive icons`() {
+        ensureBitmapSerializationSupported()
+        prefs.forceIconMonochrome.set(true)
+        themeManager.isMonoThemeEnabled = true
+        waitForPreferenceChanges()
+
+        val themedBitmap = themeManager.themeController!!.createThemedBitmap(
+            adaptiveIcon(monochrome = null),
+            BitmapInfo.LOW_RES_INFO,
+            BaseIconFactory(context, DisplayMetrics.DENSITY_MEDIUM, 30),
+        )
+
+        assertThat(themedBitmap).isNotNull()
+    }
+
+    @Test
+    fun `disabled force monochrome only themes supported adaptive icons`() {
+        themeManager.isMonoThemeEnabled = true
+        waitForPreferenceChanges()
+        val iconFactory = BaseIconFactory(context, DisplayMetrics.DENSITY_MEDIUM, 30)
+
+        assertThat(
+            themeManager.themeController!!.createThemedBitmap(
+                adaptiveIcon(monochrome = ColorDrawable(Color.RED)),
+                BitmapInfo.LOW_RES_INFO,
+                iconFactory,
+            )
+        ).isNotNull()
+        assertThat(
+            themeManager.themeController!!.createThemedBitmap(
+                adaptiveIcon(monochrome = null),
+                BitmapInfo.LOW_RES_INFO,
+                iconFactory,
+            )
+        ).isNull()
+    }
+
+    @Test
+    fun `force monochrome does not enable themed icons`() {
+        prefs.forceIconMonochrome.set(true)
+        waitForPreferenceChanges()
+        assertThat(themeManager.themeController).isNull()
+
+        prefs.forceIconMonochrome.set(false)
+        waitForPreferenceChanges()
+        assertThat(themeManager.themeController).isNull()
+    }
+
+    @Test
+    fun `force monochrome change updates icon state and notifies listeners`() {
+        themeManager.isMonoThemeEnabled = true
+        waitForPreferenceChanges()
+        val previousState = themeManager.iconState
+        var callbackCalled = false
+        themeManager.addChangeListener { callbackCalled = true }
+
+        prefs.forceIconMonochrome.set(true)
+        waitForPreferenceChanges()
+
+        assertThat(themeManager.iconState).isNotEqualTo(previousState)
+        assertThat(callbackCalled).isTrue()
+    }
+
+    private fun adaptiveIcon(monochrome: ColorDrawable?) =
+        AdaptiveIconDrawable(ColorDrawable(Color.BLACK), null, monochrome)
+
+    private fun waitForPreferenceChanges() {
+        TestUtil.runOnExecutorSync(MAIN_EXECUTOR) {}
+    }
+}
+
+@LauncherAppSingleton
+@Component(
+    modules = [AllModulesForTest::class, FakePrefsModule::class, ThemeManagerModule::class]
+)
+interface LawnchairThemeManagerTestComponent : LauncherAppComponent {
+
+    override fun getLauncherPrefs(): FakeLauncherPrefs
+
+    @Component.Builder
+    interface Builder : LauncherAppComponent.Builder {
+
+        override fun build(): LawnchairThemeManagerTestComponent
+    }
+}


### PR DESCRIPTION
### Description

Update `LawnchairThemeManager` at the point where it builds `IconState` so themed-icon enablement continues to come from the existing controller factory, while the Lawnchair `forceIconMonochrome` preference determines whether the monochrome controller may synthesize a themed layer for unsupported adaptive icons. Keep the controller absent when themed icons are disabled, and keep non-forced behavior when themed icons are enabled but the fallback preference is off, so this remains an opt-in compatibility path rather than a blanket restyling change. Continue using the existing preference listener and icon-state key to notify theme listeners and invalidate icon caches when the option changes.

Enabling themed system icons leaves apps that do not publish a monochrome adaptive-icon layer untinted, even though Lawnchair exposes a “Force monochrome” option specifically for unsupported apps. The preference is displayed and included in Lawnchair's icon-state cache key, but the production theme-controller path in `LawnchairThemeManager` delegates to the generic controller factory without using the preference value. As a result, selecting system icons cannot reliably request generated monochrome variants for the unsupported apps shown in issue #6962. The fix should preserve native app monochrome layers and themed icon-pack overrides while making the existing fallback option effective for original system icons.

Fixes #6962

### Reasoning

Not applicable to this change.

### Testing

Not applicable to this change.

### Type of change

:x: **Bug fix** (A non-breaking change that fixes an issue)
:x: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved monochrome icon theme handling, including forced monochrome modes.
  - Preserved consistent icon appearance when switching or validating theme states.
  - Improved support for adaptive icons within themed icon configurations.
- **Bug Fixes**
  - Improved synchronization between icon theme preferences and displayed icons.
  - Ensured theme changes notify the launcher correctly and update icon styling reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->