### PR TITLE
feat: allow customizing icons and labels of pinned shortcuts

### DIFF
--- a/lawnchair/src/app/lawnchair/data/iconoverride/IconOverrideDao.kt
+++ b/lawnchair/src/app/lawnchair/data/iconoverride/IconOverrideDao.kt
@@ -20,6 +20,9 @@ interface IconOverrideDao {
     @Query("SELECT * FROM iconoverride")
     fun observeAll(): Flow<List<IconOverride>>
 
+    @Query("SELECT * FROM iconoverride")
+    suspend fun getAll(): List<IconOverride>
+
     @Query("SELECT * FROM iconoverride WHERE target = :target")
     fun observeTarget(target: ComponentKey): Flow<IconOverride?>
 

--- a/lawnchair/src/app/lawnchair/data/iconoverride/IconOverrideRepository.kt
+++ b/lawnchair/src/app/lawnchair/data/iconoverride/IconOverrideRepository.kt
@@ -66,6 +66,11 @@ class IconOverrideRepository @Inject constructor(
         }
     }
 
+    /**
+     * Loads the overrides from the database on the calling thread and caches the result, unless a
+     * newer map was published while the query was in flight. See [overridesMap] for why the first
+     * read cannot wait for the observer.
+     */
     private fun loadOverridesBlocking(): Map<ComponentKey, IconPickerItem> {
         val loaded = try {
             runBlocking { dao.getAll() }.toOverridesMap()
@@ -97,6 +102,7 @@ class IconOverrideRepository @Inject constructor(
         _overridesMap?.let { _overridesMap = transform(it) }
     }
 
+    /** Rows keyed the way [overridesMap] serves them. */
     private fun List<IconOverride>.toOverridesMap() = associateBy(
         keySelector = { it.target },
         valueTransform = { it.iconPickerItem },

--- a/lawnchair/src/app/lawnchair/data/iconoverride/IconOverrideRepository.kt
+++ b/lawnchair/src/app/lawnchair/data/iconoverride/IconOverrideRepository.kt
@@ -2,6 +2,7 @@ package app.lawnchair.data.iconoverride
 
 import android.content.Context
 import android.os.UserHandle
+import android.util.Log
 import app.lawnchair.data.AppDatabase
 import app.lawnchair.icons.picker.IconPickerItem
 import com.android.launcher3.LauncherAppState
@@ -19,6 +20,7 @@ import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
+import kotlinx.coroutines.runBlocking
 
 @LauncherAppSingleton
 class IconOverrideRepository @Inject constructor(
@@ -29,20 +31,33 @@ class IconOverrideRepository @Inject constructor(
     private val dao = AppDatabase.INSTANCE.get(context).iconOverrideDao()
 
     @Volatile
-    private var _overridesMap = mapOf<ComponentKey, IconPickerItem>()
-    val overridesMap get() = _overridesMap
+    private var _overridesMap: Map<ComponentKey, IconPickerItem>? = null
 
     private val updatePackageQueue = ConcurrentLinkedQueue<ComponentKey>()
+
+    /**
+     * The overrides currently in effect.
+     *
+     * Loaded on first read rather than waiting for [IconOverrideDao.observeAll]. That flow only
+     * delivers once the main thread gets a turn, while the icon pipeline reads this from the model
+     * worker during the very first load after a cold start — so waiting for it hands out an empty
+     * map, which both loads un-overridden icons and computes an override-free freshness id.
+     * [com.android.launcher3.icons.cache.IconCacheUpdateHandler] then writes that pair into the
+     * icon cache as though it were current, so the lost override survives every later start.
+     *
+     * The first read runs a database query and blocks. It usually falls to the model worker during
+     * the loader, but a UI path can get there first — Customize loads a preview icon straight from
+     * its click handler — so this is not safe to annotate as worker-thread only.
+     */
+    val overridesMap: Map<ComponentKey, IconPickerItem>
+        get() = _overridesMap ?: loadOverridesBlocking()
 
     init {
         scope.launch {
             dao.observeAll()
                 .flowOn(Dispatchers.Main)
                 .collect { overrides ->
-                    _overridesMap = overrides.associateBy(
-                        keySelector = { it.target },
-                        valueTransform = { it.iconPickerItem },
-                    )
+                    publish(overrides.toOverridesMap())
                     while (updatePackageQueue.isNotEmpty()) {
                         val target = updatePackageQueue.poll() ?: continue
                         updatePackageIcons(target)
@@ -51,17 +66,53 @@ class IconOverrideRepository @Inject constructor(
         }
     }
 
+    private fun loadOverridesBlocking(): Map<ComponentKey, IconPickerItem> {
+        val loaded = try {
+            runBlocking { dao.getAll() }.toOverridesMap()
+        } catch (t: Throwable) {
+            // Deliberately not cached: an empty map is the state that corrupts the icon cache, so
+            // let the next reader try again instead of settling on it.
+            Log.e(TAG, "Unable to load icon overrides", t)
+            return emptyMap()
+        }
+        // The query ran outside the lock, so anything published while it was in flight is newer
+        // than this snapshot and wins.
+        return synchronized(this) { _overridesMap ?: loaded.also { _overridesMap = it } }
+    }
+
+    /** Replaces the map wholesale. Safe before the first read, since it is a complete state. */
+    @Synchronized
+    private fun publish(overrides: Map<ComponentKey, IconPickerItem>) {
+        _overridesMap = overrides
+    }
+
+    /**
+     * Applies [transform] to an already-loaded map. A map that has not been read yet is left alone:
+     * the row is already committed, so the first read picks it up.
+     */
+    @Synchronized
+    private fun patch(
+        transform: (Map<ComponentKey, IconPickerItem>) -> Map<ComponentKey, IconPickerItem>,
+    ) {
+        _overridesMap?.let { _overridesMap = transform(it) }
+    }
+
+    private fun List<IconOverride>.toOverridesMap() = associateBy(
+        keySelector = { it.target },
+        valueTransform = { it.iconPickerItem },
+    )
+
     suspend fun setOverride(target: ComponentKey, item: IconPickerItem) {
         dao.insert(IconOverride(target, item))
         // Keep the in-memory map in sync before any icon reload. The Room Flow update is
         // async and can race with onAppIconChanged / forceReload, leaving stale icons cached.
-        _overridesMap = _overridesMap + (target to item)
+        patch { it + (target to item) }
         updatePackageQueue.offer(target)
     }
 
     suspend fun deleteOverride(target: ComponentKey) {
         dao.delete(target)
-        _overridesMap = _overridesMap - target
+        patch { it - target }
         updatePackageQueue.offer(target)
     }
 
@@ -86,7 +137,7 @@ class IconOverrideRepository @Inject constructor(
 
     suspend fun deleteAll() {
         dao.deleteAll()
-        _overridesMap = emptyMap()
+        publish(emptyMap())
         LauncherAppState.getInstance(context).model.reloadIfActive()
     }
 
@@ -101,6 +152,8 @@ class IconOverrideRepository @Inject constructor(
     }
 
     companion object {
+        private const val TAG = "IconOverrideRepository"
+
         @JvmField
         val INSTANCE = DaggerSingletonObject(LauncherAppComponent::getIconOverrideRepository)
     }

--- a/lawnchair/src/app/lawnchair/data/iconoverride/IconOverrideRepository.kt
+++ b/lawnchair/src/app/lawnchair/data/iconoverride/IconOverrideRepository.kt
@@ -38,21 +38,34 @@ class IconOverrideRepository @Inject constructor(
     /**
      * The overrides currently in effect.
      *
-     * Loaded on first read rather than waiting for [IconOverrideDao.observeAll]. That flow only
-     * delivers once the main thread gets a turn, while the icon pipeline reads this from the model
+     * Loaded when this repository is built, and by the first read if that has not landed yet,
+     * rather than waiting for [IconOverrideDao.observeAll]. That flow only delivers once the main
+     * thread gets a turn, while the icon pipeline reads this from the model
      * worker during the very first load after a cold start — so waiting for it hands out an empty
      * map, which both loads un-overridden icons and computes an override-free freshness id.
      * [com.android.launcher3.icons.cache.IconCacheUpdateHandler] then writes that pair into the
      * icon cache as though it were current, so the lost override survives every later start.
      *
-     * The first read runs a database query and blocks. It usually falls to the model worker during
-     * the loader, but a UI path can get there first — Customize loads a preview icon straight from
-     * its click handler — so this is not safe to annotate as worker-thread only.
+     * A read that arrives before the preload in [init] has finished runs the query itself and
+     * blocks. That normally falls to the model worker during the loader, but a UI path can get
+     * there first — Customize loads a preview icon straight from its click handler — so this is
+     * not safe to annotate as worker-thread only.
      */
     val overridesMap: Map<ComponentKey, IconPickerItem>
         get() = _overridesMap ?: loadOverridesBlocking()
 
     init {
+        // Fill the map as soon as the singleton exists, off whatever thread built it, so that the
+        // readers above normally find it loaded instead of running the query themselves. The
+        // blocking path stays as the fallback: a reader that arrives first still needs the real
+        // map rather than an empty one, for the reason [overridesMap] documents.
+        scope.launch(Dispatchers.IO) {
+            try {
+                cacheIfUnloaded(dao.getAll().toOverridesMap())
+            } catch (t: Throwable) {
+                Log.e(TAG, "Unable to preload icon overrides", t)
+            }
+        }
         scope.launch {
             dao.observeAll()
                 .flowOn(Dispatchers.Main)
@@ -80,10 +93,18 @@ class IconOverrideRepository @Inject constructor(
             Log.e(TAG, "Unable to load icon overrides", t)
             return emptyMap()
         }
-        // The query ran outside the lock, so anything published while it was in flight is newer
-        // than this snapshot and wins.
-        return synchronized(this) { _overridesMap ?: loaded.also { _overridesMap = it } }
+        return cacheIfUnloaded(loaded)
     }
+
+    /**
+     * Caches [loaded] unless the map is already filled, and returns whichever map is in effect.
+     * Queries run outside the lock, so anything published while one was in flight is newer than
+     * its result and wins.
+     */
+    @Synchronized
+    private fun cacheIfUnloaded(
+        loaded: Map<ComponentKey, IconPickerItem>,
+    ): Map<ComponentKey, IconPickerItem> = _overridesMap ?: loaded.also { _overridesMap = it }
 
     /** Replaces the map wholesale. Safe before the first read, since it is a complete state. */
     @Synchronized
@@ -92,8 +113,8 @@ class IconOverrideRepository @Inject constructor(
     }
 
     /**
-     * Applies [transform] to an already-loaded map. A map that has not been read yet is left alone:
-     * the row is already committed, so the first read picks it up.
+     * Applies [transform] to an already-loaded map. A map that has not loaded yet is left alone:
+     * the row is already committed, so a load in flight or the observer picks it up.
      */
     @Synchronized
     private fun patch(

--- a/lawnchair/src/app/lawnchair/icons/ShortcutIconOverrides.kt
+++ b/lawnchair/src/app/lawnchair/icons/ShortcutIconOverrides.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026, Lawnchair
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.lawnchair.icons
+
+import android.content.Context
+import android.content.pm.ShortcutInfo
+import android.graphics.drawable.Drawable
+import android.util.Log
+import app.lawnchair.data.iconoverride.IconOverrideRepository
+import app.lawnchair.gestures.ui.LawnchairShortcutActivity
+import app.lawnchair.icons.iconpack.IconPackProvider
+import app.lawnchair.preferences.PreferenceManager
+import com.android.launcher3.model.data.ItemInfo
+import com.android.launcher3.shortcuts.ShortcutKey
+import com.android.launcher3.util.ComponentKey
+
+/**
+ * Per-shortcut icon and label overrides for pinned deep shortcuts.
+ *
+ * These reuse the storage that already backs per-app overrides: [ShortcutKey] is a [ComponentKey]
+ * whose class name is the shortcut id, so a shortcut override is just another row keyed by the
+ * publisher package and that id.
+ */
+object ShortcutIconOverrides {
+
+    private const val TAG = "ShortcutIconOverrides"
+
+    fun keyFor(shortcutInfo: ShortcutInfo): ComponentKey = ShortcutKey.fromInfo(shortcutInfo)
+
+    /**
+     * Whether [itemInfo] can carry an override at all.
+     *
+     * Shortcut ids are chosen by the publishing app, so unlike an activity class name one may
+     * contain the separators [ComponentKey.toString] builds on. Both the override table and the
+     * icon picker route pass keys around in that string form, so a key that does not survive the
+     * round trip is not one we can store against.
+     */
+    fun supportsOverrides(itemInfo: ItemInfo): Boolean {
+        val key = try {
+            ShortcutKey.fromItemInfo(itemInfo)
+        } catch (t: Throwable) {
+            Log.w(TAG, "Unable to derive a shortcut key for $itemInfo", t)
+            return false
+        }
+        return ComponentKey.fromString(key.toString()) == key
+    }
+
+    /** Returns the user-chosen icon for [shortcutInfo], or null when none is set. */
+    fun getIcon(context: Context, shortcutInfo: ShortcutInfo, iconDpi: Int): Drawable? {
+        val item = IconOverrideRepository.INSTANCE.get(context)
+            .overridesMap[keyFor(shortcutInfo)] ?: return null
+        return IconPackProvider.INSTANCE.get(context)
+            .getDrawable(item.toIconEntry(), iconDpi, shortcutInfo.userHandle)
+    }
+
+    fun hasIconOverride(context: Context, shortcutInfo: ShortcutInfo): Boolean {
+        return IconOverrideRepository.INSTANCE.get(context)
+            .overridesMap
+            .containsKey(keyFor(shortcutInfo))
+    }
+
+    /**
+     * A chosen icon replaces the publisher's icon outright, so the publisher badge that would sit
+     * on top of it goes too — otherwise a web app picked out of an icon pack still wears the
+     * browser's mark. Lawnchair 2's Customize behaved the same way.
+     */
+    fun shouldSkipBadge(context: Context, shortcutInfo: ShortcutInfo): Boolean {
+        return LawnchairShortcutActivity.shouldSkipShortcutBadge(context, shortcutInfo) ||
+            hasIconOverride(context, shortcutInfo)
+    }
+
+    /** Returns the user-chosen label for [shortcutInfo], or null when none is set. */
+    fun getLabel(context: Context, shortcutInfo: ShortcutInfo): CharSequence? {
+        return PreferenceManager.getInstance(context).customAppName[keyFor(shortcutInfo)]
+    }
+}

--- a/lawnchair/src/app/lawnchair/icons/ShortcutIconOverrides.kt
+++ b/lawnchair/src/app/lawnchair/icons/ShortcutIconOverrides.kt
@@ -39,7 +39,11 @@ object ShortcutIconOverrides {
 
     private const val TAG = "ShortcutIconOverrides"
 
-    fun keyFor(shortcutInfo: ShortcutInfo): ComponentKey = ShortcutKey.fromInfo(shortcutInfo)
+    /**
+     * The storage key for [shortcutInfo]. Only meaningful for a shortcut [supportsOverrides] has
+     * accepted, which is the only way an override gets written in the first place.
+     */
+    private fun keyFor(shortcutInfo: ShortcutInfo): ComponentKey = ShortcutKey.fromInfo(shortcutInfo)
 
     /**
      * Whether [itemInfo] can carry an override at all.
@@ -67,16 +71,22 @@ object ShortcutIconOverrides {
             .getDrawable(item.toIconEntry(), iconDpi, shortcutInfo.userHandle)
     }
 
-    fun hasIconOverride(context: Context, shortcutInfo: ShortcutInfo): Boolean {
+    /** Whether an icon has been chosen for [shortcutInfo], regardless of whether it still resolves. */
+    private fun hasIconOverride(context: Context, shortcutInfo: ShortcutInfo): Boolean {
         return IconOverrideRepository.INSTANCE.get(context)
             .overridesMap
             .containsKey(keyFor(shortcutInfo))
     }
 
     /**
-     * A chosen icon replaces the publisher's icon outright, so the publisher badge that would sit
-     * on top of it goes too — otherwise a web app picked out of an icon pack still wears the
-     * browser's mark. Lawnchair 2's Customize behaved the same way.
+     * Whether the publisher badge should be left off: either this is one of Lawnchair's own gesture
+     * shortcuts, which has no meaningful publisher, or the user has chosen a replacement icon.
+     *
+     * A chosen icon replaces the publisher's outright, so the badge that identified the publisher
+     * goes with it — otherwise a web app picked out of an icon pack still wears the browser's mark.
+     * Lawnchair 2's Customize behaved the same way. This asks only whether an icon was chosen, not
+     * whether it still resolves, so a shortcut whose icon pack has since been uninstalled keeps its
+     * badge off while falling back to the publisher's icon.
      */
     fun shouldSkipBadge(context: Context, shortcutInfo: ShortcutInfo): Boolean {
         return LawnchairShortcutActivity.shouldSkipShortcutBadge(context, shortcutInfo) ||

--- a/lawnchair/src/app/lawnchair/override/CustomizeDialog.kt
+++ b/lawnchair/src/app/lawnchair/override/CustomizeDialog.kt
@@ -214,6 +214,10 @@ fun CustomizeShortcutDialog(
     )
 }
 
+/**
+ * Customize dialog for an app: everything [CustomizeOverrideDialog] offers, plus hiding the app
+ * from the drawer.
+ */
 @Composable
 fun CustomizeAppDialog(
     icon: Drawable,

--- a/lawnchair/src/app/lawnchair/override/CustomizeDialog.kt
+++ b/lawnchair/src/app/lawnchair/override/CustomizeDialog.kt
@@ -132,6 +132,64 @@ fun CustomizeDialog(
     }
 }
 
+/**
+ * Customize dialog for a pinned deep shortcut, such as a web app pinned by a browser.
+ *
+ * A shortcut has no drawer entry to hide and no per-app gestures, so only the icon and the label
+ * are offered here.
+ */
+@Composable
+fun CustomizeShortcutDialog(
+    icon: Drawable,
+    defaultTitle: String,
+    componentKey: ComponentKey,
+    modifier: Modifier = Modifier,
+    onClose: () -> Unit,
+) {
+    val prefs = preferenceManager()
+    val context = LocalContext.current
+    var title by remember {
+        mutableStateOf(prefs.customAppName[componentKey] ?: defaultTitle)
+    }
+    val launcherAppState = LauncherAppState.getInstance(context)
+
+    val route = SelectIcon(componentKey.toString())
+
+    val scope = rememberCoroutineScope()
+    val openIconPicker = {
+        val intent = PreferenceActivity.createIntent(context, route)
+        scope.launch {
+            val result = BlankActivity.startBlankActivityForResult(context as Activity, intent)
+            if (result.resultCode == Activity.RESULT_OK) {
+                onClose()
+            }
+        }
+        Unit
+    }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            val previousTitle = prefs.customAppName[componentKey]
+            val newTitle = if (title != defaultTitle) title else null
+            if (newTitle != previousTitle) {
+                prefs.customAppName[componentKey] = newTitle
+                launcherAppState.model.onAppIconChanged(
+                    componentKey.componentName.packageName,
+                    componentKey.user,
+                )
+            }
+        }
+    }
+    CustomizeDialog(
+        icon = icon,
+        title = title,
+        onTitleChange = { title = it },
+        defaultTitle = defaultTitle,
+        launchSelectIcon = openIconPicker,
+        modifier = modifier,
+    )
+}
+
 @Composable
 fun CustomizeAppDialog(
     icon: Drawable,

--- a/lawnchair/src/app/lawnchair/override/CustomizeDialog.kt
+++ b/lawnchair/src/app/lawnchair/override/CustomizeDialog.kt
@@ -2,7 +2,6 @@ package app.lawnchair.override
 
 import android.app.Activity
 import android.graphics.drawable.Drawable
-import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -133,18 +132,19 @@ fun CustomizeDialog(
 }
 
 /**
- * Customize dialog for a pinned deep shortcut, such as a web app pinned by a browser.
- *
- * A shortcut has no drawer entry to hide and no per-app gestures, so only the icon and the label
- * are offered here.
+ * Shared body of the customize dialogs: the icon preview, the label field, and the write-back of a
+ * changed label when the sheet is dismissed. [content] holds the options specific to what is being
+ * customized.
  */
 @Composable
-fun CustomizeShortcutDialog(
+private fun CustomizeOverrideDialog(
     icon: Drawable,
     defaultTitle: String,
     componentKey: ComponentKey,
-    modifier: Modifier = Modifier,
     onClose: () -> Unit,
+    modifier: Modifier = Modifier,
+    pickerLabel: String? = null,
+    content: (@Composable () -> Unit)? = null,
 ) {
     val prefs = preferenceManager()
     val context = LocalContext.current
@@ -153,65 +153,7 @@ fun CustomizeShortcutDialog(
     }
     val launcherAppState = LauncherAppState.getInstance(context)
 
-    val route = SelectIcon(componentKey.toString())
-
-    val scope = rememberCoroutineScope()
-    val openIconPicker = {
-        val intent = PreferenceActivity.createIntent(context, route)
-        scope.launch {
-            val result = BlankActivity.startBlankActivityForResult(context as Activity, intent)
-            if (result.resultCode == Activity.RESULT_OK) {
-                onClose()
-            }
-        }
-        Unit
-    }
-
-    DisposableEffect(Unit) {
-        onDispose {
-            val previousTitle = prefs.customAppName[componentKey]
-            val newTitle = if (title != defaultTitle) title else null
-            if (newTitle != previousTitle) {
-                prefs.customAppName[componentKey] = newTitle
-                launcherAppState.model.onAppIconChanged(
-                    componentKey.componentName.packageName,
-                    componentKey.user,
-                )
-            }
-        }
-    }
-    CustomizeDialog(
-        icon = icon,
-        title = title,
-        onTitleChange = { title = it },
-        defaultTitle = defaultTitle,
-        launchSelectIcon = openIconPicker,
-        modifier = modifier,
-    )
-}
-
-@Composable
-fun CustomizeAppDialog(
-    icon: Drawable,
-    defaultTitle: String,
-    componentKey: ComponentKey,
-    modifier: Modifier = Modifier,
-    onClose: () -> Unit,
-) {
-    val prefs = preferenceManager()
-    val preferenceManager2 = preferenceManager2()
-    val showComponentNames by preferenceManager2.showComponentNames.asState()
-    val hiddenApps by preferenceManager2.hiddenApps.asState()
-    val adapter = preferenceManager2.hiddenApps.getAdapter()
-    val context = LocalContext.current
-    var title by remember {
-        mutableStateOf(prefs.customAppName[componentKey] ?: defaultTitle)
-    }
-    val launcherAppState = LauncherAppState.getInstance(context)
-
-    val route = SelectIcon(componentKey.toString())
-
-    Log.d("CustomizeDialog", route.toString())
+    val route = SelectIcon(componentKey.toString(), pickerLabel)
 
     val scope = rememberCoroutineScope()
     val openIconPicker = {
@@ -243,6 +185,55 @@ fun CustomizeAppDialog(
         defaultTitle = defaultTitle,
         launchSelectIcon = openIconPicker,
         modifier = modifier,
+        content = content,
+    )
+}
+
+/**
+ * Customize dialog for a pinned deep shortcut, such as a web app pinned by a browser.
+ *
+ * A shortcut has no drawer entry to hide and no per-app gestures, so only the icon and the label
+ * are offered here.
+ */
+@Composable
+fun CustomizeShortcutDialog(
+    icon: Drawable,
+    defaultTitle: String,
+    componentKey: ComponentKey,
+    modifier: Modifier = Modifier,
+    onClose: () -> Unit,
+) {
+    CustomizeOverrideDialog(
+        icon = icon,
+        defaultTitle = defaultTitle,
+        componentKey = componentKey,
+        modifier = modifier,
+        onClose = onClose,
+        // The picker cannot name a shortcut from its key alone, so hand it the shortcut's own name.
+        pickerLabel = defaultTitle,
+    )
+}
+
+@Composable
+fun CustomizeAppDialog(
+    icon: Drawable,
+    defaultTitle: String,
+    componentKey: ComponentKey,
+    modifier: Modifier = Modifier,
+    onClose: () -> Unit,
+) {
+    val preferenceManager2 = preferenceManager2()
+    val showComponentNames by preferenceManager2.showComponentNames.asState()
+    val hiddenApps by preferenceManager2.hiddenApps.asState()
+    val adapter = preferenceManager2.hiddenApps.getAdapter()
+    val context = LocalContext.current
+
+    CustomizeOverrideDialog(
+        icon = icon,
+        defaultTitle = defaultTitle,
+        componentKey = componentKey,
+        modifier = modifier,
+        onClose = onClose,
     ) {
         PreferenceGroup(
             description = componentKey.componentName.flattenToString(),

--- a/lawnchair/src/app/lawnchair/ui/popup/LawnchairShortcut.kt
+++ b/lawnchair/src/app/lawnchair/ui/popup/LawnchairShortcut.kt
@@ -9,6 +9,7 @@ import android.content.Intent
 import android.content.pm.ApplicationInfo
 import android.content.pm.LauncherActivityInfo
 import android.content.pm.LauncherApps
+import android.content.pm.ShortcutInfo
 import android.content.pm.SuspendDialogInfo
 import android.graphics.Rect
 import android.graphics.RectF
@@ -21,7 +22,9 @@ import android.widget.Toast
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.unit.dp
 import app.lawnchair.LawnchairLauncher
+import app.lawnchair.icons.ShortcutIconOverrides
 import app.lawnchair.override.CustomizeAppDialog
+import app.lawnchair.override.CustomizeShortcutDialog
 import app.lawnchair.preferences2.PreferenceManager2
 import app.lawnchair.preferences2.firstCached
 import app.lawnchair.ui.preferences.PreferenceActivity
@@ -29,6 +32,7 @@ import app.lawnchair.ui.preferences.navigation.AppDrawerAppListToFolder
 import app.lawnchair.views.ComposeBottomSheet
 import com.android.launcher3.AbstractFloatingView
 import com.android.launcher3.LauncherSettings.Favorites.ITEM_TYPE_APPLICATION
+import com.android.launcher3.LauncherSettings.Favorites.ITEM_TYPE_DEEP_SHORTCUT
 import com.android.launcher3.LauncherSettings.Favorites.ITEM_TYPE_TASK
 import com.android.launcher3.R
 import com.android.launcher3.Utilities
@@ -39,6 +43,7 @@ import com.android.launcher3.logging.StatsLogManager
 import com.android.launcher3.model.data.AppInfo as ModelAppInfo
 import com.android.launcher3.model.data.ItemInfo
 import com.android.launcher3.popup.SystemShortcut
+import com.android.launcher3.shortcuts.ShortcutKey
 import com.android.launcher3.util.ApplicationInfoWrapper
 import com.android.launcher3.util.ComponentKey
 import com.android.launcher3.util.PackageManagerHelper
@@ -90,10 +95,18 @@ class LawnchairShortcut {
         val CUSTOMIZE =
             SystemShortcut.Factory { activity: LawnchairLauncher, itemInfo, originalView ->
                 val prefs2 = PreferenceManager2.getInstance(activity)
-                if (prefs2.lockHomeScreen.firstCached()) {
-                    null
-                } else {
-                    getAppInfo(activity, itemInfo)?.let { Customize(activity, it, itemInfo, originalView) }
+                when {
+                    prefs2.lockHomeScreen.firstCached() -> null
+
+                    itemInfo.itemType == ITEM_TYPE_DEEP_SHORTCUT ->
+                        if (ShortcutIconOverrides.supportsOverrides(itemInfo)) {
+                            CustomizeShortcut(activity, itemInfo, originalView)
+                        } else {
+                            null
+                        }
+
+                    else ->
+                        getAppInfo(activity, itemInfo)?.let { Customize(activity, it, itemInfo, originalView) }
                 }
             }
 
@@ -203,6 +216,43 @@ class LawnchairShortcut {
             } else {
                 Toast.makeText(launcher, R.string.activity_not_found, Toast.LENGTH_SHORT).show()
                 AbstractFloatingView.closeAllOpenViews(launcher)
+            }
+        }
+    }
+
+    /**
+     * Customize for a pinned deep shortcut, such as a web app pinned by a browser.
+     *
+     * A shortcut has no [ModelAppInfo] behind it, so the icon and the default label come from the
+     * published [ShortcutInfo] instead, and the override is keyed by [ShortcutKey].
+     */
+    class CustomizeShortcut(
+        private val launcher: LawnchairLauncher,
+        itemInfo: ItemInfo,
+        originalView: View,
+    ) : SystemShortcut<LawnchairLauncher>(R.drawable.ic_edit, R.string.action_customize, launcher, itemInfo, originalView) {
+
+        override fun onClick(v: View) {
+            val outObj = Array<Any?>(1) { null }
+            val icon = Utilities.loadFullDrawableWithoutTheme(launcher, mItemInfo, 0, 0, outObj)
+            val shortcutInfo = outObj[0] as? ShortcutInfo
+            if (icon == null || shortcutInfo == null) {
+                Toast.makeText(launcher, R.string.activity_not_found, Toast.LENGTH_SHORT).show()
+                AbstractFloatingView.closeAllOpenViews(launcher)
+                return
+            }
+
+            AbstractFloatingView.closeAllOpenViews(launcher)
+            ComposeBottomSheet.show(
+                context = launcher,
+                contentPaddings = PaddingValues(bottom = 64.dp),
+            ) {
+                CustomizeShortcutDialog(
+                    icon = icon,
+                    // Matches the title WorkspaceItemInfo derives for a deep shortcut.
+                    defaultTitle = shortcutInfo.shortLabel?.toString().orEmpty(),
+                    componentKey = ShortcutKey.fromInfo(shortcutInfo),
+                ) { close(true) }
             }
         }
     }

--- a/lawnchair/src/app/lawnchair/ui/popup/LawnchairShortcut.kt
+++ b/lawnchair/src/app/lawnchair/ui/popup/LawnchairShortcut.kt
@@ -42,6 +42,7 @@ import com.android.launcher3.icons.LauncherIcons
 import com.android.launcher3.logging.StatsLogManager
 import com.android.launcher3.model.data.AppInfo as ModelAppInfo
 import com.android.launcher3.model.data.ItemInfo
+import com.android.launcher3.model.data.ItemInfoWithIcon
 import com.android.launcher3.popup.SystemShortcut
 import com.android.launcher3.shortcuts.ShortcutKey
 import com.android.launcher3.util.ApplicationInfoWrapper
@@ -234,12 +235,28 @@ class LawnchairShortcut {
 
         override fun onClick(v: View) {
             val outObj = Array<Any?>(1) { null }
-            val icon = Utilities.loadFullDrawableWithoutTheme(launcher, mItemInfo, 0, 0, outObj)
+            var icon = Utilities.loadFullDrawableWithoutTheme(launcher, mItemInfo, 0, 0, outObj)
             val shortcutInfo = outObj[0] as? ShortcutInfo
             if (icon == null || shortcutInfo == null) {
-                Toast.makeText(launcher, R.string.activity_not_found, Toast.LENGTH_SHORT).show()
+                // The publisher is still installed; the shortcut itself went away or was disabled.
+                Toast.makeText(launcher, R.string.shortcut_not_available, Toast.LENGTH_SHORT).show()
                 AbstractFloatingView.closeAllOpenViews(launcher)
                 return
+            }
+            // Shortcut icons are themed on the workspace, so theme the preview to match.
+            if (mItemInfo.screenId != NO_ID && Utilities.ATLEAST_T) {
+                val adaptiveIcon = icon as? AdaptiveIconDrawable
+                    ?: LauncherIcons.obtain(launcher).use { it.wrapToAdaptiveIcon(icon) }
+                if (adaptiveIcon != null) {
+                    val themeController = ThemeManager.INSTANCE.get(launcher).themeController
+                    themeController?.createThemedAdaptiveIcon(
+                        launcher,
+                        adaptiveIcon,
+                        (mItemInfo as? ItemInfoWithIcon)?.bitmap,
+                    )?.let {
+                        icon = it
+                    }
+                }
             }
 
             AbstractFloatingView.closeAllOpenViews(launcher)

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/SelectIconPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/SelectIconPreference.kt
@@ -35,11 +35,12 @@ import kotlinx.coroutines.withContext
 private const val TAG = "SelectIconPreference"
 
 @Composable
-fun SelectIconPreference(componentKey: ComponentKey) {
+fun SelectIconPreference(componentKey: ComponentKey, displayLabel: String? = null) {
     val context = LocalContext.current
     val mMSDLPlayerWrapper = MSDLPlayerWrapper.INSTANCE.get(context)
-    val label = remember(componentKey) {
-        resolveAppLabel(context.requireSystemService(), componentKey)
+    val label = remember(componentKey, displayLabel) {
+        displayLabel?.takeIf { it.isNotEmpty() }
+            ?: resolveAppLabel(context.requireSystemService(), componentKey)
     }
     val iconPacks by LocalPreferenceInteractor.current.iconPacks.collectAsStateWithLifecycle()
     val navController = LocalNavController.current

--- a/lawnchair/src/app/lawnchair/ui/preferences/navigation/PreferenceNavigation.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/navigation/PreferenceNavigation.kt
@@ -210,7 +210,7 @@ fun PreferenceNavigation(
             val args: SelectIcon = backStackEntry.toRoute()
             val componentKey = args.componentKey
             val key = ComponentKey.fromString(componentKey)!!
-            SelectIconPreference(key)
+            SelectIconPreference(key, args.label)
         }
         composable<IconPicker> { backStackEntry ->
             val args: IconPicker = backStackEntry.toRoute()

--- a/lawnchair/src/app/lawnchair/ui/preferences/navigation/PreferenceRoutes.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/navigation/PreferenceRoutes.kt
@@ -195,6 +195,10 @@ data object AboutLicenses : PreferenceRoute, PreferenceDeepLink {
 data class SelectIcon(
     // assuming componentKey is a ComponentKey.toString()
     val componentKey: String,
+    // Set when the caller already knows the target's name. A deep shortcut's key is
+    // ComponentName(publisherPackage, shortcutId), which no activity lookup resolves a label from,
+    // so the screen would otherwise be titled after the publishing app.
+    val label: String? = null,
 ) : PreferenceRoute
 
 // default to empty

--- a/src/com/android/launcher3/Utilities.java
+++ b/src/com/android/launcher3/Utilities.java
@@ -85,6 +85,7 @@ import com.android.launcher3.icons.CacheableShortcutCachingLogic;
 import com.android.launcher3.icons.CacheableShortcutInfo;
 import com.android.launcher3.icons.IconThemeController;
 import com.android.launcher3.icons.LauncherIcons;
+import com.android.launcher3.icons.UserBadgeDrawable;
 import com.android.launcher3.model.data.ItemInfo;
 import com.android.launcher3.model.data.ItemInfoWithIcon;
 import com.android.launcher3.pm.ShortcutConfigActivityInfo;
@@ -802,9 +803,15 @@ public final class Utilities {
                 if (mainIcon == null) {
                     mainIcon = CacheableShortcutInfo.getIcon(context, si, shortcutIconDpi);
                 }
+                boolean skipBadge = ShortcutIconOverrides.INSTANCE.shouldSkipBadge(context, si);
+                // LC-Note: the badge preloaded from the cached bitmap above may predate the
+                // override. Drop a stale publisher badge, but keep a plain user-profile badge —
+                // that is exactly what the refreshed cache produces for an overridden shortcut.
+                if (skipBadge && badge != null && !(badge instanceof UserBadgeDrawable)) {
+                    badge = null;
+                }
                 // Only fetch badge if the icon is on workspace
-                if (info.id != ItemInfo.NO_ID && badge == null
-                        && !ShortcutIconOverrides.INSTANCE.shouldSkipBadge(context, si)) {
+                if (info.id != ItemInfo.NO_ID && badge == null && !skipBadge) {
                     badge = appState.getIconCache().getShortcutInfoBadge(si).newIcon(
                             context,
                             ThemeManager.INSTANCE.get(context).isIconThemeEnabled()

--- a/src/com/android/launcher3/Utilities.java
+++ b/src/com/android/launcher3/Utilities.java
@@ -108,6 +108,7 @@ import java.util.Objects;
 import java.util.function.Predicate;
 
 import app.lawnchair.icons.ExtendedBitmapDrawable;
+import app.lawnchair.icons.ShortcutIconOverrides;
 import app.lawnchair.preferences.PreferenceManager;
 
 /**
@@ -796,10 +797,14 @@ public final class Utilities {
                 return null;
             } else {
                 ShortcutInfo si = siList.get(0);
-                mainIcon = CacheableShortcutInfo.getIcon(context, si,
-                        appState.getInvariantDeviceProfile().fillResIconDpi);
+                int shortcutIconDpi = appState.getInvariantDeviceProfile().fillResIconDpi;
+                mainIcon = ShortcutIconOverrides.INSTANCE.getIcon(context, si, shortcutIconDpi);
+                if (mainIcon == null) {
+                    mainIcon = CacheableShortcutInfo.getIcon(context, si, shortcutIconDpi);
+                }
                 // Only fetch badge if the icon is on workspace
-                if (info.id != ItemInfo.NO_ID && badge == null) {
+                if (info.id != ItemInfo.NO_ID && badge == null
+                        && !ShortcutIconOverrides.INSTANCE.shouldSkipBadge(context, si)) {
                     badge = appState.getIconCache().getShortcutInfoBadge(si).newIcon(
                             context,
                             ThemeManager.INSTANCE.get(context).isIconThemeEnabled()

--- a/src/com/android/launcher3/icons/CacheableShortcutInfo.kt
+++ b/src/com/android/launcher3/icons/CacheableShortcutInfo.kt
@@ -106,7 +106,7 @@ object CacheableShortcutCachingLogic : CachingLogic<CacheableShortcutInfo> {
     override fun loadIcon(context: Context, cache: BaseIconCache, info: CacheableShortcutInfo) =
         LauncherIcons.obtain(context).use { li ->
             val iconDpi = LauncherAppState.getIDP(context).fillResIconDpi
-            // A user-chosen icon wins over the one the publisher supplies.
+            // LC-Note: a user-chosen icon wins over the one the publisher supplies.
             val overrideIcon = ShortcutIconOverrides.getIcon(context, info.shortcutInfo, iconDpi)
             (overrideIcon ?: CacheableShortcutInfo.getIcon(context, info.shortcutInfo, iconDpi))
                 ?.let { d ->
@@ -117,6 +117,8 @@ object CacheableShortcutCachingLogic : CachingLogic<CacheableShortcutInfo> {
                             .setSourceHint(
                                 getSourceHint(info, cache)
                                     .copy(
+                                        // LC-Note: the hint describes the drawable actually being
+                                        // rasterized, and an icon-pack drawable is never a file.
                                         isFileDrawable =
                                             overrideIcon == null &&
                                                 ApiWrapper.INSTANCE[context].isFileDrawable(

--- a/src/com/android/launcher3/icons/CacheableShortcutInfo.kt
+++ b/src/com/android/launcher3/icons/CacheableShortcutInfo.kt
@@ -24,6 +24,7 @@ import android.content.pm.ShortcutInfo
 import android.graphics.drawable.Drawable
 import android.os.UserHandle
 import android.util.Log
+import app.lawnchair.icons.ShortcutIconOverrides
 import com.android.launcher3.LauncherAppState
 import com.android.launcher3.icons.BaseIconFactory.IconOptions
 import com.android.launcher3.icons.cache.BaseIconCache
@@ -104,11 +105,10 @@ object CacheableShortcutCachingLogic : CachingLogic<CacheableShortcutInfo> {
 
     override fun loadIcon(context: Context, cache: BaseIconCache, info: CacheableShortcutInfo) =
         LauncherIcons.obtain(context).use { li ->
-            CacheableShortcutInfo.getIcon(
-                    context,
-                    info.shortcutInfo,
-                    LauncherAppState.getIDP(context).fillResIconDpi,
-                )
+            val iconDpi = LauncherAppState.getIDP(context).fillResIconDpi
+            // A user-chosen icon wins over the one the publisher supplies.
+            val overrideIcon = ShortcutIconOverrides.getIcon(context, info.shortcutInfo, iconDpi)
+            (overrideIcon ?: CacheableShortcutInfo.getIcon(context, info.shortcutInfo, iconDpi))
                 ?.let { d ->
                     li.createBadgedIconBitmap(
                         d,
@@ -118,9 +118,10 @@ object CacheableShortcutCachingLogic : CachingLogic<CacheableShortcutInfo> {
                                 getSourceHint(info, cache)
                                     .copy(
                                         isFileDrawable =
-                                            ApiWrapper.INSTANCE[context].isFileDrawable(
-                                                info.shortcutInfo
-                                            )
+                                            overrideIcon == null &&
+                                                ApiWrapper.INSTANCE[context].isFileDrawable(
+                                                    info.shortcutInfo
+                                                )
                                     )
                             ),
                     )

--- a/src/com/android/launcher3/icons/IconCache.java
+++ b/src/com/android/launcher3/icons/IconCache.java
@@ -87,8 +87,8 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import app.lawnchair.LawnchairActivityCachingLogic;
-import app.lawnchair.gestures.ui.LawnchairShortcutActivity;
 import app.lawnchair.icons.LawnchairIconProvider;
+import app.lawnchair.icons.ShortcutIconOverrides;
 
 /**
  * Cache of application icons.  Icons can be made from any thread.
@@ -325,7 +325,7 @@ public class IconCache extends BaseIconCache {
             return;
         }
 
-        info.bitmap = LawnchairShortcutActivity.Companion.shouldSkipShortcutBadge(context, si.getShortcutInfo())
+        info.bitmap = ShortcutIconOverrides.INSTANCE.shouldSkipBadge(context, si.getShortcutInfo())
             ? bitmapInfo.withFlags(FlagOp.NO_OP)
             : bitmapInfo.withBadgeInfo(getShortcutInfoBadge(si.getShortcutInfo()));
     }
@@ -392,7 +392,7 @@ public class IconCache extends BaseIconCache {
                     lookupFlag.withSkipAddToMemCache());
             applyCacheEntry(entry, info);
 
-            if (!LawnchairShortcutActivity.Companion.shouldSkipShortcutBadge(context, si)) {
+            if (!ShortcutIconOverrides.INSTANCE.shouldSkipBadge(context, si)) {
                 info.bitmap = info.bitmap.withBadgeInfo(getShortcutInfoBadge(si));
             }
         } else {

--- a/src/com/android/launcher3/model/data/WorkspaceItemInfo.java
+++ b/src/com/android/launcher3/model/data/WorkspaceItemInfo.java
@@ -29,6 +29,8 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import app.lawnchair.icons.ShortcutIconOverrides;
+
 import com.android.launcher3.Flags;
 import com.android.launcher3.LauncherSettings;
 import com.android.launcher3.LauncherSettings.Favorites;
@@ -186,9 +188,11 @@ public class WorkspaceItemInfo extends ItemInfoWithIcon {
         }
         // {@link ShortcutInfo#getActivity} can change during an update. Recreate the intent
         intent = ShortcutKey.makeIntent(shortcutInfo);
-        title = shortcutInfo.getShortLabel();
+        CharSequence customTitle = ShortcutIconOverrides.INSTANCE.getLabel(context, shortcutInfo);
+        boolean hasCustomTitle = !TextUtils.isEmpty(customTitle);
+        title = hasCustomTitle ? customTitle : shortcutInfo.getShortLabel();
 
-        CharSequence label = shortcutInfo.getLongLabel();
+        CharSequence label = hasCustomTitle ? customTitle : shortcutInfo.getLongLabel();
         if (TextUtils.isEmpty(label)) {
             label = shortcutInfo.getShortLabel();
         }

--- a/src/com/android/launcher3/model/data/WorkspaceItemInfo.java
+++ b/src/com/android/launcher3/model/data/WorkspaceItemInfo.java
@@ -29,8 +29,6 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import app.lawnchair.icons.ShortcutIconOverrides;
-
 import com.android.launcher3.Flags;
 import com.android.launcher3.LauncherSettings;
 import com.android.launcher3.LauncherSettings.Favorites;
@@ -43,6 +41,8 @@ import com.android.launcher3.util.ContentWriter;
 import com.android.wm.shell.shared.bubbles.BubbleAnythingFlagHelper;
 
 import java.util.Arrays;
+
+import app.lawnchair.icons.ShortcutIconOverrides;
 
 /**
  * Represents a launchable icon on the workspaces and in folders.
@@ -188,6 +188,8 @@ public class WorkspaceItemInfo extends ItemInfoWithIcon {
         }
         // {@link ShortcutInfo#getActivity} can change during an update. Recreate the intent
         intent = ShortcutKey.makeIntent(shortcutInfo);
+        // LC-Note: this is the only place a pinned deep shortcut's title is set, so the custom
+        // label is applied here rather than in the caching logic the app path uses.
         CharSequence customTitle = ShortcutIconOverrides.INSTANCE.getLabel(context, shortcutInfo);
         boolean hasCustomTitle = !TextUtils.isEmpty(customTitle);
         title = hasCustomTitle ? customTitle : shortcutInfo.getShortLabel();


### PR DESCRIPTION
### Description

Restores the ability to change a pinned shortcut's icon and label, which Lawnchair 2 had and the Launcher3-based rewrite lost. Long-pressing a pinned deep shortcut now offers **Customize**, the same entry apps already have, opening the same sheet with the icon picker and the label field. When an icon is chosen, the publisher badge is dropped along with the icon it belonged to.

Fixes #4290

### Reasoning

The motivating case is progressive web apps on a device with no Play services: without WebAPK minting every installed PWA lands on the workspace as a pinned deep shortcut wearing the publishing browser's badge, and `LawnchairShortcut.CUSTOMIZE` returned `null` for anything that was not `ITEM_TYPE_APPLICATION`, so there was no way to change either the icon or the browser mark on it.

The change has three parts.

**The gate.** `CUSTOMIZE`'s factory branches on item type: deep shortcuts get a new `CustomizeShortcut`, apps keep the existing `Customize` path unchanged. A shortcut has no `AppInfo` behind it, so the preview icon and the default label come from the published `ShortcutInfo`.

**The key model — no new storage.** `ShortcutKey` is already a `ComponentKey` whose class name is the shortcut id, and that is already how the icon cache keys shortcut entries (`CacheableShortcutCachingLogic.getComponent`). Shortcut overrides therefore drop straight into the existing `IconOverride` table and `customAppName` map with no schema change and no migration. `ShortcutIconOverrides.supportsOverrides` guards the one place that model is fragile: shortcut ids are publisher-chosen strings, and both the override table and the icon-picker route pass keys through `ComponentKey.toString()`/`fromString()`, so an id that does not survive that round trip (one containing `#`, a leading `.`, or empty) does not get offered Customize rather than reaching a `!!`.

**The render seam and the badge.** Deep-shortcut icons load through `CacheableShortcutCachingLogic.loadIcon`, so that is where a chosen icon is substituted. The publisher badge is composited separately, and upstream already had a badge-skip hook at both `IconCache` sites for Lawnchair's own gesture shortcuts (`LawnchairShortcutActivity.shouldSkipShortcutBadge`, #6485); both now route through `ShortcutIconOverrides.shouldSkipBadge`, which composes that condition with the new one. `IconCache` no longer imports `app.lawnchair.gestures.ui` as a result.

**Skipping the badge on override is a deliberate design choice**, matching Lawnchair 2's Customize semantics: a chosen icon replaces the publisher's outright, so the badge that identified the publisher goes with it. Keeping it would leave a web app picked out of an icon pack still wearing the browser's mark, which is the specific complaint in #4290.

Cache invalidation needed no new machinery. `SelectIconPreference` already calls `model.onAppIconChanged(pkg, user)`, which enqueues `PackageUpdatedTask(OP_UPDATE)` → `updateIconsForPkg` → `removeIconsForPkg`, whose `COLUMN_COMPONENT LIKE '<pkg>/%'` already matches shortcut rows because their component is `pkg/shortcutId`; `onAppIconChanged` then separately enqueues `ShortcutsChangedTask` for the package's pinned shortcuts. Icon-cache freshness is likewise already covered, since `LawnchairIconProvider.getStateForApp` folds in `getPackageOverrideState(pkg, user)`, which filters by package name — the publisher package for a shortcut key.

### Testing

Build: `./gradlew assembleLawnWithQuickstepGithubDebug spotlessCheck` passes.

Manual steps:

1. Install a PWA from a browser so it pins as a shortcut on the workspace (on a device without Play services this is the default path; with Play services, pin any deep shortcut from an app's long-press menu).
2. Long-press it. **Customize** now appears.
3. Confirm the sheet's preview shows the shortcut's icon and its name, and that the picker screen opened from it is titled with the shortcut's name rather than the publishing app's.
4. Pick an icon from any icon pack. The workspace icon should update immediately, with no publisher badge on it.
5. Edit the label and dismiss. The workspace label should update.
6. Reboot or restart the launcher and confirm both survive.
7. Open the picker again and use **Reset to default**. The publisher's icon and badge should both come back.
8. Regression check on apps: long-press a normal app, Customize, change the icon and label. Behaviour should be unchanged.

**Device testing so far** (GrapheneOS, Pixel, PWAs pinned by a Play-services-free browser — the motivating case): steps 1–5 and 8 verified. Step 6 initially **failed** — the custom icon reverted after switching default launchers and back — which turned out to be a real cold-start ordering bug in the override map's population, fixed in 7b6354f and re-verified on device. I would still appreciate a second pair of eyes on the two things I could not exercise without more devices: work/private-profile shortcuts, and shortcuts published by apps other than browsers.

There is no automated coverage here — the app module wires no JVM unit tests (`testLawnWithQuickstepGithubDebugUnitTest` is `NO-SOURCE`) and `tests/multivalentTests` is instrumentation-only — so everything above was verified by reading the call paths plus the build, not by a test run.

### Notes for reviewers

Three things I decided rather than discovered, which are the most reasonable places to disagree with me:

- **The label half touches `WorkspaceItemInfo.updateFromDeepShortcutInfo`.** That is the only place a pinned deep shortcut's title is set (`WorkspaceItemProcessor` builds the item there, and `getShortcutIcon` writes only `bitmap`), so unlike the app path there is no `CachingLogic.getLabel` seam that would work; applying it in the caching logic alone would leave the workspace label untouched. `CacheableShortcutCachingLogic.getLabel` is deliberately left returning the publisher label, since nothing currently reads the cached title for a pinned shortcut. Happy to drop the label half entirely if you would rather keep this to icons.
- **The `Utilities.getFullDrawable` hunk incidentally de-badges gesture shortcuts in drag previews and launch animations.** #6485 only covered the two `IconCache` sites, so this is new behaviour for that feature. It looks like a fix rather than a regression — the preview now agrees with the workspace icon, which #6485 already de-badged — but it is a real behaviour change and I would rather name it than have it found later.
- **App and shortcut overrides share one key space.** A publisher whose shortcut id exactly equals one of its own activity class names would have that shortcut and that app entry read the same override row. It is confined to the publisher's own package (the package half comes from the system), and the icon cache already aliases them this way today, so I left it alone rather than adding a sentinel prefix to a persisted key format. Say the word if you would rather it were namespaced.

One known limitation, deliberately not fixed: `shouldSkipBadge` asks whether an icon was chosen, not whether it still resolves, so if the source icon pack is later uninstalled the shortcut falls back to the publisher's icon while keeping the badge off. Making it exact would mean re-resolving the icon pack (a blocking load) at every badge decision on the model thread, which seemed the wrong trade for a cosmetic edge case. It is documented on the function.

### Type of change

:x: **Bug fix** (A non-breaking change that fixes an issue)
:white_check_mark: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Customize supported deep shortcuts independently from their parent apps.
  - Apply custom icons and labels to shortcuts.
  - Use icon-pack artwork and custom app names for shortcut appearance.
  - Optionally hide publisher badges for customized shortcuts and Lawnchair gesture shortcuts.
  - Display clearer shortcut names throughout customization settings.

- **Bug Fixes**
  - Improved fallback behavior when customized or publisher-provided shortcut icons are unavailable.
  - Preserved standard shortcut labels and icons when no customization is configured.
  - Retained user-profile badges when publisher badges are hidden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
