### PR TITLE
fix: Disable managed/private space user on affected 37.2 Beta 3

### DIFF
--- a/lawnchair/src/app/lawnchair/predictions/LawnchairPredictionEngine.kt
+++ b/lawnchair/src/app/lawnchair/predictions/LawnchairPredictionEngine.kt
@@ -9,6 +9,7 @@ import android.content.pm.LauncherApps
 import android.os.Build
 import android.os.Process
 import android.os.UserHandle
+import android.util.Log
 import androidx.annotation.RequiresApi
 import app.lawnchair.preferences2.PreferenceManager2
 import app.lawnchair.preferences2.firstCached
@@ -186,7 +187,16 @@ class LawnchairPredictionEngine(
         val appFilter = AppFilter(context)
         return userProfilesInPredictionOrder()
             .asSequence()
-            .flatMap { user -> launcherApps.getActivityList(null, user).asSequence() }
+            .flatMap { user ->
+                try {
+                    launcherApps.getActivityList(null, user)
+                } catch (e: SecurityException) {
+                    // Lawnchair-Note: Android 17 QPR2 Beta 3 crash when accessing activity list with null pkgName for non-Main user
+                    // Ref: https://issuetracker.google.com/issues/547643926
+                    Log.e("LawnchairPredictionEngine", "Failed to get activity list for user $user", e)
+                    emptyList()
+                }.asSequence()
+            }
             .filter { activityInfo -> appFilter.shouldShowApp(activityInfo.componentName) }
             .map { activityInfo -> toStoreKey(activityInfo.componentName, activityInfo.user) }
             .distinct()

--- a/lawnchair/src/app/lawnchair/util/AppsList.kt
+++ b/lawnchair/src/app/lawnchair/util/AppsList.kt
@@ -21,6 +21,7 @@ import android.content.pm.LauncherActivityInfo
 import android.content.pm.LauncherApps
 import android.graphics.Bitmap
 import android.os.Handler
+import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.State
@@ -51,7 +52,16 @@ fun appsState(
 
             if (launcherApps != null) {
                 appsState.value = UserCache.INSTANCE.get(context).userProfiles.asSequence()
-                    .flatMap { launcherApps.getActivityList(null, it) }
+                    .flatMap {
+                        try {
+                            launcherApps.getActivityList(null, it)
+                        } catch (e: SecurityException) {
+                            // Lawnchair-Note: Android 17 QPR2 Beta 3 crash when accessing activity list with null pkgName for non-Main user
+                            // Ref: https://issuetracker.google.com/issues/547643926
+                            Log.e("LC-AppsList", "Failed to get activity list for user $it", e)
+                            emptyList()
+                        }
+                    }
                     .filter { filter.shouldShowApp(it.componentName) }
                     .map { App(context, it) }
                     .sortedWith(comparator)

--- a/quickstep/src/com/android/launcher3/model/WellbeingModel.java
+++ b/quickstep/src/com/android/launcher3/model/WellbeingModel.java
@@ -282,14 +282,19 @@ public final class WellbeingModel implements SafeCloseable {
         final LauncherApps mLauncherApps = mContext.getSystemService(LauncherApps.class);
         List<LauncherActivityInfo> apps;
         
-        try {
-            apps = mLauncherApps.getActivityList(null, Process.myUserHandle());
-        } catch (SecurityException e) {
-            // Lawnchair-Note: Android 17 QPR2 Beta 3 crash when accessing activity list with null pkgName for non-Main user
-            // Ref: https://issuetracker.google.com/issues/547643926
-            Log.e("LC-LoaderTask", "Failed to get activity list for user " + Process.myUserHandle(), e);
+        // Lawnchair-Note: Android 17 QPR2 Beta 3 crash when accessing activity list with null pkgName for non-Main user
+        // Ref: https://issuetracker.google.com/issues/547643926
+        if (TextUtils.isEmpty(packageName)) {
+            try {
+                apps = mLauncherApps.getActivityList(null, Process.myUserHandle());
+            } catch (SecurityException e) {
+                Log.e("LC-LoaderTask", "Failed to get activity list for user " + Process.myUserHandle(), e);
+                apps = Collections.emptyList();
+            }
+        } else {
             apps = Collections.emptyList();
         }
+        
         if (DEBUG || mIsInTest) {
             Log.i(TAG,
                     "updateActionsWithRetry(); retryCount: " + retryCount + ", package: "

--- a/quickstep/src/com/android/launcher3/model/WellbeingModel.java
+++ b/quickstep/src/com/android/launcher3/model/WellbeingModel.java
@@ -26,6 +26,7 @@ import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.pm.LauncherActivityInfo;
 import android.content.pm.LauncherApps;
 import android.database.ContentObserver;
 import android.net.Uri;
@@ -59,7 +60,9 @@ import com.android.launcher3.views.ActivityContext;
 import com.android.quickstep.dagger.QuickstepBaseAppComponent;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.inject.Inject;
@@ -276,14 +279,24 @@ public final class WellbeingModel implements SafeCloseable {
 
     @WorkerThread
     private void updateActionsWithRetry(int retryCount, @Nullable String packageName) {
+        final LauncherApps mLauncherApps = mContext.getSystemService(LauncherApps.class);
+        List<LauncherActivityInfo> apps;
+        
+        try {
+            apps = mLauncherApps.getActivityList(null, Process.myUserHandle());
+        } catch (SecurityException e) {
+            // Lawnchair-Note: Android 17 QPR2 Beta 3 crash when accessing activity list with null pkgName for non-Main user
+            // Ref: https://issuetracker.google.com/issues/547643926
+            Log.e("LC-LoaderTask", "Failed to get activity list for user " + Process.myUserHandle(), e);
+            apps = Collections.emptyList();
+        }
         if (DEBUG || mIsInTest) {
             Log.i(TAG,
                     "updateActionsWithRetry(); retryCount: " + retryCount + ", package: "
                             + packageName);
         }
         String[] packageNames = TextUtils.isEmpty(packageName)
-                ? mContext.getSystemService(LauncherApps.class)
-                .getActivityList(null, Process.myUserHandle()).stream()
+                ? apps.stream()
                 .map(li -> li.getApplicationInfo().packageName).distinct()
                 .toArray(String[]::new)
                 : new String[]{packageName};

--- a/src/com/android/launcher3/model/LoaderTask.java
+++ b/src/com/android/launcher3/model/LoaderTask.java
@@ -106,6 +106,7 @@ import dagger.assisted.AssistedInject;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -615,7 +616,15 @@ public class LoaderTask implements Runnable {
         boolean isPrivateProfileQuiet = false;
         for (UserHandle user : profiles) {
             // Query for the set of apps
-            final List<LauncherActivityInfo> apps = mLauncherApps.getActivityList(null, user);
+            List<LauncherActivityInfo> apps;
+            try {
+                apps = mLauncherApps.getActivityList(null, user);
+            } catch (SecurityException e) {
+                // Lawnchair-Note: Android 17 QPR2 Beta 3 crash when accessing activity list with null pkgName for non-Main user
+                // Ref: https://issuetracker.google.com/issues/547643926
+                Log.e("LC-LoaderTask", "Failed to get activity list for user " + user, e);
+                apps = Collections.emptyList();
+            }
             // Fail if we don't have any apps
             if (apps == null || apps.isEmpty()) {
                 if (myUserHandle().equals(user)) {


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Fixes #7158 (the symptom)

Fix Android 17 QPR2 Beta 3 issue by disabling managed/private space profile support when the OS crash with SecurityException instead of returning empty list.

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->

See report written by Niagara Launcher team @ https://issuetracker.google.com/issues/547643926

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Pixel 7 - Android 17 QPR2 Beta 3 (affected)

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved launcher stability when app or activity information cannot be retrieved.
  * App loading, ranking, and wellbeing actions now continue gracefully instead of crashing when access is unavailable.
  * Affected profiles are treated as having no available activities, while failures are recorded for troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->