### PR TITLE
fix: Widget colouring compatibility with Android 13

### DIFF
--- a/src/com/android/launcher3/widget/LauncherAppWidgetHostView.java
+++ b/src/com/android/launcher3/widget/LauncherAppWidgetHostView.java
@@ -114,14 +114,16 @@ public class LauncherAppWidgetHostView extends BaseLauncherAppWidgetHostView
         }
 
         // LC-Note: Fix widget idmap theming issue
-        if (Utilities.ATLEAST_T) {
-            // LC-Note: Yes, this exist, don't get fool by your language processor.
-            // https://cs.android.com/android/platform/superproject/+/android-latest-release:frameworks/base/core/java/android/widget/RemoteViews.java;l=9162;bpv=1?q=RemoteViews.ColorResources&ss=android%2Fplatform%2Fsuperproject
+        if (Utilities.ATLEAST_U) {
+            // LC-Note: Yes, this exists, don't get fool by your language processor.
+            // Since Android 13 Initial
             RemoteViews.ColorResources colorResources = RemoteViews.ColorResources.create(getContext(), colors);
             if (colorResources == null) {
                 resetColorResources();
                 return;
             }
+            // LC-Note: Yes, this super also exists.
+            // Since Android 14 Initial
             super.setColorResources(colorResources);
         } else {
             // LC-Note: Fall back for Android 12 impl


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Fixes #7161

The original change was misleading because the code does reference that `ColorResources` (from `RemoteView`) exist but the `setColorResources` super (from `AppWidgetHostView`) does not. This change bump the requirement for CR to Android 14 while Android 13 and below use `SparseIntArray`

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->


### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved widget color resource handling on newer Android versions.
  * Preserved the existing fallback behavior for Android 12 and earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->