### PR TITLE
fix: Compatibility layer for config night mode check for API <30

### DIFF
--- a/src/com/android/launcher3/util/DisplayController.java
+++ b/src/com/android/launcher3/util/DisplayController.java
@@ -347,9 +347,25 @@ public class DisplayController implements DesktopVisibilityListener {
                 != info.showLockedTaskbarOnHome()
                 || mWMProxy.showDesktopTaskbarForFreeformDisplay(windowContext)
                 != info.showDesktopTaskbarForFreeformDisplay()
-                || config.isNightModeActive() != info.mIsNightModeActive) {
+                || isNightModeActiveCompat(config) != info.mIsNightModeActive) {
             notifyConfigChange(displayId);
         }
+    }
+
+    /** 
+     * LC-Note: Returns whether the configuration is in night mode
+     * <p> 
+     * Compat <code>API 30</code> and higher: <code>config.isNightModeActive()</code>
+     * <p> 
+     * Compat <code>API 29</code> and lower: <code>(config.uiMode & UI_MODE_NIGHT_MASK) == UI_MODE_NIGHT_YES</code>
+     * 
+     * @return true if night mode is active and false otherwise
+     */
+    private static boolean isNightModeActiveCompat(Configuration config) {
+        if (Utilities.ATLEAST_R) {
+            return config.isNightModeActive();
+        }
+        return (config.uiMode & UI_MODE_NIGHT_MASK) == UI_MODE_NIGHT_YES;
     }
 
     public void setPriorityListener(DisplayInfoChangeListener listener) {
@@ -579,11 +595,7 @@ public class DisplayController implements DesktopVisibilityListener {
             mStableDensityScaleFactor = (float) defaultDensityDpi / DisplayMetrics.DENSITY_DEFAULT;
             mScreenSizeDp = new PortraitSize(config.screenHeightDp, config.screenWidthDp);
             navigationMode = wmProxy.getNavigationMode(displayInfoContext);
-            if (Utilities.ATLEAST_R) {
-                mIsNightModeActive = config.isNightModeActive();
-            } else {
-                mIsNightModeActive = (config.uiMode & UI_MODE_NIGHT_MASK) == UI_MODE_NIGHT_YES;
-            }
+            mIsNightModeActive = isNightModeActiveCompat(config);
 
             // LC: Hacky stuff but it work!
             mIsFoldable = Utilities.ATLEAST_R && displayInfoContext.getPackageManager()


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Fix crash coming from `Configuration.isNightModeActive()` on Android 10 and lower during system theme mode switching.

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Toggle the system theme mode (light mode <-> dark mode) and observe.

Tested on Huawei Honor 10 lite

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved night-mode detection across supported Android versions.
  * Ensured configuration updates and launcher display information consistently reflect the active night mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->