### PR TITLE
fix: Inconsistent L3 theming around work pfp and widget selector

### DIFF
--- a/lawnchair/src/app/lawnchair/theme/drawable/DrawableTokens.kt
+++ b/lawnchair/src/app/lawnchair/theme/drawable/DrawableTokens.kt
@@ -187,6 +187,29 @@ object DrawableTokens {
         .setColor(ColorTokens.SurfaceContainerHighest)
 
     @JvmField
+    val WorkFabBackground = ResourceDrawableToken<RippleDrawable>(R.drawable.work_mode_fab_background)
+        .mutate { context, scheme, uiColorMode ->
+            val background = getDrawable(0) as? GradientDrawable
+            background?.setColor(ColorTokens.PrimaryButton.resolveColor(context, scheme, uiColorMode))
+        }
+
+    @JvmField
+    val WorkSchedulerBackground = ResourceDrawableToken<RippleDrawable>(R.drawable.work_scheduler_background)
+        .mutate { context, scheme, uiColorMode ->
+            val background = getDrawable(0) as? GradientDrawable
+            background?.setColor(ColorTokens.PrimaryButton.resolveColor(context, scheme, uiColorMode))
+        }
+
+    @JvmField
+    val WorkAppsPausedActionButton = ResourceDrawableToken<RippleDrawable>(R.drawable.bg_work_apps_paused_action_button)
+        .mutate { context, scheme, uiColorMode ->
+            val strokeWidth = context.resources.getDimensionPixelSize(R.dimen.work_apps_paused_button_stroke)
+            val strokeColor = ColorTokens.PrimaryButton.resolveColor(context, scheme, uiColorMode)
+            val background = findDrawableByLayerId(android.R.id.background) as? GradientDrawable
+            background?.setStroke(strokeWidth, strokeColor)
+        }
+
+    @JvmField
     val WidgetAddButtonBackground = ResourceDrawableToken<InsetDrawable>(R.drawable.widget_cell_add_button_background)
         .setTint(ColorTokens.WidgetAddButtonBackgroundColor)
 }

--- a/src/com/android/launcher3/allapps/WorkPausedCard.java
+++ b/src/com/android/launcher3/allapps/WorkPausedCard.java
@@ -33,6 +33,7 @@ import com.android.launcher3.views.ActivityContext;
 
 import app.lawnchair.font.FontManager;
 import app.lawnchair.theme.color.tokens.ColorTokens;
+import app.lawnchair.theme.drawable.DrawableTokens;
 
 /**
  * Work profile toggle switch shown at the bottom of AllApps work tab
@@ -62,13 +63,25 @@ public class WorkPausedCard extends LinearLayout implements View.OnClickListener
         mBtn = findViewById(R.id.enable_work_apps);
         mBtn.setOnClickListener(this);
 
+        setWorkProfilePausedResources();
         updateStringFromCache();
     }
 
     public void updateStringFromCache() {
         StringCache cache = mActivityContext.getStringCache();
         if (cache != null) {
-            setWorkProfilePausedResources();
+            if (cache.workProfilePausedTitle != null) {
+                TextView title = findViewById(R.id.work_apps_paused_title);
+                title.setText(cache.workProfilePausedTitle);
+            }
+            if (cache.workProfilePausedDescription != null) {
+                TextView body = findViewById(R.id.work_apps_paused_content);
+                body.setText(cache.workProfilePausedDescription);
+            }
+            if (cache.workProfileEnableButton != null) {
+                Button button = findViewById(R.id.enable_work_apps);
+                button.setText(cache.workProfileEnableButton);
+            }
         }
     }
 
@@ -81,11 +94,13 @@ public class WorkPausedCard extends LinearLayout implements View.OnClickListener
         TextView body = findViewById(R.id.work_apps_paused_content);
         body.setText(R.string.work_apps_paused_body);
         body.setTextColor(ColorTokens.TextColorPrimary.resolveColor(getContext()));
-        FontManager.INSTANCE.get(getContext()).setCustomFont(title, R.id.font_body_medium);
+        FontManager.INSTANCE.get(getContext()).setCustomFont(body, R.id.font_body_medium);
 
         Button button = findViewById(R.id.enable_work_apps);
         button.setText(R.string.work_apps_enable_btn_text);
-        FontManager.INSTANCE.get(getContext()).setCustomFont(title, R.id.font_button);
+        button.setBackground(DrawableTokens.WorkAppsPausedActionButton.resolve(getContext()));
+        button.setTextColor(ColorTokens.TextColorPrimary.resolveColor(getContext()));
+        FontManager.INSTANCE.get(getContext()).setCustomFont(button, R.id.font_button);
         button.setOnClickListener(this);
     }
 

--- a/src/com/android/launcher3/allapps/WorkUtilityView.java
+++ b/src/com/android/launcher3/allapps/WorkUtilityView.java
@@ -27,6 +27,7 @@ import android.animation.ObjectAnimator;
 import android.animation.ValueAnimator;
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.ColorStateList;
 import android.graphics.Rect;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
@@ -57,6 +58,10 @@ import com.android.launcher3.anim.KeyboardInsetAnimationCallback;
 import com.android.launcher3.logging.StatsLogManager;
 import com.android.launcher3.model.StringCache;
 import com.android.launcher3.views.ActivityContext;
+
+import app.lawnchair.font.FontManager;
+import app.lawnchair.theme.color.tokens.ColorTokens;
+import app.lawnchair.theme.drawable.DrawableTokens;
 
 import java.util.ArrayList;
 
@@ -136,6 +141,17 @@ public class WorkUtilityView extends LinearLayout implements Insettable,
         mSchedulerButton = findViewById(R.id.work_scheduler);
         mWorkUtilityView = findViewById(R.id.work_utility_view);
         setSelected(true);
+
+        // LC-Note: Theme work FAB and scheduler button with Lawnchair tokens
+        mWorkFAB.setBackground(DrawableTokens.WorkFabBackground.resolve(getContext()));
+        int onPrimaryColor = ColorTokens.TextColorPrimaryInverse.resolveColor(getContext());
+        mPauseText.setTextColor(onPrimaryColor);
+        mWorkIcon.setImageTintList(ColorStateList.valueOf(onPrimaryColor));
+        FontManager.INSTANCE.get(getContext()).setCustomFont(mPauseText, R.id.font_body_medium);
+
+        mSchedulerButton.setBackground(DrawableTokens.WorkSchedulerBackground.resolve(getContext()));
+        mSchedulerButton.setImageTintList(ColorStateList.valueOf(onPrimaryColor));
+
         KeyboardInsetAnimationCallback keyboardInsetAnimationCallback =
             null;
         if (Utilities.ATLEAST_R) {

--- a/src/com/android/launcher3/widget/WidgetCell.java
+++ b/src/com/android/launcher3/widget/WidgetCell.java
@@ -67,8 +67,10 @@ import com.android.launcher3.widget.util.WidgetSizes;
 
 import java.util.function.Consumer;
 
+import android.content.res.ColorStateList;
 import app.lawnchair.LawnchairAppWidgetHostView;
 import app.lawnchair.font.FontManager;
+import app.lawnchair.theme.color.tokens.ColorTokens;
 import app.lawnchair.theme.drawable.DrawableTokens;
 
 /**
@@ -165,6 +167,9 @@ public class WidgetCell extends LinearLayout {
         
         // LC: Allow customisability to the Add Button, Test: Press on any Widget on the Widget sheet.
         mWidgetAddButton.setBackground(DrawableTokens.WidgetAddButtonBackground.resolve(getContext()));
+        int widgetAddButtonTextColor = ColorTokens.TextColorPrimaryInverse.resolveColor(getContext());
+        mWidgetAddButton.setTextColor(widgetAddButtonTextColor);
+        mWidgetAddButton.setCompoundDrawableTintList(ColorStateList.valueOf(widgetAddButtonTextColor));
         fontManager.setCustomFont(mWidgetAddButton, R.id.font_body_medium);
 
         setAccessibilityDelegate(new AccessibilityDelegate() {


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Theme more or fix inconsistent style on Launcher3 components (specifically work profile, and widget area)

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Visual test

Tested on Huawei Honor 10 lite (Android 10)

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated Work Mode controls with consistent themed backgrounds, ripple effects, colors, and typography.
  - Improved the appearance of the Work Mode paused-app card, including its action button and text styling.
  - Refined the Work Mode FAB and scheduler button for clearer visual consistency.
  - Improved widget “Add” button text and icon contrast for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->