### PR TITLE
fix: Prediction settings intent open from Lawnchair instead

### DIFF
--- a/lawnchair/src/app/lawnchair/ui/preferences/PreferenceActivity.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/PreferenceActivity.kt
@@ -70,6 +70,7 @@ class PreferenceActivity : ComponentActivity() {
 
         private const val EXTRA_DESTINATION_ROUTE = "app.lawnchair.ui.preferences.DESTINATION_ROUTE"
 
+        @JvmStatic
         fun createIntent(context: Context, destination: PreferenceRoute): Intent {
             val intent = Intent(context, PreferenceActivity::class.java)
             val routeString = Json.encodeToString(destination)

--- a/quickstep/src/com/android/launcher3/hybridhotseat/HotseatEduController.java
+++ b/quickstep/src/com/android/launcher3/hybridhotseat/HotseatEduController.java
@@ -17,6 +17,7 @@ package com.android.launcher3.hybridhotseat;
 
 import static com.android.launcher3.logging.StatsLogManager.LauncherEvent.LAUNCHER_HOTSEAT_EDU_ONLY_TIP;
 
+import android.content.Context;
 import android.content.Intent;
 import android.graphics.Rect;
 import android.util.Log;
@@ -39,6 +40,9 @@ import com.android.launcher3.views.Snackbar;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
+
+import app.lawnchair.ui.preferences.PreferenceActivity;
+import app.lawnchair.ui.preferences.navigation.Predictions;
 
 /**
  * Controller class for managing user onboaridng flow for hybrid hotseat
@@ -70,7 +74,7 @@ public class HotseatEduController {
         migrateHotseatWhole();
         Snackbar.show(mLauncher, R.string.hotsaet_tip_prediction_enabled,
                 R.string.hotseat_prediction_settings, null,
-                () -> mLauncher.startActivity(getSettingsIntent()));
+                () -> mLauncher.startActivity(getLawnchairSettingsIntent(mLauncher)));
     }
 
     /**
@@ -158,7 +162,8 @@ public class HotseatEduController {
         if (childCount < mLauncher.getDeviceProfile().numShownHotseatIcons) {
             Snackbar.show(mLauncher, R.string.hotseat_tip_gaps_filled,
                     R.string.hotseat_prediction_settings, null,
-                    () -> mLauncher.startActivity(getSettingsIntent()));
+                    // LC-Note: Start Lawnchair prediction settings instead of AOSP
+                    () -> mLauncher.startActivity(getLawnchairSettingsIntent(mLauncher)));
         } else {
             showHotseatArrowTip(true, mLauncher.getString(R.string.hotseat_tip_no_empty_slots));
         }
@@ -241,6 +246,12 @@ public class HotseatEduController {
         mActiveDialog = HotseatEduDialog.getDialog(mLauncher);
         mActiveDialog.setHotseatEduController(this);
         mActiveDialog.show(mPredictedApps);
+    }
+
+    // LC-Note: Start Lawnchair prediction settings instead of AOSP
+    public static Intent getLawnchairSettingsIntent(Context context) {
+        return PreferenceActivity.createIntent(context, Predictions.INSTANCE)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
     }
 
     static Intent getSettingsIntent() {

--- a/quickstep/src/com/android/launcher3/hybridhotseat/HotseatPredictionController.java
+++ b/quickstep/src/com/android/launcher3/hybridhotseat/HotseatPredictionController.java
@@ -18,6 +18,7 @@ package com.android.launcher3.hybridhotseat;
 import static com.android.launcher3.LauncherAnimUtils.SCALE_PROPERTY;
 import static com.android.launcher3.LauncherState.NORMAL;
 import static com.android.launcher3.anim.AnimatorListeners.forSuccessCallback;
+import static com.android.launcher3.hybridhotseat.HotseatEduController.getLawnchairSettingsIntent;
 import static com.android.launcher3.hybridhotseat.HotseatEduController.getSettingsIntent;
 import static com.android.launcher3.logging.StatsLogManager.LauncherEvent.LAUNCHER_HOTSEAT_PREDICTION_PINNED;
 import static com.android.launcher3.logging.StatsLogManager.LauncherEvent.LAUNCHER_HOTSEAT_RANKED;
@@ -111,7 +112,8 @@ public class HotseatPredictionController implements DragController.DragListener,
         if (mEnableHotseatLongPressTipForTesting && !HOTSEAT_LONGPRESS_TIP_SEEN.get(mLauncher)) {
             Snackbar.show(mLauncher, R.string.hotseat_tip_gaps_filled,
                     R.string.hotseat_prediction_settings, null,
-                    () -> mLauncher.startActivity(getSettingsIntent()));
+                    // LC-Note: Start Lawnchair prediction settings instead of AOSP
+                    () -> mLauncher.startActivity(getLawnchairSettingsIntent(mLauncher)));
             LauncherPrefs.get(mLauncher).put(HOTSEAT_LONGPRESS_TIP_SEEN, true);
             mLauncher.getDragLayer().performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
             return true;


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Lawnchair prediction setting page is always available on all devices unlike one provided by Android or ASI and thus will not crash when Android prediction setting is unavailable. (Additionally, the change add a nice improvement to consistency where you will not see the ASI prediction settings when Lawnchair is set as prediction provider)

Fixes https://t.me/lccommunity/823700

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Tested on Huawei Honor 10 lite

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Hotseat onboarding now links directly to Lawnchair’s prediction settings.
  - Prediction-related actions open the dedicated Predictions page in Lawnchair preferences.
  - Improved compatibility for launching preference screens from Java-based components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->