### PR TITLE
fix: Widget sheet recycler view resource mismatch with AOSP

### DIFF
--- a/lawnchair/res/layout/widgets_two_pane_sheet_recyclerview.xml
+++ b/lawnchair/res/layout/widgets_two_pane_sheet_recyclerview.xml
@@ -68,7 +68,7 @@
                     android:tint="?attr/widgetPickerWidgetOptionsMenuColor" />
             </LinearLayout>
 
-            <LinearLayout
+            <FrameLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:id="@+id/suggestions_header"
@@ -77,7 +77,7 @@
                 android:paddingBottom="16dp"
                 android:background="?attr/widgetPickerPrimarySurfaceColor"
                 launcher:layout_sticky="true">
-            </LinearLayout>
+            </FrameLayout>
         </LinearLayout>
 
         <com.android.launcher3.widget.picker.WidgetsRecyclerView


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Correct Lawnchair specific two pane widget sheet recycler view resource to match AOSP to prevent CCE exception.

~~(Do not merge yet, there's gonna be a reason why we do it this way right?)~~

Fixes #7182

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

N/A, can't this issue reproduce in local environment which includes: Huawei Honor 10 lite (A10), Nothing 3a-series (A16 initial), and Pixel 7 (A17 QPR2 Beta 3)

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the layout behavior of the suggestions header in the two-pane view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->