### PR TITLE
fix: Keep wallpaper orientation stable when returning home

### DIFF
--- a/src/com/android/launcher3/Launcher.java
+++ b/src/com/android/launcher3/Launcher.java
@@ -1010,6 +1010,7 @@ public class Launcher extends StatefulActivity<LauncherState>
     @Override
     protected void onStop() {
         super.onStop();
+        mRotationHelper.setCurrentTransitionRequest(REQUEST_LOCK);
         if (mDeferOverlayCallbacks) {
             checkIfOverlayStillDeferred();
         } else {

--- a/tests/src/com/android/launcher3/integration/rotation/LauncherRotationIntegrationTest.kt
+++ b/tests/src/com/android/launcher3/integration/rotation/LauncherRotationIntegrationTest.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.launcher3.integration.rotation
+
+import android.content.Context
+import android.content.pm.ActivityInfo.SCREEN_ORIENTATION_LOCKED
+import android.content.pm.ActivityInfo.SCREEN_ORIENTATION_NOSENSOR
+import android.content.pm.ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+import android.content.pm.ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE
+import androidx.lifecycle.Lifecycle
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
+import com.android.launcher3.InvariantDeviceProfile.TYPE_PHONE
+import com.android.launcher3.Launcher
+import com.android.launcher3.LauncherPrefs
+import com.android.launcher3.LauncherPrefs.Companion.ALLOW_ROTATION
+import com.android.launcher3.integration.util.LauncherActivityScenarioRule
+import com.android.launcher3.util.Wait.atMost
+import org.junit.After
+import org.junit.Assume.assumeTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@LargeTest
+@RunWith(AndroidJUnit4::class)
+class LauncherRotationIntegrationTest {
+
+    private val targetContext: Context = getInstrumentation().targetContext
+    private val launcherActivity = LauncherActivityScenarioRule<Launcher>(targetContext)
+    private val originalAllowRotation = LauncherPrefs.get(targetContext).get(ALLOW_ROTATION)
+
+    @get:Rule val activityRule: LauncherActivityScenarioRule<Launcher> = launcherActivity
+
+    @Before
+    fun setup() {
+        assumeTrue(
+            "Wallpaper transition rotation lock is only needed on phones",
+            launcherActivity.getFromLauncher { it.deviceProfile.inv.deviceType } == TYPE_PHONE,
+        )
+    }
+
+    @After
+    fun cleanup() {
+        launcherActivity.executeOnLauncher { it.rotationHelper.setFixedLandscape(false) }
+        setAllowRotation(originalAllowRotation)
+    }
+
+    @Test
+    fun `stop locks rotation until home entry with rotation disabled`() {
+        setAllowRotation(false)
+        waitForOrientation(SCREEN_ORIENTATION_NOSENSOR)
+
+        stopAndResumeLauncher(SCREEN_ORIENTATION_LOCKED)
+
+        completeHomeEntry()
+        waitForOrientation(SCREEN_ORIENTATION_NOSENSOR)
+    }
+
+    @Test
+    fun `stop lock restores sensor rotation after home entry`() {
+        setAllowRotation(true)
+        waitForOrientation(SCREEN_ORIENTATION_UNSPECIFIED)
+
+        stopAndResumeLauncher(SCREEN_ORIENTATION_LOCKED)
+
+        completeHomeEntry()
+        waitForOrientation(SCREEN_ORIENTATION_UNSPECIFIED)
+    }
+
+    @Test
+    fun `fixed landscape remains authoritative across home entry`() {
+        launcherActivity.executeOnLauncher { it.rotationHelper.setFixedLandscape(true) }
+        waitForOrientation(SCREEN_ORIENTATION_USER_LANDSCAPE)
+
+        stopAndResumeLauncher(SCREEN_ORIENTATION_USER_LANDSCAPE)
+
+        completeHomeEntry()
+        waitForOrientation(SCREEN_ORIENTATION_USER_LANDSCAPE)
+    }
+
+    @Test
+    fun `repeated stop and home entry does not strand rotation lock`() {
+        setAllowRotation(false)
+        waitForOrientation(SCREEN_ORIENTATION_NOSENSOR)
+
+        repeat(2) {
+            stopAndResumeLauncher(SCREEN_ORIENTATION_LOCKED)
+            completeHomeEntry()
+            waitForOrientation(SCREEN_ORIENTATION_NOSENSOR)
+        }
+    }
+
+    private fun stopAndResumeLauncher(expectedOrientation: Int) {
+        launcherActivity.activity.moveToState(Lifecycle.State.CREATED)
+        waitForOrientation(expectedOrientation)
+        launcherActivity.activity.moveToState(Lifecycle.State.RESUMED)
+        waitForOrientation(expectedOrientation)
+    }
+
+    private fun completeHomeEntry() {
+        launcherActivity.executeOnLauncher { it.onEnterAnimationComplete() }
+    }
+
+    private fun setAllowRotation(allowRotation: Boolean) {
+        LauncherPrefs.get(targetContext).putSync(ALLOW_ROTATION.to(allowRotation))
+    }
+
+    private fun waitForOrientation(expectedOrientation: Int) {
+        atMost(
+            "Launcher did not request orientation $expectedOrientation",
+            { launcherActivity.getFromLauncher { it.requestedOrientation } == expectedOrientation },
+        )
+    }
+}


### PR DESCRIPTION
### Description

Use the transition-scoped orientation request already owned by `RotationHelper`: when `Launcher.onStop()` moves the home activity into the background, set its current-transition request to `REQUEST_LOCK` so Launcher and its wallpaper surface retain the last settled home orientation while another app is foregrounded. Keep the existing `Launcher.onEnterAnimationComplete()` release point, which clears the request only after the app-to-home animation finishes and then lets `RotationHelper` reapply the user's normal rotation preference, tablet behavior, or fixed-landscape policy. Add an instrumented lifecycle regression test using the existing `LauncherActivityScenarioRule` pattern to verify the lock is present while Launcher is stopped and is released after home entry.

When a phone-only Lawnchair home screen is configured to remain portrait, returning home from a landscape app lets the wallpaper participate in the orientation change before Launcher settles back to portrait. The resulting wallpaper rotation produces a black frame and visible flicker on the reported Galaxy S25+ / Android 15 setup. The reproduction is a normal app-to-home lifecycle transition and does not require changing wallpaper content, scrolling, or zoom behavior. The bundled issue evidence shows no assignee, claim, competing open PR, or closed prior attempt.

Fixes #5772

### Reasoning

Not applicable to this change.

### Testing

Not applicable to this change.

### Type of change

:x: **Bug fix** (A non-breaking change that fixes an issue)
:x: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rotation handling when the Launcher stops and resumes.
  * Prevented unexpected orientation changes during shutdown and transitions.

* **Tests**
  * Added coverage for rotation behavior across home-entry animations, repeated stop/resume cycles, rotation preferences, and fixed-landscape mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->