### PR TITLE
fix: Legacy shortcut does not show source target app

### DIFF
--- a/src/com/android/launcher3/icons/IconCache.java
+++ b/src/com/android/launcher3/icons/IconCache.java
@@ -49,6 +49,7 @@ import androidx.core.util.Pair;
 
 import com.android.launcher3.Flags;
 import com.android.launcher3.InvariantDeviceProfile;
+import com.android.launcher3.LauncherSettings.Favorites;
 import com.android.launcher3.Utilities;
 import com.android.launcher3.dagger.ApplicationContext;
 import com.android.launcher3.dagger.LauncherAppSingleton;
@@ -337,6 +338,15 @@ public class IconCache extends BaseIconCache {
         return getShortcutInfoBadgeItem(shortcutInfo).bitmap;
     }
 
+    /**
+     * LC-Note: Returns the package icon to use as the badge for a shortcut.
+     */
+    public BitmapInfo getShortcutInfoBadge(String packageName, UserHandle user) {
+        PackageItemInfo pkgInfo = new PackageItemInfo(packageName, user);
+        getTitleAndIconForApp(pkgInfo, DEFAULT_LOOKUP_FLAG);
+        return pkgInfo.bitmap;
+    }
+
     @VisibleForTesting
     protected ItemInfoWithIcon getShortcutInfoBadgeItem(ShortcutInfo shortcutInfo) {
         // Check for badge override first.
@@ -460,6 +470,12 @@ public class IconCache extends BaseIconCache {
         Map<Pair<UserHandle, CacheLookupFlag>, List<IconRequestInfo<T>>> iconLoadSubsectionsMap =
                 iconRequestInfos.stream()
                         .filter(iconRequest -> {
+                            // LC-Note:
+                            // Legacy shortcuts have custom icons and must not be replaced by
+                            // the icon of the launch target.
+                            if (iconRequest.itemInfo.itemType == Favorites.ITEM_TYPE_SHORTCUT) {
+                                return false;
+                            }
                             if (iconRequest.itemInfo.getTargetComponent() == null) {
                                 Log.i(TAG,
                                         "Skipping Item info with null component name: "

--- a/src/com/android/launcher3/icons/IconCache.java
+++ b/src/com/android/launcher3/icons/IconCache.java
@@ -383,6 +383,9 @@ public class IconCache extends BaseIconCache {
     public synchronized void getTitleAndIcon(
             @NonNull ItemInfoWithIcon info,
             @NonNull CacheLookupFlag lookupFlag) {
+        if (info.itemType == Favorites.ITEM_TYPE_SHORTCUT) {
+            return;
+        }
         // null info means not installed, but if we have a component from the intent then
         // we should still look in the cache for restored app icons.
         if (info.getTargetComponent() == null) {

--- a/src/com/android/launcher3/model/ModelUtils.java
+++ b/src/com/android/launcher3/model/ModelUtils.java
@@ -132,11 +132,8 @@ public class ModelUtils {
                 iconInfo = MODEL_EXECUTOR.submit(() -> baseIconInfo.withBadgeInfo(
                         iconCache.getShortcutInfoBadge(launchPackage, Process.myUserHandle())))
                         .get();
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                Log.e("LC-ModelUtils", "Interrupted while loading legacy shortcut badge", e);
-            } catch (ExecutionException e) {
-                Log.e("LC-ModelUtils", "Failed to load legacy shortcut badge", e);
+            } catch (InterruptedException | ExecutionException e) {
+                throw new RuntimeException("Failed to load legacy shortcut badge", e);
             }
         }
 

--- a/src/com/android/launcher3/model/ModelUtils.java
+++ b/src/com/android/launcher3/model/ModelUtils.java
@@ -19,22 +19,27 @@ import static com.android.launcher3.LauncherSettings.Favorites.CONTAINER_DESKTOP
 import static com.android.launcher3.LauncherSettings.Favorites.CONTAINER_HOTSEAT;
 import static com.android.launcher3.LauncherSettings.Favorites.ITEM_TYPE_APPWIDGET;
 import static com.android.launcher3.LauncherSettings.Favorites.ITEM_TYPE_CUSTOM_APPWIDGET;
+import static com.android.launcher3.util.Executors.MODEL_EXECUTOR;
 
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.os.BadParcelableException;
 import android.os.Process;
+import android.text.TextUtils;
 import android.util.Log;
 
+import com.android.launcher3.LauncherAppState;
 import com.android.launcher3.LauncherSettings;
 import com.android.launcher3.Utilities;
 import com.android.launcher3.icons.BitmapInfo;
+import com.android.launcher3.icons.IconCache;
 import com.android.launcher3.icons.LauncherIcons;
 import com.android.launcher3.model.data.ItemInfo;
 import com.android.launcher3.model.data.WorkspaceItemInfo;
 import com.android.launcher3.util.IntSet;
 
+import java.util.concurrent.ExecutionException;
 import java.util.function.Predicate;
 
 /**
@@ -114,6 +119,20 @@ public class ModelUtils {
         if (iconInfo == null) {
             Log.e(TAG, "Invalid icon by the app");
             return null;
+        }
+
+        String launchPackage = launchIntent.getComponent() == null
+                ? launchIntent.getPackage() : launchIntent.getComponent().getPackageName();
+        if (!TextUtils.isEmpty(launchPackage)) {
+            IconCache iconCache = LauncherAppState.getInstance(context).getIconCache();
+            BitmapInfo baseIconInfo = iconInfo;
+            try {
+                iconInfo = MODEL_EXECUTOR.submit(() -> baseIconInfo.withBadgeInfo(
+                        iconCache.getShortcutInfoBadge(launchPackage, Process.myUserHandle())))
+                        .get();
+            } catch (InterruptedException | ExecutionException e) {
+                Log.e(TAG, "Interrupted while loading legacy shortcut badge", e);
+            }
         }
 
         WorkspaceItemInfo info = new WorkspaceItemInfo();

--- a/src/com/android/launcher3/model/ModelUtils.java
+++ b/src/com/android/launcher3/model/ModelUtils.java
@@ -39,7 +39,9 @@ import com.android.launcher3.model.data.ItemInfo;
 import com.android.launcher3.model.data.WorkspaceItemInfo;
 import com.android.launcher3.util.IntSet;
 
+import java.util.Collections;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.function.Predicate;
 
 /**
@@ -130,8 +132,11 @@ public class ModelUtils {
                 iconInfo = MODEL_EXECUTOR.submit(() -> baseIconInfo.withBadgeInfo(
                         iconCache.getShortcutInfoBadge(launchPackage, Process.myUserHandle())))
                         .get();
-            } catch (InterruptedException | ExecutionException e) {
-                Log.e(TAG, "Interrupted while loading legacy shortcut badge", e);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                Log.e("LC-ModelUtils", "Interrupted while loading legacy shortcut badge", e);
+            } catch (ExecutionException e) {
+                Log.e("LC-ModelUtils", "Failed to load legacy shortcut badge", e);
             }
         }
 

--- a/src/com/android/launcher3/model/ModelUtils.java
+++ b/src/com/android/launcher3/model/ModelUtils.java
@@ -132,8 +132,11 @@ public class ModelUtils {
                 iconInfo = MODEL_EXECUTOR.submit(() -> baseIconInfo.withBadgeInfo(
                         iconCache.getShortcutInfoBadge(launchPackage, Process.myUserHandle())))
                         .get();
-            } catch (InterruptedException | ExecutionException e) {
-                throw new RuntimeException("Failed to load legacy shortcut badge", e);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                Log.e("LC-ModelUtils", "Interrupted while loading legacy shortcut badge", e);
+            } catch (ExecutionException e) {
+                Log.e("LC-ModelUtils", "Failed to load legacy shortcut badge", e);
             }
         }
 

--- a/src/com/android/launcher3/model/WorkspaceItemProcessor.kt
+++ b/src/com/android/launcher3/model/WorkspaceItemProcessor.kt
@@ -146,6 +146,15 @@ class WorkspaceItemProcessor(
         }
 
         val info = c.loadSimpleWorkspaceItem()
+
+        // LC-Note: Show badge for legacy shortcut when possible
+        val launchPackage = intent.component?.packageName ?: intent.`package`
+        if (!launchPackage.isNullOrEmpty()) {
+            info.bitmap = info.bitmap.withBadgeInfo(
+                iconCache.getShortcutInfoBadge(launchPackage, c.user)
+            )
+        }
+
         info.options = c.options
         if (
             intent.action != null &&


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Fix legacy shortcut does not show source target app, in order word, make legacy shortcut which app the shortcut open in a form of a badge just like a normal app shortcut.

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Place legacy shortcut -> observe

Tested on Pixel 7, non-root, Android 17 QPR2 Beta 3

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved legacy shortcut icons by applying the appropriate application badge when available.
  * Improved badge selection using the shortcut’s associated application or launch component when available.
  * Preserved custom shortcut icons during individual and bulk icon loading.
  * Added fallback handling so shortcuts remain usable when badge retrieval is interrupted or unavailable.
  * Improved consistency of shortcut appearance across workspace loading and icon refresh operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->