### PR TITLE
fix: mark the first rendered search result as quick launch

### DIFF
--- a/lawnchair/src/app/lawnchair/search/algorithms/LawnchairSearchAlgorithm.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/LawnchairSearchAlgorithm.kt
@@ -74,13 +74,15 @@ sealed class LawnchairSearchAlgorithm(
         roundBottom = true,
     )
 
+    /** Drops the targets that never get bound to a view. */
+    private fun List<SearchTargetCompat>.filterRenderable(): List<SearchTargetCompat> = asSequence()
+        .filter { it.packageName != BuildConfig.APPLICATION_ID }
+        .filter { LawnchairSearchAdapterProvider.viewTypeMap[it.layoutType] != null }
+        .removeDuplicateDividers()
+        .toList()
+
     protected fun transformSearchResults(results: List<SearchTargetCompat>): List<SearchAdapterItem> {
-        val filtered = results
-            .asSequence()
-            .filter { it.packageName != BuildConfig.APPLICATION_ID }
-            .filter { LawnchairSearchAdapterProvider.viewTypeMap[it.layoutType] != null }
-            .removeDuplicateDividers()
-            .toList()
+        val filtered = results.filterRenderable()
 
         val appAndShortcutIndices = findAppAndShorcutIndices(filtered)
         val smallIconIndices = findIndices(filtered, SMALL_ICON_HORIZONTAL_TEXT)
@@ -125,17 +127,12 @@ sealed class LawnchairSearchAlgorithm(
     }
 
     protected fun setFirstItemQuickLaunch(searchTargets: List<SearchTargetCompat>) {
-        val hasQuickLaunch = searchTargets.any { it.extras.getBoolean(EXTRA_QUICK_LAUNCH, false) }
-        if (!hasQuickLaunch) {
-            // check if we have a header or spacer item. if so, we skip as there isn't any relevant
-            // action to be applied
-            val target = searchTargets.getOrNull(
-                searchTargets.indexOfFirst { it.layoutType != TEXT_HEADER },
-            )
-            target?.extras?.apply {
-                putBoolean(EXTRA_QUICK_LAUNCH, true)
-            }
-        }
+        // Only renderable targets are bound to a view, so marking one that is dropped later would
+        // leave the results with nothing for enter to launch. Headers have no action to apply.
+        val renderable = searchTargets.filterRenderable()
+        if (renderable.any { it.extras.getBoolean(EXTRA_QUICK_LAUNCH, false) }) return
+        renderable.firstOrNull { it.layoutType != TEXT_HEADER }
+            ?.extras?.putBoolean(EXTRA_QUICK_LAUNCH, true)
     }
 
     private fun findIndices(filtered: List<SearchTargetCompat>, layoutType: String): List<Int> {

--- a/lawnchair/src/app/lawnchair/search/algorithms/LawnchairSearchAlgorithm.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/LawnchairSearchAlgorithm.kt
@@ -128,11 +128,13 @@ sealed class LawnchairSearchAlgorithm(
 
     protected fun setFirstItemQuickLaunch(searchTargets: List<SearchTargetCompat>) {
         // Only renderable targets are bound to a view, so marking one that is dropped later would
-        // leave the results with nothing for enter to launch. Headers have no action to apply.
-        val renderable = searchTargets.filterRenderable()
-        if (renderable.any { it.extras.getBoolean(EXTRA_QUICK_LAUNCH, false) }) return
-        renderable.firstOrNull { it.layoutType != TEXT_HEADER }
-            ?.extras?.putBoolean(EXTRA_QUICK_LAUNCH, true)
+        // leave the results with nothing for enter to launch. Headers and dividers have no action
+        // to apply: a divider survives filtering whenever a header precedes it.
+        val candidates = searchTargets.filterRenderable().filter {
+            it.layoutType != TEXT_HEADER && it.layoutType != EMPTY_DIVIDER
+        }
+        if (candidates.any { it.extras.getBoolean(EXTRA_QUICK_LAUNCH, false) }) return
+        candidates.firstOrNull()?.extras?.putBoolean(EXTRA_QUICK_LAUNCH, true)
     }
 
     private fun findIndices(filtered: List<SearchTargetCompat>, layoutType: String): List<Int> {


### PR DESCRIPTION
### Description

Pressing Enter in the drawer search does nothing for some queries, and no result is highlighted at all — no pill background, no arrow hint in the search bar.

`setFirstItemQuickLaunch()` flags the first target in the **raw** target list, but `transformSearchResults()` filters that list before building adapter items, dropping targets with no matching view type and targets belonging to Lawnchair itself. When the flagged target is one of the dropped ones, no bound view carries `EXTRA_QUICK_LAUNCH`, so `launchHighlightedItem()` has nothing to launch.

This happens whenever Lawnchair's own entry sorts first — i.e. queries matching its app name (`l`, `la`, `law`, …). Confirmed on device by logging every bind:

```
'ins' → types=[short_icon_row × 5, header]  → bind pos=0 'Instagram' quick=true   ✓
'law' → types=[icon × 5, header]            → bind pos=0 'Drive'     quick=false  ✗
        (6 targets in, 5 adapter items out — the flagged one was filtered away)
```

Both now select from the same filtered list, extracted as `filterRenderable()`.

### Testing

Tested on a Pixel 8 Pro (Android 16) with the Local search algorithm, on a clean user profile. Searched queries matching Lawnchair's own app name and confirmed the first result is highlighted and Enter launches it; verified unaffected queries are unchanged.

## Before

https://github.com/user-attachments/assets/6036d579-0a20-4938-82dc-5006a4da6d49

## After

https://github.com/user-attachments/assets/afd85f7b-89f2-47a4-a710-e92a69d024cd

### Type of change

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
:x: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search results by removing entries that cannot be displayed and eliminating duplicate dividers.
  * Prevented the app itself from appearing in its own search results.
  * Improved Quick Launch behavior so it consistently highlights the first valid, actionable result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->