### PR TITLE
fix: open the first search result when Enter is pressed before results load

### DIFF
--- a/lawnchair/src/app/lawnchair/search/LawnchairSearchAdapterProvider.kt
+++ b/lawnchair/src/app/lawnchair/search/LawnchairSearchAdapterProvider.kt
@@ -38,6 +38,10 @@ class LawnchairSearchAdapterProvider(
         append(SEARCH_RESULT_EMPTY_STATE, R.layout.search_result_empty_state)
         append(SEARCH_RESULT_SEARCH_SETTINGS, R.layout.search_result_search_settings)
     }
+
+    /** Query the user pressed enter on before there was anything to launch, if any. */
+    private var pendingQuickLaunchQuery: String? = null
+
     private var quickLaunchItem: SearchResultView? = null
         set(value) {
             field = value
@@ -47,6 +51,9 @@ class LawnchairSearchAdapterProvider(
                 field != null,
             )
             appsView.mSearchRecyclerView.invalidate()
+            if (value != null) {
+                runPendingQuickLaunch()
+            }
         }
 
     override fun isViewSupported(viewType: Int): Boolean = layoutIdMap.contains(viewType)
@@ -92,7 +99,38 @@ class LawnchairSearchAdapterProvider(
 
     override fun getItemsPerRow(viewType: Int, appsPerRow: Int) = if (viewType != SEARCH_RESULT_ICON) 1 else super.getItemsPerRow(viewType, appsPerRow)
 
-    override fun launchHighlightedItem(): Boolean = quickLaunchItem?.launch() ?: false
+    override fun launchHighlightedItem(): Boolean {
+        val item = quickLaunchItem
+        if (item != null) {
+            pendingQuickLaunchQuery = null
+            return item.launch()
+        }
+        val query = currentQuery()
+        if (query.isNullOrBlank()) return false
+        pendingQuickLaunchQuery = query
+        // Consume the press. Unhandled, it would advance focus off the single line search field,
+        // closing the keyboard and leaving the user unable to press enter again.
+        return true
+    }
+
+    private fun currentQuery() = appsView.searchUiManager.editText?.text?.toString()
+
+    /** Opens the first result if the user pressed enter before there was one. */
+    private fun runPendingQuickLaunch() {
+        if (pendingQuickLaunchQuery == null) return
+        // Launching mid bind would tear down all apps while the recycler view is still laying out.
+        appsView.mSearchRecyclerView.post {
+            val query = pendingQuickLaunchQuery ?: return@post
+            if (query != currentQuery()) {
+                pendingQuickLaunchQuery = null
+                return@post
+            }
+            // A newer batch of results may have cleared the item again; wait for the next bind.
+            val item = quickLaunchItem ?: return@post
+            pendingQuickLaunchQuery = null
+            item.launch()
+        }
+    }
 
     override fun getHighlightedItem() = quickLaunchItem as View?
 

--- a/lawnchair/src/app/lawnchair/search/LawnchairSearchAdapterProvider.kt
+++ b/lawnchair/src/app/lawnchair/search/LawnchairSearchAdapterProvider.kt
@@ -137,6 +137,11 @@ class LawnchairSearchAdapterProvider(
     override fun clearHighlightedItem() {
         super.clearHighlightedItem()
         quickLaunchItem = null
+        // Results are coming in for a different query, so a press queued for the old one is stale.
+        // Without this it could be revived by typing the old query back in.
+        if (pendingQuickLaunchQuery != currentQuery()) {
+            pendingQuickLaunchQuery = null
+        }
     }
 
     override fun getDecorator() = decorator


### PR DESCRIPTION
### Description

Typing a query and hitting Enter before the results render does nothing — the press is dropped. The search field also loses focus and the keyboard closes, so Enter can't be pressed again without re-focusing.

Two causes:

- `launchHighlightedItem()` returned `false` when no result was bound yet, discarding the press.
- Returning `false` leaves the action unhandled, so it falls through to `TextView.onKeyUp`, where a `singleLine` EditText advances focus on Enter. You can see this on the keyboard itself: the **→ (Go)** key flips to a **↵ (return)** key the moment the field is unfocused.

The press is now remembered along with the query it was made for, and the first result opens as soon as one is bound. It retries on each bind, since results are published in several batches per query (local search combines app, calculator, web-suggestion and settings providers) and every batch clears the highlighted item via `clearHighlightedItem()`. The press is dropped as soon as the query changes, so it can never open a result the user didn't ask for.

The launch is posted rather than run inline because the retry fires from `onBindView`, and tearing down All Apps during the recycler view's layout pass is not safe.

Independent of #7200, but related — that one fixes queries where no result gets flagged at all, so a query matching Lawnchair's own app name will show nothing to open until both land.

### Testing

Tested on a Pixel 8 Pro (Android 16) with the Local search algorithm, on a clean user profile:

- Enter before results appear → the first result opens once it lands
- Enter after results appear → unchanged
- Typing on after an early Enter → opens nothing
- Enter on an empty query → does nothing

Verified with logging that the queued press is cancelled on the next keystroke and when the search resets.

## Before

https://github.com/user-attachments/assets/3a77d7f6-950e-4a41-a4b3-d2e90cfdcf95

## After

https://github.com/user-attachments/assets/1838227f-0e02-4736-8d41-e8a87ce69192

### Type of change

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
:x: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Enter-key handling when launching quick actions.
  * Prevented launches for unavailable or outdated search results.
  * Ensured matching quick-launch results open reliably once available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->