### PR TITLE
fix: OEM report incorrect unit for battery's microampere

### DIFF
--- a/lawnchair/src/app/lawnchair/smartspace/provider/BatteryStatusProvider.kt
+++ b/lawnchair/src/app/lawnchair/smartspace/provider/BatteryStatusProvider.kt
@@ -114,7 +114,7 @@ class BatteryStatusProvider(context: Context) :
 
             val powerWatts = normalizedAmps * voltageVolts
 
-            Log.d("BatteryStatusProvider", "Power: ${"%.2f".format(powerWatts)}W, Voltage:${voltageVolts}V, Raw Amp: ${currentAmps}, Normalized Amp: ${normalizedAmps}A")
+            Log.d("BatteryStatusProvider", "Power: ${"%.2f".format(powerWatts)}W, Voltage:${voltageVolts}V, Raw Amp: $currentAmps, Normalized Amp: ${normalizedAmps}A")
 
             return powerWatts
         }.getOrDefault(0f)

--- a/lawnchair/src/app/lawnchair/smartspace/provider/BatteryStatusProvider.kt
+++ b/lawnchair/src/app/lawnchair/smartspace/provider/BatteryStatusProvider.kt
@@ -100,12 +100,21 @@ class BatteryStatusProvider(context: Context) :
             if (voltageMilliVolts <= 0 || currentMicroAmps == Long.MIN_VALUE) return 0f
 
             // Some devices report negative current when charging
-            val currentAmps = abs(currentMicroAmps).toFloat() / 1_000_000f
+            val currentAmps = abs(currentMicroAmps).toFloat()
+
+            // If the ampere reading is suspiciously low, then the unit may be in milliampere
+            // instead of microampere.
+            val normalizedAmps = if (currentAmps < 10_000) {
+                currentAmps / 1_000f // Milliampere
+            } else {
+                currentAmps / 1_000_000f // Microampere
+            }
+
             val voltageVolts = voltageMilliVolts.toFloat() / 1000f
 
-            val powerWatts = currentAmps * voltageVolts
+            val powerWatts = normalizedAmps * voltageVolts
 
-            Log.d("BatteryStatusProvider", "Power: ${"%.2f".format(powerWatts)}W, Voltage:${voltageVolts}V, Amp: ${currentAmps}A")
+            Log.d("BatteryStatusProvider", "Power: ${"%.2f".format(powerWatts)}W, Voltage:${voltageVolts}V, Raw Amp: ${currentAmps}, Normalized Amp: ${normalizedAmps}A")
 
             return powerWatts
         }.getOrDefault(0f)


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Fix a problem where battery provider report 0 wattage because certain OEM or devices report microampere as milliampere thus making the calculation wrong.

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Huawei Honor 10 lite, Android 10 (EMUI 10, Huawei)

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved charging power estimates across devices with different battery-current reporting formats.
  * Corrected handling of negative and low-range current readings for more accurate wattage display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->