### PR TITLE
feat: Add "Show labels" toggle for folder labels in the Dock

### DIFF
--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
@@ -810,6 +810,11 @@ class PreferenceManager2 @Inject constructor(
         defaultValue = false,
     )
 
+    val enableFolderLabelInDock = preference(
+        key = booleanPreferencesKey(name = "enable_folder_label_dock"),
+        defaultValue = false,
+    )
+
     val doubleTapGestureHandler = serializablePreference<GestureHandlerConfig>(
         key = stringPreferencesKey("double_tap_gesture_handler"),
         defaultValue = GestureHandlerConfig.Sleep,
@@ -911,6 +916,12 @@ class PreferenceManager2 @Inject constructor(
             .launchIn(scope)
 
         enableLabelInDock.get()
+            .drop(1)
+            .distinctUntilChanged()
+            .onEach { reloadHelper.reloadGrid() }
+            .launchIn(scope)
+
+        enableFolderLabelInDock.get()
             .drop(1)
             .distinctUntilChanged()
             .onEach { reloadHelper.reloadGrid() }

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/DockPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/DockPreferences.kt
@@ -87,6 +87,12 @@ fun DockPreferences(modifier: Modifier = Modifier) {
                     label = stringResource(id = R.string.show_labels),
                 )
             }
+            PreferenceGroup(heading = stringResource(id = R.string.folders_label)) {
+                SwitchPreference(
+                    adapter = prefs2.enableFolderLabelInDock.getAdapter(),
+                    label = stringResource(id = R.string.show_labels),
+                )
+            }
         }
     }
 }

--- a/src/com/android/launcher3/DeviceProfile.java
+++ b/src/com/android/launcher3/DeviceProfile.java
@@ -897,7 +897,8 @@ public class DeviceProfile {
     /** Updates hotseatCellHeightPx and hotseatBarSizePx */
     private void updateHotseatSizes(int hotseatIconSizePx) {
         int iconTextHeight = Utilities.calculateTextHeight(iconTextSizePx);
-        boolean isLabelInDock = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getEnableLabelInDock());
+        boolean isLabelInDock = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getEnableLabelInDock())
+                || PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getEnableFolderLabelInDock());
         HotseatMode hotseatMode = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.getHotseatMode());
         boolean isQsbEnable = hotseatMode.getLayoutResourceId() != R.layout.empty_view;
         // Ensure there is enough space for folder icons, which have a slightly larger radius.

--- a/src/com/android/launcher3/WorkspaceLayoutManager.java
+++ b/src/com/android/launcher3/WorkspaceLayoutManager.java
@@ -123,7 +123,7 @@ public interface WorkspaceLayoutManager {
                 PreferenceManager2 prefs = PreferenceManager2.getInstance(child.getContext());
                 ((FolderIcon) child).setTextVisible(
                         PreferenceCacheExtensionsKt.firstCached(
-                                prefs.getEnableLabelInDock()));
+                                prefs.getEnableFolderLabelInDock()));
             }
         } else {
             // Show folder title if not in the hotseat


### PR DESCRIPTION
### Description
Adds a setting to control folder label visibility on the Dock, matching the existing app icon label visibility toggle.

Defaults to untoggled (folder label icons invisible.)

### Testing
Tested on Samsung Galaxy Flip7. Toggled the setting on and off and confirmed dock folder labels show/hide correctly.

<img width="1079" height="4160" alt="Screenshot_20260827_193227_Lawnchair (Debug)" src="https://github.com/user-attachments/assets/770f281e-6fa1-4e64-9990-7ba3e12b8f32" />
<img width="1067" height="4146" alt="Screenshot_20260827_193308_Lawnchair (Debug)" src="https://github.com/user-attachments/assets/c4d83130-596a-47f7-ae4e-7206acddd92c" />

Closes LawnchairLauncher/lawnchair#6232

Written with the assistance of Claude Code. Claude-Session: https://claude.ai/code/session_01S8BCsYnGTuLXZQcvBYVPM2

:x: **Bug fix** (A non-breaking change that fixes an issue)
:white_check_mark: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option in Dock settings to show or hide labels for folders placed in the dock.
  * Dock spacing and layout now adjust automatically when folder labels are enabled.
  * Changes take effect immediately after updating the preference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->