### PR TITLE
feat: Add Quickstep Protolog for Baklava

### DIFF
--- a/quickstep/src/com/android/quickstep/QuickstepProcessInitializer.java
+++ b/quickstep/src/com/android/quickstep/QuickstepProcessInitializer.java
@@ -23,6 +23,7 @@ import android.os.UserManager;
 import android.util.Log;
 import android.view.ThreadedRenderer;
 
+import app.lawnchair.LawnchairApp;
 import com.android.launcher3.BuildConfig;
 import com.android.launcher3.MainProcessInitializer;
 import com.android.quickstep.util.QuickstepProtoLogGroup;
@@ -66,6 +67,10 @@ public class QuickstepProcessInitializer extends MainProcessInitializer {
                                 ThreadedRenderer.EGL_CONTEXT_PRIORITY_HIGH_IMG);
         } catch (Exception e) {
                 Log.e(TAG, "init: " + e);
+        }
+
+        if (Utilities.ATLEAST_BAKLAVA && LawnchairApp.isRecentsEnabled()) {
+            QuickstepProtoLogGroup.initProtoLog();
         }
     }
 }

--- a/quickstep/src_protolog/com/android/quickstep/util/QuickstepProtoLogGroup.java
+++ b/quickstep/src_protolog/com/android/quickstep/util/QuickstepProtoLogGroup.java
@@ -51,6 +51,7 @@ public enum QuickstepProtoLogGroup implements IProtoLogGroup {
         return Variables.sIsInitialized;
     }
 
+    @RequiresApi(36)
     public static void initProtoLog() {
         if (Variables.sIsInitialized) {
             Log.e(Constants.TAG,


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Expose quickstep protolog to logcat for more indepth analysis of quickstep feature when user is on Android 16 initial and above and is using Lawnchair as Recents provider

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->

Make Recents feature more indepth and should hopefully give us more clue on where to fix things in logcat.

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Nothing (3a)-series, Android 16 Initial

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **New feature** (A non-breaking change that adds functionality)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Quickstep logging initialization on supported newer Android versions when the recents feature is enabled.
  * Added compatibility safeguards to ensure logging setup only runs on appropriate platform versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->