### PR TITLE
chore: Clean up experimental expressive API opt-in

### DIFF
--- a/lawnchair/src/app/lawnchair/backup/ui/CreateBackupScreen.kt
+++ b/lawnchair/src/app/lawnchair/backup/ui/CreateBackupScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -54,7 +53,6 @@ import app.lawnchair.util.removeFlag
 import com.android.launcher3.R
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun CreateBackupScreen(
     viewModel: CreateBackupViewModel,

--- a/lawnchair/src/app/lawnchair/backup/ui/RestoreBackupScreen.kt
+++ b/lawnchair/src/app/lawnchair/backup/ui/RestoreBackupScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -112,7 +111,6 @@ fun RestoreBackupScreen(
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun ColumnScope.RestoreBackupOptions(
     isPortrait: Boolean,

--- a/lawnchair/src/app/lawnchair/gestures/handlers/GestureWithAccessibilityHandler.kt
+++ b/lawnchair/src/app/lawnchair/gestures/handlers/GestureWithAccessibilityHandler.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -43,7 +42,6 @@ object GestureWithAccessibilityHandler {
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun ServiceWarningDialog(
     title: Int,

--- a/lawnchair/src/app/lawnchair/ui/OverflowMenuGrouped.kt
+++ b/lawnchair/src/app/lawnchair/ui/OverflowMenuGrouped.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.MoreVert
 import androidx.compose.material3.DropdownMenuPopup
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
@@ -12,7 +11,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import app.lawnchair.ui.preferences.components.layout.ClickableIcon
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun OverflowMenuGrouped(
     modifier: Modifier = Modifier,

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/ChangesDialog.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/ChangesDialog.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
@@ -36,7 +35,7 @@ import com.android.launcher3.R
 import java.time.Instant
 import java.util.concurrent.TimeUnit
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ChangesDialog(
     changelogState: ChangelogState?,
@@ -120,7 +119,6 @@ fun ChangesDialog(
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun CommitItem(
     commit: GitHubCommit,

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/ContributorRow.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/ContributorRow.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -85,7 +84,6 @@ fun ContributorRow(
  * @param onClick The action to perform when the row is clicked.
  * @param modifier Optional [Modifier] for customization.
  */
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun ContributorRow(
     name: String,

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/LawnchairLink.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/LawnchairLink.kt
@@ -28,7 +28,6 @@ import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -84,7 +83,6 @@ fun LawnchairLink(
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun HorizontalLawnchairLink(
     @DrawableRes iconResId: Int,

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/UpdateSection.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/UpdateSection.kt
@@ -9,7 +9,6 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -30,7 +29,6 @@ import app.lawnchair.util.getApkVersionComparison
 import com.android.launcher3.R
 import java.io.File
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun UpdateSection(
     updateState: UpdateState,

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/AnnouncementPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/AnnouncementPreference.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.Launch
 import androidx.compose.material.icons.rounded.NewReleases
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.LocalTextStyle
@@ -136,7 +135,6 @@ private fun AnnouncementItem(
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun AnnouncementItemContent(
     text: String,
@@ -215,7 +213,6 @@ fun calculateAlpha(progress: Float): Float {
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun AnnouncementPreferenceItemContent(
     text: String,

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/AppItem.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/AppItem.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -128,7 +127,6 @@ fun AppItemPlaceholder(
     )
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun AppItemLayout(
     icon: @Composable () -> Unit,

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/FontPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/FontPreference.kt
@@ -1,6 +1,5 @@
 package app.lawnchair.ui.preferences.components
 
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -13,7 +12,6 @@ import app.lawnchair.ui.preferences.navigation.GeneralFontSelection
 import com.android.launcher3.util.MSDLPlayerWrapper
 import com.google.android.msdl.data.model.MSDLToken
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun FontPreference(
     fontPref: BasePreferenceManager.FontPref,

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/GestureHandlerPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/GestureHandlerPreference.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.RadioButton
@@ -43,7 +42,6 @@ import com.android.launcher3.util.MSDLPlayerWrapper
 import com.google.android.msdl.data.model.MSDLToken
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun GestureHandlerPreference(
     adapter: PreferenceAdapter<GestureHandlerConfig>,
@@ -115,7 +113,6 @@ fun GestureHandlerPreference(
     )
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun AppGesturePreference(
     cmp: ComponentKey,

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/NavigationActionPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/NavigationActionPreference.kt
@@ -16,7 +16,6 @@
 
 package app.lawnchair.ui.preferences.components
 
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -30,7 +29,6 @@ import app.lawnchair.ui.util.preview.PreviewLawnchair
 import com.android.launcher3.util.MSDLPlayerWrapper
 import com.google.android.msdl.data.model.MSDLToken
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun NavigationActionPreference(
     label: String,

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/NotificationDotsPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/NotificationDotsPreference.kt
@@ -23,7 +23,6 @@ import android.os.Bundle
 import android.provider.Settings
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -53,7 +52,6 @@ import com.google.android.msdl.data.model.MSDLToken
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.callbackFlow
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun NotificationDotsPreference(
     enabled: Boolean,

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/OverlayHandlerPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/OverlayHandlerPreference.kt
@@ -4,7 +4,6 @@ import android.R as AndroidR
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.RadioButton
@@ -32,7 +31,6 @@ val overlayOptions = listOf(
     FullScreenOverlayMode.FADE_IN,
 )
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun OverlayHandlerPreference(
     adapter: PreferenceAdapter<FullScreenOverlayMode>,

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/PermissionDialog.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/PermissionDialog.kt
@@ -20,7 +20,6 @@ import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -57,7 +56,6 @@ import com.google.accompanist.permissions.shouldShowRationale
  * @param onGoToSettings Called when the user clicks the "Go to settings" button.
  * @param modifier The modifier to be applied to the dialog.
  */
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun PermissionDialog(
     title: String,
@@ -104,7 +102,7 @@ fun PermissionDialog(
  * @param modifier The modifier to be applied to the dialog.
  * @param onPermissionRequest Called when a permission request is initiated.
  */
-@OptIn(ExperimentalPermissionsApi::class, ExperimentalMaterial3ExpressiveApi::class)
+@OptIn(ExperimentalPermissionsApi::class)
 @Composable
 fun WallpaperAccessPermissionDialog(
     managedFilesChecked: Boolean,

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/WallpaperPreview.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/WallpaperPreview.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Wallpaper
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -43,7 +42,6 @@ import com.google.accompanist.drawablepainter.rememberDrawablePainter
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun ColumnScope.WithWallpaper(
     modifier: Modifier = Modifier,

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/colorpreference/ColorPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/colorpreference/ColorPreference.kt
@@ -16,7 +16,6 @@
 
 package app.lawnchair.ui.preferences.components.colorpreference
 
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -58,7 +57,6 @@ fun ColorPreference(
     )
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun ColorPreference(
     label: String,

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/colorpreference/ColorSelectionPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/colorpreference/ColorSelectionPreference.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
@@ -39,7 +38,6 @@ import com.google.android.msdl.data.model.MSDLToken
 import com.patrykmichalik.opto.domain.Preference
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun ColorSelection(
     label: String,

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/colorpreference/ColorSlider.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/colorpreference/ColorSlider.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
@@ -36,7 +35,6 @@ import com.android.launcher3.util.MSDLPlayerWrapper
 import com.google.android.msdl.data.model.MSDLToken
 import kotlin.math.roundToInt
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun RgbColorSlider(
     label: String,
@@ -105,7 +103,6 @@ fun RgbColorSlider(
     )
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun HsbColorSlider(
     type: HsbSliderType,

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/colorpreference/pickers/PresetsList.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/colorpreference/pickers/PresetsList.kt
@@ -2,7 +2,6 @@ package app.lawnchair.ui.preferences.components.colorpreference.pickers
 
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -20,7 +19,6 @@ import com.android.launcher3.R
 import com.android.launcher3.util.MSDLPlayerWrapper
 import com.google.android.msdl.data.model.MSDLToken
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun PresetsList(
     dynamicEntries: List<ColorPreferenceEntry<ColorOption>>,

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/controls/ClickablePreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/controls/ClickablePreference.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.ListItemColors
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
@@ -40,7 +39,6 @@ import app.lawnchair.ui.util.preview.PreviewLawnchair
 import com.android.launcher3.util.MSDLPlayerWrapper
 import com.google.android.msdl.data.model.MSDLToken
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun ClickablePreference(
     label: String,
@@ -80,7 +78,6 @@ fun ClickablePreference(
     )
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun PreferenceClickConfirmation(
     title: String,

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/controls/ListPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/controls/ListPreference.kt
@@ -20,7 +20,6 @@ import android.R as AndroidR
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.RadioButton
@@ -65,7 +64,6 @@ fun <T> ListPreference(
     )
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun <T> ListPreference(
     entries: List<ListPreferenceEntry<T>>,

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/controls/MainSwitchPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/controls/MainSwitchPreference.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
@@ -95,7 +94,6 @@ fun MainSwitchPreference(
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun MainSwitchPreference(
     checked: Boolean,

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/controls/PreferenceCategory.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/controls/PreferenceCategory.kt
@@ -20,7 +20,6 @@ import androidx.annotation.DrawableRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -39,7 +38,6 @@ import com.android.launcher3.R
 import com.android.launcher3.util.MSDLPlayerWrapper
 import com.google.android.msdl.data.model.MSDLToken
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun PreferenceCategory(
     label: String,

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/controls/SliderPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/controls/SliderPreference.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
@@ -115,7 +114,6 @@ fun SliderPreference(
     )
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun SliderPreference(
     label: String,

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/controls/SwitchPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/controls/SwitchPreference.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
@@ -70,7 +69,6 @@ fun SwitchPreference(
 /**
  * A Preference that provides a two-state toggleable option.
  */
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun SwitchPreference(
     checked: Boolean,

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/controls/TextPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/controls/TextPreference.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -47,7 +46,6 @@ fun TextPreference(
     )
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun TextPreference(
     value: String,
@@ -82,7 +80,6 @@ fun TextPreference(
     )
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun TextPreferenceDialog(
     title: String,

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/controls/TwoTargetSwitchPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/controls/TwoTargetSwitchPreference.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
@@ -72,7 +71,6 @@ fun TwoTargetSwitchPreference(
 /**
  * A Preference that provides a two-state toggleable option with two click targets.
  */
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun TwoTargetSwitchPreference(
     checked: Boolean,

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/controls/WarningPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/controls/WarningPreference.kt
@@ -21,7 +21,6 @@ import app.lawnchair.ui.theme.LawnchairTheme
 import app.lawnchair.ui.util.preview.PreferenceGroupPreviewContainer
 import app.lawnchair.ui.util.preview.PreviewLawnchair
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun WarningPreference(
     text: String,
@@ -42,7 +41,6 @@ fun WarningPreference(
     )
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun WarningPreference(
     text: String,

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/layout/ClickableIcon.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/layout/ClickableIcon.kt
@@ -1,7 +1,6 @@
 package app.lawnchair.ui.preferences.components.layout
 
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButtonDefaults
@@ -18,7 +17,6 @@ import androidx.compose.ui.platform.LocalContext
 import com.android.launcher3.util.MSDLPlayerWrapper
 import com.google.android.msdl.data.model.MSDLToken
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun ClickableIcon(
     painter: Painter,

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/layout/PreferenceGroup.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/layout/PreferenceGroup.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeight
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -37,7 +36,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun PreferenceGroup(
     modifier: Modifier = Modifier,

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/layout/PreferenceTemplate.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/layout/PreferenceTemplate.kt
@@ -18,7 +18,6 @@ package app.lawnchair.ui.preferences.components.layout
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Column
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.ListItemColors
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.ListItemShapes
@@ -36,7 +35,6 @@ import androidx.compose.ui.Modifier
 /***
  * A template used to create most preference-related components in the Preference UI.
  */
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun PreferenceTemplate(
     title: @Composable () -> Unit,

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/reorderable/PositionalList.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/reorderable/PositionalList.kt
@@ -11,7 +11,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.Remove
 import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -379,7 +378,6 @@ object PositionalListDefaults {
  * @param contentPadding Padding applied to the underlying scrollable container.
  * @param modifier The modifier to be applied to the container.
  */
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun <T, K : Any> PositionalList(
     state: PositionalListState<T, K>,

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/reorderable/ReorderablePreferenceDefaults.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/reorderable/ReorderablePreferenceDefaults.kt
@@ -13,7 +13,6 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.rounded.DragHandle
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItemDefaults
@@ -63,7 +62,6 @@ fun ReorderablePreferenceItem(
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun ReorderableSwitchPreference(
     label: String,

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/search/DockSearchPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/search/DockSearchPreferences.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.TipsAndUpdates
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -56,7 +55,6 @@ import app.lawnchair.ui.theme.isSelectedThemeDark
 import app.lawnchair.ui.theme.preferenceGroupColor
 import com.android.launcher3.R
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun DockSearchPreference(
     modifier: Modifier = Modifier,

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/search/WebSearchProvider.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/search/WebSearchProvider.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -82,7 +81,6 @@ fun WebSearchProvider(
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun SearchPopupPreference(
     title: String,

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/AppDrawerFoldersPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/AppDrawerFoldersPreference.kt
@@ -13,7 +13,6 @@ import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
@@ -108,7 +107,6 @@ fun AppDrawerFoldersPreference(
     )
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun AppDrawerFoldersPreference(
     folders: List<FolderEntry>?,
@@ -217,7 +215,6 @@ fun AppDrawerFoldersPreference(
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun FolderEditSheet(
     folderId: Int,
@@ -285,7 +282,6 @@ fun FolderEditSheet(
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun FolderItem(
     folderEntry: FolderEntry,

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/CustomIconShapePreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/CustomIconShapePreference.kt
@@ -18,7 +18,6 @@ import androidx.compose.material.icons.rounded.ContentCopy
 import androidx.compose.material.icons.rounded.ContentPaste
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.LocalContentColor
@@ -65,7 +64,6 @@ import com.google.android.msdl.data.model.MSDLToken
 import kotlin.math.roundToInt
 import kotlin.toString
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun CustomIconShapePreference(
     modifier: Modifier = Modifier,
@@ -240,7 +238,6 @@ private fun IconShapeClipboardPreferenceGroup(
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun ClipboardButton(
     label: String,
@@ -290,7 +287,6 @@ private fun IconShapeCornerPreference(
     )
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun CornerSlider(
     label: String,

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/DismissedPredictionAppsPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/DismissedPredictionAppsPreferences.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.DropdownMenuGroup
 import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MenuDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -127,7 +126,6 @@ fun DismissedPredictionAppsPreferences(
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun ResetDismissedAppsAction(
     onReset: () -> Unit,

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/DummyPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/DummyPreference.kt
@@ -1,13 +1,11 @@
 package app.lawnchair.ui.preferences.destinations
 
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import app.lawnchair.ui.preferences.components.layout.PreferenceLayout
 import app.lawnchair.ui.preferences.components.layout.PreferenceTemplate
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun DummyPreference(
     modifier: Modifier = Modifier,

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/FeatureFlagsPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/FeatureFlagsPreference.kt
@@ -4,7 +4,6 @@ import android.content.Intent
 import android.widget.Toast
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -31,7 +30,6 @@ import com.android.launcher3.util.OnboardingPrefs.HOTSEAT_LONGPRESS_TIP_SEEN
 import com.android.launcher3.util.OnboardingPrefs.TASKBAR_EDU_TOOLTIP_STEP
 import com.google.android.msdl.data.model.MSDLToken
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun FeatureFlagsPreference(modifier: Modifier = Modifier) {
     val context = LocalContext.current
@@ -192,7 +190,6 @@ private fun IntentPreference(
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 private fun LazyListScope.preferenceCategory(heading: String, description: String? = null) {
     item(key = heading) {
         PreferenceTemplate(

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/FontSelectionPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/FontSelectionPreference.kt
@@ -22,7 +22,6 @@ import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
@@ -66,7 +65,6 @@ private enum class ContentType {
     FONT,
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun FontSelection(
     fontPref: BasePreferenceManager.FontPref,
@@ -209,7 +207,6 @@ fun FontSelection(
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun FontSelectionItem(
     adapter: PreferenceAdapter<FontCache.Font>,
@@ -279,7 +276,6 @@ private fun removeFamilyPrefix(
     return fontName.removePrefix(familyName).trim().toString()
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun VariantDropdown(
     adapter: PreferenceAdapter<FontCache.Font>,

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/HiddenAppsPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/HiddenAppsPreferences.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.DropdownMenuGroup
 import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MenuDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -129,7 +128,6 @@ fun HiddenAppsPreferences(
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun ListSortingOptions(
     originalList: List<App>,

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/HomeScreenGridPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/HomeScreenGridPreferences.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
@@ -46,7 +45,6 @@ import app.lawnchair.ui.preferences.components.layout.PreferenceTemplate
 import com.android.launcher3.InvariantDeviceProfile
 import com.android.launcher3.R
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun HomeScreenGridPreferences(
     modifier: Modifier = Modifier,
@@ -253,7 +251,6 @@ fun HomeScreenGridPreferences(
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun FakeExpandedGridPreference(
     columns: Int,

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/IconShapePreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/IconShapePreference.kt
@@ -30,7 +30,6 @@ import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.Edit
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.LocalTextStyle
@@ -131,7 +130,6 @@ fun ShapePreference(
     )
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun ShapeTabContent(currentTab: ShapeRoute) {
     val context = LocalContext.current
@@ -187,7 +185,6 @@ private fun ShapeTabContent(currentTab: ShapeRoute) {
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun CustomIconShapePreferenceOption(
     iconShapeAdapter: PreferenceAdapter<IconShape>,

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/PreferencesDashboard.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/PreferencesDashboard.kt
@@ -37,7 +37,6 @@ import androidx.compose.material.icons.rounded.Science
 import androidx.compose.material.icons.rounded.TipsAndUpdates
 import androidx.compose.material3.DropdownMenuGroup
 import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
@@ -232,7 +231,6 @@ fun PreferencesDashboard(
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun RowScope.PreferencesOverflowMenu(
     currentRoute: PreferenceRootRoute,
@@ -324,7 +322,6 @@ fun RowScope.PreferencesOverflowMenu(
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun PreferencesDebugWarning(
     modifier: Modifier = Modifier,
@@ -340,7 +337,6 @@ fun PreferencesDebugWarning(
     )
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun PreferencesSetDefaultLauncherWarning(
     modifier: Modifier = Modifier,

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/QuickstepPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/QuickstepPreferences.kt
@@ -1,7 +1,6 @@
 package app.lawnchair.ui.preferences.destinations
 
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -131,7 +130,6 @@ fun QuickstepPreferences(
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @PreviewLawnchair
 @Composable
 private fun QuickSwitchIgnoredWarning(

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/SearchProviderPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/SearchProviderPreferences.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.LocalTextStyle
@@ -96,7 +95,6 @@ fun SearchProviderPreferences(
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun ListItem(
     title: String,
@@ -153,7 +151,6 @@ private fun ListItem(
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun Options(
     appEnabled: Boolean,
@@ -206,7 +203,6 @@ private fun Options(
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun SponsorDisclaimer(
     sponsor: String,

--- a/lawnchair/src/app/lawnchair/ui/theme/Shape.kt
+++ b/lawnchair/src/app/lawnchair/ui/theme/Shape.kt
@@ -17,11 +17,9 @@
 package app.lawnchair.ui.theme
 
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Shapes
 import androidx.compose.ui.unit.dp
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 val Shapes = Shapes(
     extraSmall = RoundedCornerShape(4.dp),
     small = RoundedCornerShape(8.dp),

--- a/lawnchair/src/app/lawnchair/ui/theme/Theme.kt
+++ b/lawnchair/src/app/lawnchair/ui/theme/Theme.kt
@@ -22,7 +22,6 @@ import androidx.activity.SystemBarStyle
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.ColorScheme
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialExpressiveTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MotionScheme
@@ -48,7 +47,6 @@ import app.lawnchair.ui.preferences.components.ThemeChoice
 import app.lawnchair.wallpaper.WallpaperManagerCompat
 import com.android.launcher3.Utilities
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun LawnchairTheme(
     darkTheme: Boolean = isSelectedThemeDark,
@@ -106,7 +104,6 @@ fun getColorScheme(darkTheme: Boolean): ColorScheme {
     return colorScheme.toComposeColorScheme(isDark = darkTheme)
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 private fun getPreviewColorScheme(darkTheme: Boolean) = if (darkTheme) {
     darkColorScheme()
 } else {

--- a/lawnchair/src/app/lawnchair/ui/theme/Type.kt
+++ b/lawnchair/src/app/lawnchair/ui/theme/Type.kt
@@ -16,13 +16,11 @@
 
 package app.lawnchair.ui.theme
 
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Typography
 import androidx.compose.ui.unit.sp
 
 private val base = Typography()
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 val Typography = Typography(
     displayLarge = base.displayLarge.copy(fontFamily = GoogleSansFlex.Display.Emphasized.Large),
     displayMedium = base.displayMedium.copy(fontFamily = GoogleSansFlex.Display.Emphasized.Medium),


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Remove most of opt-in tag for experimental expressive API.

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->

Before we opt into experimental expressive API when the expressive component for Compose was new at the time, now most of the components are going into stable so the opt-in tag for them isn't needed anymore.

...

Unless Material 3 API changed it again to reintroduce the opt-in tag which has happened a few time in the update but the library seems to be getting close to finally releasing expressive... right?

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Chore** (Changes to the build process or other tooling)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated UI and preference components to no longer rely on unnecessary experimental Material 3 opt-ins.
  * Existing launcher screens, dialogs, settings, gestures, themes, and controls continue to behave unchanged.
* **Maintenance**
  * Simplified internal UI configuration and removed redundant annotations without changing user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->