### PR TITLE
feat: add installed global search providers

### DIFF
--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -825,6 +825,10 @@
 
     <!-- Search providers -->
     <string name="search_provider_app_search">App search</string>
+    <string name="search_provider_other_app">Other search app</string>
+    <string name="search_provider_choose_app">Choose an installed app</string>
+    <string name="search_provider_select_app">Choose a search app</string>
+    <string name="search_provider_no_compatible_apps">No compatible search apps found</string>
     <string name="search_provider_startpage" translatable="false">Startpage</string>
     <string name="search_provider_startpage_eu" translatable="false">Startpage (EU)</string>
     <string name="search_provider_google" translatable="false">Google</string>

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
@@ -303,6 +303,11 @@ class PreferenceManager2 @Inject constructor(
         save = { it.id },
     )
 
+    val hotseatQsbGlobalSearchPackage = preference(
+        key = stringPreferencesKey(name = "dock_search_bar_global_search_package"),
+        defaultValue = "",
+    )
+
     val hotseatQsbForceWebsite = preference(
         key = booleanPreferencesKey(name = "dock_search_bar_force_website"),
         defaultValue = context.resources.getBoolean(R.bool.config_default_dock_search_bar_force_website),

--- a/lawnchair/src/app/lawnchair/qsb/LawnQsbLayout.kt
+++ b/lawnchair/src/app/lawnchair/qsb/LawnQsbLayout.kt
@@ -23,6 +23,7 @@ import app.lawnchair.preferences2.PreferenceManager2
 import app.lawnchair.preferences2.asState
 import app.lawnchair.preferences2.firstCached
 import app.lawnchair.qsb.providers.AppSearch
+import app.lawnchair.qsb.providers.GlobalSearchApp
 import app.lawnchair.qsb.providers.Google
 import app.lawnchair.qsb.providers.PixelSearch
 import app.lawnchair.qsb.providers.QsbSearchProvider
@@ -236,7 +237,7 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
             context: Context,
             provider: QsbSearchProvider,
         ): QsbSearchProvider {
-            return if (provider == AppSearch ||
+            return if (provider == AppSearch || provider == GlobalSearchApp ||
                 resolveIntent(context, provider.createSearchIntent()) ||
                 resolveIntent(context, provider.createWebsiteIntent())
             ) {

--- a/lawnchair/src/app/lawnchair/qsb/providers/GlobalSearchApp.kt
+++ b/lawnchair/src/app/lawnchair/qsb/providers/GlobalSearchApp.kt
@@ -1,0 +1,152 @@
+package app.lawnchair.qsb.providers
+
+import android.app.SearchManager
+import android.content.ActivityNotFoundException
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.content.pm.ResolveInfo
+import android.graphics.drawable.Drawable
+import android.os.Bundle
+import android.util.Log
+import app.lawnchair.preferences2.PreferenceManager2
+import app.lawnchair.qsb.ThemingMethod
+import com.android.launcher3.Launcher
+import com.android.launcher3.R
+import com.patrykmichalik.opto.core.first
+import java.text.Collator
+
+data object GlobalSearchApp : QsbSearchProvider(
+    id = "global_search_app",
+    name = R.string.search_provider_other_app,
+    icon = R.drawable.ic_qsb_search,
+    themingMethod = ThemingMethod.TINT,
+    packageName = "",
+    website = "",
+    type = QsbSearchProviderType.LOCAL,
+) {
+
+    override suspend fun launch(launcher: Launcher, forceWebsite: Boolean) {
+        val selectedPackage = PreferenceManager2.getInstance(launcher)
+            .hotseatQsbGlobalSearchPackage
+            .first()
+        val selectedIntent = resolveSearchIntent(launcher, selectedPackage)
+        val systemIntent = resolveSystemSearchIntent(launcher)
+
+        listOfNotNull(selectedIntent, systemIntent)
+            .distinctBy { it.component }
+            .forEach { intent ->
+                try {
+                    launcher.startActivity(intent)
+                    return
+                } catch (e: ActivityNotFoundException) {
+                    Log.w(TAG, "Global search activity is no longer available", e)
+                } catch (e: SecurityException) {
+                    Log.w(TAG, "Global search activity cannot be launched", e)
+                }
+            }
+
+        AppSearch.launch(launcher, forceWebsite = false)
+    }
+
+    fun queryInstalledApps(
+        context: Context,
+        excludedPackages: Set<String> = emptySet(),
+    ): List<GlobalSearchAppInfo> {
+        val packageManager = context.packageManager
+        val resolveInfos = packageManager.queryIntentActivities(
+            Intent(SearchManager.INTENT_ACTION_GLOBAL_SEARCH),
+            PackageManager.MATCH_DEFAULT_ONLY,
+        )
+        val collator = Collator.getInstance()
+
+        return resolveInfos
+            .asSequence()
+            .filter(::isLaunchable)
+            .distinctBy { it.activityInfo.packageName }
+            .filterNot { it.activityInfo.packageName in excludedPackages }
+            .map { resolveInfo ->
+                val applicationInfo = resolveInfo.activityInfo.applicationInfo
+                GlobalSearchAppInfo(
+                    label = packageManager.getApplicationLabel(applicationInfo).toString(),
+                    packageName = applicationInfo.packageName,
+                    icon = packageManager.getApplicationIcon(applicationInfo),
+                )
+            }
+            .sortedWith { first, second -> collator.compare(first.label, second.label) }
+            .toList()
+    }
+
+    fun getApplicationLabel(context: Context, packageName: String): String? {
+        if (packageName.isBlank()) return null
+
+        val resolveInfo = querySearchActivities(context, packageName).firstOrNull() ?: return null
+        return context.packageManager
+            .getApplicationLabel(resolveInfo.activityInfo.applicationInfo)
+            .toString()
+    }
+
+    private fun resolveSearchIntent(context: Context, packageName: String): Intent? {
+        if (packageName.isBlank()) return null
+
+        val packageManager = context.packageManager
+        val packageIntent = Intent(SearchManager.INTENT_ACTION_GLOBAL_SEARCH)
+            .setPackage(packageName)
+        val resolvedActivity = packageManager.resolveActivity(
+            packageIntent,
+            PackageManager.MATCH_DEFAULT_ONLY,
+        )?.takeIf {
+            isLaunchable(it) && it.activityInfo.packageName == packageName
+        } ?: querySearchActivities(context, packageName).firstOrNull()
+
+        return resolvedActivity?.activityInfo?.let {
+            createLaunchIntent(context, ComponentName(it.packageName, it.name))
+        }
+    }
+
+    private fun resolveSystemSearchIntent(context: Context): Intent? {
+        val searchManager = context.getSystemService(SearchManager::class.java)
+        val component = searchManager.globalSearchActivity ?: return null
+        return createLaunchIntent(context, component)
+            .takeIf { context.packageManager.resolveActivity(it, 0) != null }
+    }
+
+    private fun querySearchActivities(context: Context, packageName: String): List<ResolveInfo> {
+        return context.packageManager.queryIntentActivities(
+            Intent(SearchManager.INTENT_ACTION_GLOBAL_SEARCH).setPackage(packageName),
+            PackageManager.MATCH_DEFAULT_ONLY,
+        )
+            .asSequence()
+            .filter(::isLaunchable)
+            .sortedWith(
+                compareByDescending<ResolveInfo> { it.priority }
+                    .thenByDescending { it.preferredOrder }
+                    .thenByDescending { it.match }
+                    .thenBy { it.activityInfo.name },
+            )
+            .toList()
+    }
+
+    private fun createLaunchIntent(context: Context, component: ComponentName): Intent {
+        return Intent(SearchManager.INTENT_ACTION_GLOBAL_SEARCH)
+            .setComponent(component)
+            .addFlags(INTENT_FLAGS)
+            .putExtra(
+                SearchManager.APP_DATA,
+                Bundle().apply { putString("source", context.packageName) },
+            )
+    }
+
+    private fun isLaunchable(resolveInfo: ResolveInfo): Boolean {
+        return resolveInfo.activityInfo.enabled && resolveInfo.activityInfo.exported
+    }
+
+    private const val TAG = "GlobalSearchApp"
+}
+
+data class GlobalSearchAppInfo(
+    val label: String,
+    val packageName: String,
+    val icon: Drawable,
+)

--- a/lawnchair/src/app/lawnchair/qsb/providers/QsbSearchProvider.kt
+++ b/lawnchair/src/app/lawnchair/qsb/providers/QsbSearchProvider.kt
@@ -124,6 +124,7 @@ sealed class QsbSearchProvider(
             GoogleGo,
             Youtube,
             PixelSearch,
+            GlobalSearchApp,
             Sesame,
             Wikipedia,
             GitHub,
@@ -171,7 +172,7 @@ sealed class QsbSearchProvider(
 
             // Return the best default option if the config.xml value is invalid
             return values()
-                .filterNot { it == AppSearch }
+                .filterNot { it == AppSearch || it == GlobalSearchApp }
                 .firstOrNull { LawnQsbLayout.resolveIntent(context, it.createSearchIntent()) }
                 ?: AppSearch
         }

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/search/DockSearchPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/search/DockSearchPreferences.kt
@@ -35,6 +35,7 @@ import app.lawnchair.qsb.LawnQsbUi
 import app.lawnchair.qsb.QsbActions
 import app.lawnchair.qsb.buildQsbStyle
 import app.lawnchair.qsb.getHotseatBackgroundColor
+import app.lawnchair.qsb.providers.GlobalSearchApp
 import app.lawnchair.qsb.providers.Google
 import app.lawnchair.qsb.providers.PixelSearch
 import app.lawnchair.qsb.providers.QsbSearchProvider
@@ -61,6 +62,7 @@ import com.android.launcher3.R
 fun DockSearchPreference(
     modifier: Modifier = Modifier,
 ) {
+    val context = LocalContext.current
     val prefs = preferenceManager()
     val prefs2 = preferenceManager2()
 
@@ -72,6 +74,18 @@ fun DockSearchPreference(
     val qsbHotseatStrokeWidth = prefs.hotseatQsbStrokeWidth.getAdapter()
     val strokeColorStyleAdapter = prefs2.strokeColorStyle.getAdapter()
     val hotseatQsbProviderAdapter by prefs2.hotseatQsbProvider.getAdapter()
+    val globalSearchPackage by prefs2.hotseatQsbGlobalSearchPackage.getAdapter()
+    val searchProviderDescription = if (hotseatQsbProviderAdapter == GlobalSearchApp) {
+        remember(context, globalSearchPackage) {
+            GlobalSearchApp.getApplicationLabel(context, globalSearchPackage)
+        } ?: stringResource(R.string.search_provider_other_app)
+    } else {
+        stringResource(
+            id = QsbSearchProvider.values()
+                .first { it == hotseatQsbProviderAdapter }
+                .name,
+        )
+    }
 
     Crossfade(isHotseatEnabled.state.value, label = "transition", modifier = modifier) { hotseatEnabled ->
         val isLawnchairHotseat = hotseatModeAdapter.state.value == LawnchairHotseat
@@ -102,11 +116,7 @@ fun DockSearchPreference(
                             NavigationActionPreference(
                                 label = stringResource(R.string.search_provider),
                                 destination = DockSearchProvider,
-                                subtitle = stringResource(
-                                    id = QsbSearchProvider.values()
-                                        .first { it == hotseatQsbProviderAdapter }
-                                        .name,
-                                ),
+                                subtitle = searchProviderDescription,
                             )
                         }
                         PreferenceGroup(

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/SearchProviderPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/SearchProviderPreferences.kt
@@ -1,10 +1,14 @@
 package app.lawnchair.ui.preferences.destinations
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.ListItemDefaults
@@ -16,13 +20,18 @@ import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import app.lawnchair.preferences.getAdapter
 import app.lawnchair.preferences2.preferenceManager2
+import app.lawnchair.qsb.providers.GlobalSearchApp
+import app.lawnchair.qsb.providers.GlobalSearchAppInfo
 import app.lawnchair.qsb.providers.QsbSearchProvider
 import app.lawnchair.qsb.providers.QsbSearchProviderType
 import app.lawnchair.ui.ModalBottomSheetContent
@@ -35,6 +44,8 @@ import app.lawnchair.ui.preferences.components.layout.PreferenceLayout
 import app.lawnchair.ui.preferences.components.layout.PreferenceTemplate
 import app.lawnchair.ui.util.LocalBottomSheetHandler
 import com.android.launcher3.R
+import com.google.accompanist.drawablepainter.rememberDrawablePainter
+import kotlinx.coroutines.launch
 
 @Composable
 fun SearchProviderPreferences(
@@ -42,8 +53,19 @@ fun SearchProviderPreferences(
 ) {
     val context = LocalContext.current
     val bottomSheetHandler = LocalBottomSheetHandler.current
-    val adapter = preferenceManager2().hotseatQsbProvider.getAdapter()
-    val forceWebsiteAdapter = preferenceManager2().hotseatQsbForceWebsite.getAdapter()
+    val scope = rememberCoroutineScope()
+    val preferences = preferenceManager2()
+    val adapter = preferences.hotseatQsbProvider.getAdapter()
+    val globalSearchPackageAdapter = preferences.hotseatQsbGlobalSearchPackage.getAdapter()
+    val forceWebsiteAdapter = preferences.hotseatQsbForceWebsite.getAdapter()
+    val knownProviderPackages = remember {
+        QsbSearchProvider.values()
+            .asSequence()
+            .filterNot { it == GlobalSearchApp }
+            .map { it.packageName }
+            .filter(String::isNotBlank)
+            .toSet()
+    }
 
     PreferenceLayout(
         label = stringResource(R.string.search_provider),
@@ -53,18 +75,51 @@ fun SearchProviderPreferences(
             itemSpacing = 0.dp,
         ) {
             QsbSearchProvider.values().forEach { qsbSearchProvider ->
+                val isGlobalSearchApp = qsbSearchProvider == GlobalSearchApp
                 val appInstalled = qsbSearchProvider.isDownloaded(context)
                 val selected = adapter.state.value == qsbSearchProvider
                 val hasAppAndWebsite = qsbSearchProvider.type == QsbSearchProviderType.APP_AND_WEBSITE
                 val showDownloadButton = qsbSearchProvider.type == QsbSearchProviderType.APP && !appInstalled
                 Column {
                     val title = stringResource(id = qsbSearchProvider.name)
+                    val globalSearchPackage = globalSearchPackageAdapter.state.value
+                    val globalSearchAppDescription = if (isGlobalSearchApp) {
+                        remember(context, globalSearchPackage) {
+                            GlobalSearchApp.getApplicationLabel(context, globalSearchPackage)
+                        } ?: globalSearchPackage.takeIf(String::isNotBlank)
+                            ?: stringResource(R.string.search_provider_choose_app)
+                    } else {
+                        null
+                    }
                     ListItem(
                         title = title,
                         showDownloadButton = showDownloadButton,
                         enabled = qsbSearchProvider.type != QsbSearchProviderType.APP || appInstalled,
                         selected = selected,
-                        onClick = { adapter.onChange(newValue = qsbSearchProvider) },
+                        onClick = if (isGlobalSearchApp) {
+                            {
+                                val apps = GlobalSearchApp.queryInstalledApps(
+                                    context = context,
+                                    excludedPackages = knownProviderPackages,
+                                )
+                                bottomSheetHandler.show {
+                                    GlobalSearchAppPicker(
+                                        apps = apps,
+                                        selectedPackage = globalSearchPackageAdapter.state.value,
+                                        onSelect = { packageName ->
+                                            bottomSheetHandler.hide()
+                                            scope.launch {
+                                                preferences.hotseatQsbGlobalSearchPackage.set(packageName)
+                                                preferences.hotseatQsbProvider.set(GlobalSearchApp)
+                                            }
+                                        },
+                                        onDismiss = { bottomSheetHandler.hide() },
+                                    )
+                                }
+                            }
+                        } else {
+                            { adapter.onChange(newValue = qsbSearchProvider) }
+                        },
                         onDownloadClick = { qsbSearchProvider.launchOnAppMarket(context = context) },
                         onSponsorDisclaimerClick = {
                             bottomSheetHandler.show {
@@ -73,7 +128,9 @@ fun SearchProviderPreferences(
                                 }
                             }
                         }.takeIf { qsbSearchProvider.sponsored },
-                        description = if (showDownloadButton) {
+                        description = if (globalSearchAppDescription != null) {
+                            globalSearchAppDescription
+                        } else if (showDownloadButton) {
                             stringResource(id = R.string.qsb_search_provider_app_required)
                         } else {
                             null
@@ -90,6 +147,69 @@ fun SearchProviderPreferences(
                         )
                     }
                     Spacer(Modifier.height(ListItemDefaults.SegmentedGap))
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun GlobalSearchAppPicker(
+    apps: List<GlobalSearchAppInfo>,
+    selectedPackage: String,
+    onSelect: (String) -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    ModalBottomSheetContent(
+        title = { Text(stringResource(R.string.search_provider_select_app)) },
+        buttons = {
+            OutlinedButton(
+                onClick = onDismiss,
+                shapes = ButtonDefaults.shapes(),
+            ) {
+                Text(stringResource(android.R.string.cancel))
+            }
+        },
+        modifier = modifier,
+    ) {
+        if (apps.isEmpty()) {
+            Text(
+                text = stringResource(R.string.search_provider_no_compatible_apps),
+                modifier = Modifier.padding(horizontal = 16.dp),
+            )
+        } else {
+            LazyColumn {
+                itemsIndexed(
+                    items = apps,
+                    key = { _, app -> app.packageName },
+                ) { index, app ->
+                    if (index > 0) {
+                        PreferenceDivider(startIndent = 56.dp)
+                    }
+                    PreferenceTemplate(
+                        title = { Text(app.label) },
+                        description = { Text(app.packageName) },
+                        startWidget = {
+                            Image(
+                                painter = rememberDrawablePainter(app.icon),
+                                contentDescription = null,
+                                modifier = Modifier
+                                    .padding(start = 16.dp)
+                                    .size(32.dp),
+                            )
+                        },
+                        endWidget = {
+                            RadioButton(
+                                selected = selectedPackage == app.packageName,
+                                onClick = null,
+                                modifier = Modifier.padding(end = 16.dp),
+                            )
+                        },
+                        colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                        onClick = { onSelect(app.packageName) },
+                    )
                 }
             }
         }


### PR DESCRIPTION
### Description

Adds an “Other search app” option to the dock search provider settings. It discovers installed apps that support Android’s `GLOBAL_SEARCH` intent and lets users select one without adding a dedicated provider for every app.

### Reasoning

The existing provider list only supports explicitly integrated apps such as Google and Pixel Search. Other apps may already implement `GLOBAL_SEARCH`, but Lawnchair currently cannot select them.

The selection is stored by package name rather than activity name, allowing the provider activity to change after an app update. When launching search, Lawnchair resolves a current compatible activity from the selected package. If that is unavailable, it falls back to the system global search provider and then Lawnchair Search.

Known providers remain available through their existing entries and are excluded from the new picker.

### Testing

1. Install an app that exposes an activity for `android.search.action.GLOBAL_SEARCH`.
2. Open **Lawnchair Settings → Dock → Search provider**.
3. Select **Other search app**.
4. Verify that compatible installed apps are listed with their name, package, and icon.
5. Select an app and tap the dock search bar.
6. Verify that search opens in the selected app.
7. Update the selected app so its search activity changes, then verify search still works.
8. Uninstall or disable the selected app and verify Lawnchair falls back to the system global search provider, followed by Lawnchair Search when no system provider is available.
9. Verify existing providers such as Google and Pixel Search remain unchanged.

Build checks completed:

- `spotlessCheck`
- `assembleLawnWithQuickstepGithubDebug`
- `assembleLawnWithQuickstepNightlyRelease`

### Type of change

:x: **Bug fix** (A non-breaking change that fixes an issue)
:white_check_mark: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for choosing a compatible external app as the dock search provider.
  - Added a picker showing available search apps, icons, package names, and the current selection.
  - Displays the selected app’s name in search preferences.
  - Falls back to the system search or app search when the selected provider is unavailable.
- **Bug Fixes**
  - Improved handling of unavailable or incompatible search apps, including fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->