### PR TITLE
revert: feat: Add Quickstep Protolog for Baklava

### DIFF
--- a/quickstep/src/com/android/quickstep/QuickstepProcessInitializer.java
+++ b/quickstep/src/com/android/quickstep/QuickstepProcessInitializer.java
@@ -23,7 +23,6 @@ import android.os.UserManager;
 import android.util.Log;
 import android.view.ThreadedRenderer;
 
-import app.lawnchair.LawnchairApp;
 import com.android.launcher3.BuildConfig;
 import com.android.launcher3.MainProcessInitializer;
 import com.android.quickstep.util.QuickstepProtoLogGroup;
@@ -67,10 +66,6 @@ public class QuickstepProcessInitializer extends MainProcessInitializer {
                                 ThreadedRenderer.EGL_CONTEXT_PRIORITY_HIGH_IMG);
         } catch (Exception e) {
                 Log.e(TAG, "init: " + e);
-        }
-
-        if (Utilities.ATLEAST_BAKLAVA && LawnchairApp.isRecentsEnabled()) {
-            QuickstepProtoLogGroup.initProtoLog();
         }
     }
 }

--- a/quickstep/src_protolog/com/android/quickstep/util/QuickstepProtoLogGroup.java
+++ b/quickstep/src_protolog/com/android/quickstep/util/QuickstepProtoLogGroup.java
@@ -51,7 +51,6 @@ public enum QuickstepProtoLogGroup implements IProtoLogGroup {
         return Variables.sIsInitialized;
     }
 
-    @RequiresApi(36)
     public static void initProtoLog() {
         if (Variables.sIsInitialized) {
             Log.e(Constants.TAG,


### PR DESCRIPTION
Reverts LawnchairLauncher/lawnchair#7217

Regression roll over to stable commit, to be reland when the change doesn't crash on non-quickstep device.

Fix #7224 #7223

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility across supported Android versions by updating diagnostic logging initialization.
  * Prevented unnecessary logging setup during the launcher’s startup process, helping ensure more consistent startup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->