### PR TITLE
fix: Predictive nav animation is gone after dependency upgrade

### DIFF
--- a/lawnchair/src/app/lawnchair/ui/preferences/navigation/PreferenceNavigation.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/navigation/PreferenceNavigation.kt
@@ -83,6 +83,8 @@ fun PreferenceNavigation(
         exitTransition = { materialSharedAxisXOut(!isRtl, slideDistance) },
         popEnterTransition = { materialSharedAxisXIn(isRtl, slideDistance) },
         popExitTransition = { materialSharedAxisXOut(isRtl, slideDistance) },
+        predictivePopEnterTransition = { materialSharedAxisXIn(isRtl, slideDistance) },
+        predictivePopExitTransition = { materialSharedAxisXOut(isRtl, slideDistance) },
     ) {
         composable<Root> {
             val isExpandedScreen = LocalIsExpandedScreen.current


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Re-add navigation animation for predictive nav.

Fixes #7210 

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->

Navigation dependency now set enter/back transition and predictive enter/back transition (`predictivePopEnterTransition`, `predictivePopExitTransition`) independently of each other.

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Tested on Pixel 7

Just go to lawnchair settings (1 page deep), and invoke gesture navigation to go back.

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved back-navigation animations in Preferences with predictive transitions that match existing slide effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->