### PR TITLE
fix: make home screen status bar icon override work both ways

### DIFF
--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -755,7 +755,8 @@
 
     <string name="status_bar_label">Status bar</string>
     <string name="show_status_bar">Show status bar</string>
-    <string name="dark_status_bar_label">Dark status bar</string>
+    <string name="status_bar_icon_mode_label">Status bar icons</string>
+    <string name="status_bar_icon_mode_description">Choose dark or light icons on the home screen, or let the wallpaper decide</string>
     <string name="status_bar_clock_label">Status bar clock</string>
     <string name="status_bar_clock_description">Dynamically hide the status bar clock on the first screen</string>
 

--- a/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
+++ b/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
@@ -46,6 +46,7 @@ import app.lawnchair.preferences2.firstCached
 import app.lawnchair.root.RootHelperManager
 import app.lawnchair.root.RootNotAvailableException
 import app.lawnchair.theme.ThemeProvider
+import app.lawnchair.theme.color.ColorMode
 import app.lawnchair.ui.popup.LauncherOptionsPopup
 import app.lawnchair.ui.popup.LawnchairShortcut
 import app.lawnchair.util.getThemedIconPacksInstalled
@@ -225,8 +226,13 @@ class LawnchairLauncher : QuickstepLauncher() {
             RoundedCornerEnforcement.sRoundedCornerEnabled = it
         }
         val isWorkspaceDarkText = Themes.getAttrBoolean(this, R.attr.isWorkspaceDarkText)
-        preferenceManager2.darkStatusBar.onEach(launchIn = lifecycleScope) { darkStatusBar ->
-            systemUiController?.updateUiState(UI_STATE_BASE_WINDOW, isWorkspaceDarkText || darkStatusBar)
+        preferenceManager2.statusBarIconMode.onEach(launchIn = lifecycleScope) { mode ->
+            val useDarkIcons = when (mode) {
+                ColorMode.LIGHT -> false
+                ColorMode.DARK -> true
+                ColorMode.AUTO -> isWorkspaceDarkText
+            }
+            systemUiController?.updateUiState(UI_STATE_BASE_WINDOW, useDarkIcons)
         }
         preferenceManager2.backPressGestureHandler.onEach(launchIn = lifecycleScope) { handler ->
             hasBackGesture = handler !is GestureHandlerConfig.NoOp

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
@@ -120,9 +120,15 @@ class PreferenceManager2 @Inject constructor(
 
     private val reloadHelper = ReloadHelper(context)
 
-    val darkStatusBar = preference(
-        key = booleanPreferencesKey(name = "dark_status_bar"),
-        defaultValue = context.resources.getBoolean(R.bool.config_default_dark_status_bar),
+    val statusBarIconMode = preference(
+        key = stringPreferencesKey(name = "status_bar_icon_mode"),
+        defaultValue = if (context.resources.getBoolean(R.bool.config_default_dark_status_bar)) {
+            ColorMode.DARK
+        } else {
+            ColorMode.AUTO
+        },
+        parse = { ColorMode.fromString(it) ?: ColorMode.AUTO },
+        save = { it.toString() },
     )
 
     val hotseatMode = preference(
@@ -974,7 +980,12 @@ class PreferenceManager2 @Inject constructor(
     companion object {
         private val Context.preferencesDataStore by preferencesDataStore(
             name = "preferences",
-            produceMigrations = { listOf(SharedPreferencesMigration(context = it).produceMigration()) },
+            produceMigrations = {
+                listOf(
+                    SharedPreferencesMigration(context = it).produceMigration(),
+                    StatusBarIconModeMigration(),
+                )
+            },
         )
 
         @JvmField

--- a/lawnchair/src/app/lawnchair/preferences2/StatusBarIconModeMigration.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/StatusBarIconModeMigration.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026, Lawnchair
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.lawnchair.preferences2
+
+import androidx.datastore.core.DataMigration
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import app.lawnchair.theme.color.ColorMode
+
+/**
+ * Migrates the legacy boolean `dark_status_bar` preference to the tri-state
+ * `status_bar_icon_mode` preference.
+ *
+ * The old boolean could only ever force dark icons on, because it was OR-ed with the
+ * wallpaper-derived value. `true` therefore becomes [ColorMode.DARK], while `false` becomes
+ * [ColorMode.AUTO] — which preserves the previous behaviour exactly, since a disabled switch
+ * left the wallpaper hints in charge.
+ *
+ * The legacy key is intentionally left in place: [SharedPreferencesMigration] treats a missing
+ * mapped key as "migration still pending", so removing it would re-trigger that migration on
+ * every launch.
+ */
+class StatusBarIconModeMigration : DataMigration<Preferences> {
+
+    override suspend fun shouldMigrate(currentData: Preferences): Boolean = currentData.contains(LEGACY_KEY) && !currentData.contains(NEW_KEY)
+
+    override suspend fun migrate(currentData: Preferences): Preferences {
+        val mutablePreferences = currentData.toMutablePreferences()
+        val wasDark = currentData[LEGACY_KEY] == true
+        mutablePreferences[NEW_KEY] = if (wasDark) {
+            ColorMode.DARK.toString()
+        } else {
+            ColorMode.AUTO.toString()
+        }
+        return mutablePreferences.toPreferences()
+    }
+
+    override suspend fun cleanUp() = Unit
+
+    companion object {
+        private val LEGACY_KEY = booleanPreferencesKey("dark_status_bar")
+        private val NEW_KEY = stringPreferencesKey("status_bar_icon_mode")
+    }
+}

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/HomeScreenPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/HomeScreenPreferences.kt
@@ -187,9 +187,11 @@ fun HomeScreenPreferences(
                 label = stringResource(id = R.string.show_status_bar),
             )
             ExpandAndShrink(visible = showStatusBarAdapter.state.value) {
-                SwitchPreference(
-                    adapter = prefs2.darkStatusBar.getAdapter(),
-                    label = stringResource(id = R.string.dark_status_bar_label),
+                ListPreference(
+                    adapter = prefs2.statusBarIconMode.getAdapter(),
+                    entries = ColorMode.entries(),
+                    label = stringResource(id = R.string.status_bar_icon_mode_label),
+                    description = stringResource(id = R.string.status_bar_icon_mode_description),
                 )
             }
             ExpandAndShrink(visible = showStatusBarAdapter.state.value && LawnchairApp.isRecentsEnabled) {


### PR DESCRIPTION
### Description

The **Dark status bar** switch on the home screen can only ever turn dark icons *on*. Turning it off does nothing when the wallpaper already resolved to dark text, because the two inputs are OR-ed together:

```kotlin
// LawnchairLauncher.kt
val isWorkspaceDarkText = Themes.getAttrBoolean(this, R.attr.isWorkspaceDarkText)
preferenceManager2.darkStatusBar.onEach(launchIn = lifecycleScope) { darkStatusBar ->
    systemUiController?.updateUiState(UI_STATE_BASE_WINDOW, isWorkspaceDarkText || darkStatusBar)
}
```

`isWorkspaceDarkText` comes from `Themes.getActivityThemeRes()`, which in `ColorMode.AUTO` (the default) is derived from the wallpaper's `HINT_SUPPORTS_DARK_TEXT`. So on any wallpaper Android considers light, the left operand is already `true` and the switch is inert — there is no way to force light icons back.

This replaces the boolean with a tri-state preference so the automatic behaviour stays the default while both overrides actually work.

### Changes

- `darkStatusBar` (`Boolean`, `dark_status_bar`) → `statusBarIconMode` (`ColorMode`, `status_bar_icon_mode`), reusing the existing `ColorMode` enum rather than introducing a parallel one.
- The `||` is replaced with an explicit `when`: `AUTO` → wallpaper-derived, `LIGHT` → force light icons, `DARK` → force dark icons.
- The `SwitchPreference` becomes a `ListPreference` with the same `ColorMode.entries()` used by **Home screen text color** just above it, so the two related settings now read consistently.
- Added `StatusBarIconModeMigration`, a DataStore `DataMigration` that maps the old key to the new one.
  It leaves the legacy `dark_status_bar` entry in place on purpose: `SharedPreferencesMigration.getShouldRunMigration()`
  returns true when any mapped key is absent, so deleting it would mark that migration unfinished and re-run it on every launch.

### Behaviour / migration

Existing users keep exactly what they had:

| old `dark_status_bar` | new `status_bar_icon_mode` | resulting behaviour |
|---|---|---|
| `true` | `DARK` | dark icons, unchanged |
| `false` | `AUTO` | wallpaper decides — identical to the old `false` branch, where `isWorkspaceDarkText` was the only remaining input |
| unset | `AUTO` (or `DARK` when `config_default_dark_status_bar` is `true`) | unchanged default |

`AUTO` is not new behaviour — it is precisely what the old `false` case already did. The only genuinely new capability is `LIGHT`, which is the case that was previously unreachable.

The `config_default_dark_status_bar` bool resource is retained and still honoured, so downstream builds overriding it are unaffected.

### Scope

Deliberately limited to the launcher's own window. A launcher can only request light/dark system-bar icon *appearance*; the actual icon colours belong to SystemUI, so arbitrary colours are out of scope regardless of this preference.

This also does not change how `AUTO` derives its answer. `WallpaperColorHints` reads `getWallpaperColors(FLAG_SYSTEM)`, whose hints are computed over the **whole** wallpaper — so a wallpaper that is broadly light but dark behind the status bar (or the reverse) can still resolve "correctly on average" yet be wrong where the icons actually sit. Fixing that means region-sampling the status bar strip rather than trusting whole-wallpaper hints, which is a larger change and better kept separate. I left a longer write-up of that in #4167. With this PR, users hitting that case at least have a working manual override, which they currently do not.

### Test Plan

- `./gradlew :compileLawnWithQuickstepGithubDebugKotlin` — compiles clean.
- `./gradlew lint` / `spotlessCheck` per CI.
- Manual: with **Show status bar** on, switch **Status bar icons** between Auto / Light / Dark on both a light and a dark wallpaper and confirm the icons follow; confirm Auto still flips by itself when the wallpaper changes; confirm an existing install with the old switch enabled comes back as `Dark` after update.

Refs #4167

---

I do not have a physical device set up to validate the app-drawer/overview interaction of `SystemUiController`'s state priority, so the on-device manual pass above is worth a second pair of eyes before merge.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added status bar icon options for the home screen: light icons, dark icons, or automatic selection based on the wallpaper.
  * Replaced the previous dark status bar toggle with a three-option setting and clearer guidance.

* **Bug Fixes**
  * Existing status bar preferences are migrated automatically, preserving prior behavior after updating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->