### PR TITLE
fix(backup): close file streams and write grid state after extraction

### DIFF
--- a/lawnchair/src/app/lawnchair/backup/LawnchairBackup.kt
+++ b/lawnchair/src/app/lawnchair/backup/LawnchairBackup.kt
@@ -66,7 +66,7 @@ class LawnchairBackup(
                     {
                         val file = entry.value
                         file.parentFile?.mkdirs()
-                        it.copyTo(file.outputStream())
+                        file.outputStream().use { out -> it.copyTo(out) }
                     }
                 },
             )
@@ -78,10 +78,12 @@ class LawnchairBackup(
             }
         }
         context.getDatabasePath(LAUNCHER_DB_FILE_NAME).parentFile?.deleteRecursively()
-        DeviceGridState(info.gridState).writeToPrefs(context, true)
         readZip(handlers)
+        // Written after the zip has been extracted: the backed up preferences file is one of
+        // the restored entries, so writing the grid state first would let it be overwritten.
+        DeviceGridState(info.gridState).writeToPrefs(context, true)
 
-        var dbController = ModelDbController(context)
+        val dbController = ModelDbController(context)
         RestoreDbTask.performRestore(context, dbController)
     }
 
@@ -181,7 +183,7 @@ class LawnchairBackup(
                         getFiles(context, forRestore = false).entries.forEach {
                             if (!it.value.exists()) return@forEach
                             out.putNextEntry(ZipEntry(it.key))
-                            it.value.inputStream().copyTo(out)
+                            it.value.inputStream().use { input -> input.copyTo(out) }
                         }
                     }
                 }


### PR DESCRIPTION
## What

Three small defects in `LawnchairBackup`, found while investigating a restore that
did not behave as expected.

### File streams are never closed

`restore()` copies every archive entry into `file.outputStream()` without ever
closing it:

```kotlin
it.copyTo(file.outputStream())
```

That leaks one file descriptor per restored file, and the descriptor only goes
away when the finalizer runs. `create()` has the same problem with
`File.inputStream()`. Both are now wrapped in `use {}`.

### The grid state is written before the archive is extracted

```kotlin
DeviceGridState(info.gridState).writeToPrefs(context, true)
readZip(handlers)
```

`writeToPrefs` writes into `LauncherFiles.SHARED_PREFERENCES_KEY`, and that very
file (`com.android.launcher3.prefs.xml`) is one of the entries `readZip` restores.
So the grid state written on the line above is immediately overwritten by the
archived one. On top of that, `writeToPrefs` goes through an asynchronous
`apply()`, whose deferred flush rewrites the whole file from the in-memory map —
potentially landing on top of the file that was just restored.

Moving the call after `readZip()` makes it effective again, and keeps it ordered
before `RestoreDbTask.performRestore()`, which is what consumes it.

### Minor

`dbController` was declared `var` although it is never reassigned.

## Notes, not addressed here

Two further issues showed up while reading this code. Neither is fixed in this PR,
because both deserve a maintainer's opinion first:

- **The DataStore file is replaced underneath a live cache.** `restore()` overwrites
  `files/datastore/preferences.preferences_pb` while the process still holds an open
  DataStore instance for that file. DataStore keeps its state in memory and never
  re-reads the file, so any write happening between `readZip()` and the
  `exitProcess(0)` in `restartLauncher()` rewrites the whole file from the stale
  in-memory state, silently discarding the restored preferences. The window is
  short (a `Toast`, a `startActivity`, an `AlarmManager` call) but real. A proper
  fix probably means writing through the DataStore API rather than replacing the
  file, which is a larger change.

- **`databases/` is wiped entirely.** `context.getDatabasePath(LAUNCHER_DB_FILE_NAME).parentFile?.deleteRecursively()`
  removes the whole directory, not just `launcher.db`. Narrowing it risks leaving
  orphaned `-wal`/`-shm` files behind, so the current behaviour may well be
  deliberate.

## Testing

`./gradlew compileLawnWithQuickstepNightlyDebugKotlin` passes. The changes are
confined to stream handling and statement ordering; no behaviour was intentionally
altered beyond the three points above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backup restoration so grid settings are preserved correctly after restoring preferences.
  * Improved backup and restore reliability by ensuring file resources are closed after use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->