### PR TITLE
fix: Recompose QSB on state changes

### DIFF
--- a/lawnchair/src/app/lawnchair/allapps/AllAppsSearchInput.kt
+++ b/lawnchair/src/app/lawnchair/allapps/AllAppsSearchInput.kt
@@ -14,6 +14,7 @@ import android.text.style.ForegroundColorSpan
 import android.util.AttributeSet
 import android.view.KeyEvent
 import android.view.MotionEvent
+import android.view.View
 import android.view.ViewTreeObserver
 import android.view.ViewTreeObserver.OnGlobalFocusChangeListener
 import android.view.animation.DecelerateInterpolator
@@ -246,6 +247,18 @@ class AllAppsSearchInput(context: Context, attrs: AttributeSet?) :
                 }
             }
         }
+
+        // Stop Compose QSB from disappearing
+        // https://stackoverflow.com/questions/72781705/jetpack-compose-view-not-drawing-when-coming-back-to-fragment/77496737#77496737
+        qsbShell.addOnAttachStateChangeListener(object : OnAttachStateChangeListener {
+            override fun onViewAttachedToWindow(v: View) {
+                requestLayout()
+                qsbShell.disposeComposition()
+            }
+            override fun onViewDetachedFromWindow(v: View) {
+                qsbShell.disposeComposition()
+            }
+        })
 
         val currentPaddingLeft = initialPaddingLeft
         val currentPaddingRight = initialPaddingRight

--- a/lawnchair/src/app/lawnchair/qsb/LawnQsbLayout.kt
+++ b/lawnchair/src/app/lawnchair/qsb/LawnQsbLayout.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.graphics.Rect
 import android.graphics.RectF
 import android.util.AttributeSet
+import android.view.View
 import android.widget.FrameLayout
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -136,6 +137,18 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
                 }
             }
         }
+
+        // Stop Compose QSB from disappearing
+        // https://stackoverflow.com/questions/72781705/jetpack-compose-view-not-drawing-when-coming-back-to-fragment/77496737#77496737
+        composeView.addOnAttachStateChangeListener(object : OnAttachStateChangeListener {
+            override fun onViewAttachedToWindow(v: View) {
+                requestLayout()
+                composeView.disposeComposition()
+            }
+            override fun onViewDetachedFromWindow(v: View) {
+                composeView.disposeComposition()
+            }
+        })
 
         addView(
             composeView,


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Manually recompose compose on view stuff on state changes.

Really annoying when lifecycle is imploded/recreate our Lawnchair Compose QSB failed to render the QSB for entirely no reason (or some voodoo advanced magic reason)

Fixes #7038 
Fixes #7228
Fixes #7219

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->

Thank you stackoverflow https://stackoverflow.com/questions/72781705/jetpack-compose-view-not-drawing-when-coming-back-to-fragment/77496737#77496737

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Tested on Pixel 7

1. Change system them from light <-> dark
2. Observe QSB on Hotseat and Allapps layer

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the search interface’s behavior when navigating between screens or changing its attachment state.
  - Fixed an issue that could cause the search bar to disappear after being reattached.
  - Ensured the search interface refreshes its layout correctly when returning to view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->