### PR TITLE
fix: Compensate text style for predicted app icon

### DIFF
--- a/quickstep/src/com/android/launcher3/uioverrides/PredictedAppIcon.java
+++ b/quickstep/src/com/android/launcher3/uioverrides/PredictedAppIcon.java
@@ -39,6 +39,7 @@ import android.util.AttributeSet;
 import android.util.FloatProperty;
 import android.util.Log;
 import android.util.Property;
+import android.util.TypedValue;
 
 import androidx.core.graphics.ColorUtils;
 
@@ -68,7 +69,7 @@ public class PredictedAppIcon extends DoubleShadowBubbleTextView {
 
     private static final float RING_SCALE_START_VALUE = 0.75f;
     private static final int RING_SHADOW_COLOR = 0x99000000;
-    private static final float RING_EFFECT_RATIO = Flags.enableLauncherIconShapes() ? 0.1f : 0.095f;
+    public static final float RING_EFFECT_RATIO = Flags.enableLauncherIconShapes() ? 0.1f : 0.095f;
     private static final long ICON_CHANGE_ANIM_DURATION = 360;
     private static final long ICON_CHANGE_ANIM_STAGGER = 50;
 
@@ -142,6 +143,23 @@ public class PredictedAppIcon extends DoubleShadowBubbleTextView {
                 R.dimen.blur_size_thin_outline);
         mShadowFilter = new BlurMaskFilter(shadowSize, BlurMaskFilter.Blur.OUTER);
         mShapePath = ThemeManager.INSTANCE.get(context).getIconShape().getPath(mNormalizedIconSize);
+        compensateTextStyle();
+    }
+
+    /** LC-Note: Normalise text size for predicted app container
+     * <p> 
+     * Because the text size and padding are exactly compensated for app icon and not the predicted 
+     * container, the text will be small and sitting too close to the container. 
+     * <p> 
+     * This function will update the text size and padding to compensate for the container. */
+    private void compensateTextStyle() {
+        if (mDisplay == DISPLAY_WORKSPACE) {
+            float scale = !mIsPinned ? (1 - 2f * RING_EFFECT_RATIO) : 1f;
+            float ringCompensation = !mIsPinned ? (getIconSize() * RING_EFFECT_RATIO) : 0f;
+            setTextSize(TypedValue.COMPLEX_UNIT_PX, mDeviceProfile.iconTextSizePx / scale);
+            setCompoundDrawablePadding(
+                    Math.round((mDeviceProfile.iconDrawablePaddingPx + ringCompensation) / scale));
+        }
     }
 
     @Override
@@ -272,6 +290,7 @@ public class PredictedAppIcon extends DoubleShadowBubbleTextView {
     public void pin(WorkspaceItemInfo info) {
         if (mIsPinned) return;
         mIsPinned = true;
+        compensateTextStyle();
         applyFromWorkspaceItem(info);
         setOnLongClickListener(ItemLongClickListener.INSTANCE_WORKSPACE);
         ((CellLayoutLayoutParams) getLayoutParams()).canReorder = true;

--- a/quickstep/src/com/android/launcher3/uioverrides/PredictedAppIcon.java
+++ b/quickstep/src/com/android/launcher3/uioverrides/PredictedAppIcon.java
@@ -146,7 +146,7 @@ public class PredictedAppIcon extends DoubleShadowBubbleTextView {
         compensateTextStyle();
     }
 
-    /** LC-Note: Normalise text size for predicted app container
+    /** LC-Note: Compensate text size for predicted app container
      * <p> 
      * Because the text size and padding are exactly compensated for app icon and not the predicted 
      * container, the text will be small and sitting too close to the container. 


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Compensate text style being too small and too close to the predicted container (or ring) of the predicted app.

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->

Scale up the size and padding to compensate.

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Tested on Pixel 7

1. Show predicted app on hotseat
2. Observe

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved predicted app icons so workspace labels and icon spacing remain properly aligned when the prediction ring is displayed.
  * Applied consistent sizing adjustments when predicted apps are pinned to the workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->