### PR TITLE
build: Publish library modules to GitHub Packages

### DIFF
--- a/.github/workflows/publish_packages.yml
+++ b/.github/workflows/publish_packages.yml
@@ -1,0 +1,54 @@
+name: Publish packages
+
+on:
+  push:
+    tags:
+      - 'lib-v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Maven version to publish (e.g. 16.0.0-alpha01). Defaults to 16.0.0-dev.<run number>.'
+        required: false
+        type: string
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
+      - uses: actions/setup-java@v6
+        with:
+          distribution: 'zulu'
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@v6
+
+      # Tags are named lib-v<version>; anything else falls back to a dev version
+      # keyed by the run number so re-runs never collide in GitHub Packages.
+      - name: Resolve version
+        id: version
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            version="${{ inputs.version }}"
+          elif [[ "${{ github.ref }}" == refs/tags/lib-v* ]]; then
+            version="${GITHUB_REF#refs/tags/lib-v}"
+          else
+            version="16.0.0-dev.${{ github.run_number }}"
+          fi
+          echo "value=$version" >> "$GITHUB_OUTPUT"
+          echo "Publishing version $version"
+
+      - name: Publish to GitHub Packages
+        run: ./gradlew publishAllPublicationsToGitHubPackagesRepository
+        env:
+          PUBLISH_VERSION: ${{ steps.version.outputs.value }}
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Summary
+        run: |
+          echo "Published \`${{ steps.version.outputs.value }}\` to https://github.com/${{ github.repository }}/packages" >> "$GITHUB_STEP_SUMMARY"

--- a/build.gradle
+++ b/build.gradle
@@ -125,6 +125,14 @@ allprojects {
     }
 }
 
+// Library modules are published to GitHub Packages so other projects can depend on
+// them; see gradle/publishing.gradle for the published set and docs/publishing.md.
+subprojects {
+    plugins.withId('com.android.library') {
+        apply from: rootProject.file('gradle/publishing.gradle')
+    }
+}
+
 final def buildCommit = providers.exec {
     commandLine('git', 'rev-parse', '--short=7', 'HEAD')
 }.standardOutput.asText.get().trim()

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,0 +1,153 @@
+# Publishing the library modules
+
+Lawnchair's reusable Android library modules are published as AARs to
+[GitHub Packages](https://github.com/Lazygarde/lawnchair/packages) so other projects can
+depend on them without vendoring this repository.
+
+The launcher itself (the root `:` project) is an application module and is **not** published.
+
+## Coordinates
+
+All artifacts share the group `com.github.lazygarde.lawnchair`, configured in
+`gradle.properties`:
+
+```properties
+lawnchair.publish.group=com.github.lazygarde.lawnchair
+lawnchair.publish.version=16.0.0-local
+lawnchair.publish.repository=Lazygarde/lawnchair
+```
+
+| Gradle project | artifactId |
+| --- | --- |
+| `:iconloaderlib` | `iconloaderlib` |
+| `:searchuilib` | `searchuilib` |
+| `:animationlib` | `animationlib` |
+| `:msdllib` | `msdllib` |
+| `:contextualeducationlib` | `contextualeducationlib` |
+| `:viewcapturelib` | `viewcapturelib` |
+| `:displaylib` | `displaylib` |
+| `:mechanics` | `mechanics` |
+| `:shared` | `systemui-shared` |
+| `:plugin` | `systemui-plugin` |
+| `:plugincore` | `systemui-plugin-core` |
+| `:common` | `systemui-common` |
+| `:log` | `systemui-log` |
+| `:animation` | `systemui-animation` |
+| `:unfold` | `systemui-unfold` |
+| `:utils` | `systemui-utils` |
+| `:compatLib` | `compatlib` |
+| `:compatLib:compatLibVQ` … `:compatLibVBaklava` | `compatlib-vq` … `compatlib-vbaklava` |
+| `:hidden-api` | `hidden-api` |
+| `:androidx-lib` | `androidx-lib` |
+| `:flags` | `flags` |
+| `:wmshell` | `wmshell` |
+| `:dagger` | `dagger` |
+| `:concurrent` | `concurrent` |
+| `:modules:widgetpicker` | `widgetpicker` |
+
+The `systemui-` prefix exists because the upstream module names (`log`, `common`,
+`utils`, …) are too generic to publish unqualified.
+
+The mapping lives in [`gradle/publishing.gradle`](../gradle/publishing.gradle). A
+`com.android.library` module that is absent from that map is simply not published, so
+adding a new module to the published set means adding one line there.
+
+## Publishing
+
+### From CI (the normal path)
+
+The `Publish packages` workflow (`.github/workflows/publish_packages.yml`) publishes
+every module. It runs on:
+
+- a pushed tag named `lib-v<version>`, e.g. `lib-v16.0.0-alpha01`, which publishes
+  version `16.0.0-alpha01`;
+- a manual `workflow_dispatch`, which takes an optional version input and otherwise
+  publishes `16.0.0-dev.<run number>`.
+
+```bash
+git tag lib-v16.0.0-alpha01
+git push origin lib-v16.0.0-alpha01
+```
+
+GitHub Packages rejects re-publishing an existing non-snapshot version, which is why
+the dev fallback is keyed by the run number rather than the commit.
+
+### From a local machine
+
+Publishing to GitHub Packages needs a personal access token with the `write:packages`
+scope. Put it in `~/.gradle/gradle.properties` so it never lands in the repository:
+
+```properties
+gpr.user=your-github-username
+gpr.key=ghp_xxxxxxxxxxxxxxxxxxxx
+```
+
+The build also accepts the `GITHUB_ACTOR` / `GITHUB_TOKEN` environment variables, which
+is what CI uses.
+
+```bash
+# Everything, at the version from gradle.properties
+./gradlew publishAllPublicationsToGitHubPackagesRepository
+
+# A specific version
+PUBLISH_VERSION=16.0.0-alpha01 ./gradlew publishAllPublicationsToGitHubPackagesRepository
+
+# A single module
+./gradlew :iconloaderlib:publishAllPublicationsToGitHubPackagesRepository
+```
+
+To try the artifacts without uploading anything, publish to the local Maven cache
+instead — no token required:
+
+```bash
+./gradlew publishToMavenLocal
+```
+
+## Consuming the artifacts
+
+GitHub Packages requires authentication even for public repositories, so the consuming
+project needs a token with the `read:packages` scope.
+
+`settings.gradle.kts` in the consuming project:
+
+```kotlin
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+        maven {
+            url = uri("https://maven.pkg.github.com/Lazygarde/lawnchair")
+            credentials {
+                username = providers.gradleProperty("gpr.user").orNull
+                    ?: System.getenv("GITHUB_ACTOR")
+                password = providers.gradleProperty("gpr.key").orNull
+                    ?: System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
+}
+```
+
+`build.gradle.kts` in the consuming module:
+
+```kotlin
+dependencies {
+    implementation("com.github.lazygarde.lawnchair:iconloaderlib:16.0.0-alpha01")
+    implementation("com.github.lazygarde.lawnchair:animationlib:16.0.0-alpha01")
+}
+```
+
+Inter-module dependencies resolve automatically: `systemui-common` pulls in
+`systemui-utils`, `compatlib-vbaklava` pulls in the whole `compatlib-v*` chain, and so on.
+
+### Caveats
+
+- **Hidden APIs.** Several modules compile against the AOSP stubs in `prebuilts/libs`
+  (`framework-16.jar`, `SystemUI-core-16.jar`, `WindowManager-Shell-16.jar`) as
+  `compileOnly` dependencies. Those are deliberately absent from the published POMs. If
+  your code touches the hidden APIs these modules expose, copy the relevant jars into
+  your project and add them as `compileOnly files(...)` yourself. At runtime the calls
+  still need a device where those APIs are reachable.
+- **minSdk 26** and `compileSdk 37` come from the root build script and apply to every
+  published module.
+- Sources jars are published; javadoc jars are not.

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,3 +6,9 @@ org.gradle.parallel=true
 org.gradle.configuration-cache=true
 org.gradle.configuration-cache.parallel=true
 org.gradle.tooling.parallel=true
+
+# Maven coordinates for the published library modules (see docs/publishing.md).
+# `lawnchair.publish.version` is the local default; CI overrides it via PUBLISH_VERSION.
+lawnchair.publish.group=com.github.lazygarde.lawnchair
+lawnchair.publish.version=16.0.0-local
+lawnchair.publish.repository=Lazygarde/lawnchair

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -1,0 +1,129 @@
+/*
+ * Publishes Lawnchair's library modules as Maven artifacts so other projects can
+ * consume them without vendoring this repository.
+ *
+ * Applied by the root build script to every `com.android.library` project. Modules
+ * that are not listed in `artifactIds` below are skipped, which keeps internal-only
+ * or test-only libraries out of the published set.
+ *
+ * See docs/publishing.md for how to publish and how to consume the artifacts.
+ */
+
+// Project path -> Maven artifactId. The systemUI/* modules get a `systemui-` prefix
+// because names such as `log`, `common` and `utils` are far too generic to publish
+// as-is.
+def artifactIds = [
+        ':iconloaderlib'            : 'iconloaderlib',
+        ':searchuilib'              : 'searchuilib',
+        ':animationlib'             : 'animationlib',
+        ':msdllib'                  : 'msdllib',
+        ':contextualeducationlib'   : 'contextualeducationlib',
+        ':viewcapturelib'           : 'viewcapturelib',
+        ':displaylib'               : 'displaylib',
+        ':mechanics'                : 'mechanics',
+
+        ':shared'                   : 'systemui-shared',
+        ':plugin'                   : 'systemui-plugin',
+        ':plugincore'               : 'systemui-plugin-core',
+        ':common'                   : 'systemui-common',
+        ':log'                      : 'systemui-log',
+        ':animation'                : 'systemui-animation',
+        ':unfold'                   : 'systemui-unfold',
+        ':utils'                    : 'systemui-utils',
+
+        ':compatLib'                : 'compatlib',
+        ':compatLib:compatLibVQ'    : 'compatlib-vq',
+        ':compatLib:compatLibVR'    : 'compatlib-vr',
+        ':compatLib:compatLibVS'    : 'compatlib-vs',
+        ':compatLib:compatLibVT'    : 'compatlib-vt',
+        ':compatLib:compatLibVU'    : 'compatlib-vu',
+        ':compatLib:compatLibVV'    : 'compatlib-vv',
+        ':compatLib:compatLibVBaklava': 'compatlib-vbaklava',
+
+        ':hidden-api'               : 'hidden-api',
+        ':androidx-lib'             : 'androidx-lib',
+        ':flags'                    : 'flags',
+        ':wmshell'                  : 'wmshell',
+        ':dagger'                   : 'dagger',
+        ':concurrent'               : 'concurrent',
+        ':modules:widgetpicker'     : 'widgetpicker',
+]
+
+def artifactId = artifactIds[project.path]
+if (artifactId == null) {
+    return
+}
+
+apply plugin: 'maven-publish'
+
+def publishGroup = providers.gradleProperty('lawnchair.publish.group').get()
+// CI overrides the version per run; locally it falls back to gradle.properties.
+def publishVersion = providers.environmentVariable('PUBLISH_VERSION')
+        .orElse(providers.gradleProperty('lawnchair.publish.version'))
+        .get()
+def publishRepoSlug = providers.gradleProperty('lawnchair.publish.repository').get()
+
+def gprUser = providers.gradleProperty('gpr.user')
+        .orElse(providers.environmentVariable('GITHUB_ACTOR'))
+        .getOrElse('')
+def gprToken = providers.gradleProperty('gpr.key')
+        .orElse(providers.environmentVariable('GITHUB_TOKEN'))
+        .getOrElse('')
+
+android {
+    publishing {
+        singleVariant('release') {
+            withSourcesJar()
+        }
+    }
+}
+
+afterEvaluate {
+    // Modules such as :compatLib and :wmshell point `aidl.srcDirs` at the same directory
+    // as their Java sources, so the generated AIDL stubs land on top of the checked-in
+    // files when the sources jar is assembled. Keeping the first copy (the checked-in
+    // one) is the right result for a sources artifact.
+    tasks.named('sourceReleaseJar', Jar) {
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    }
+
+    publishing {
+        publications {
+            release(MavenPublication) {
+                from components.release
+
+                groupId = publishGroup
+                setArtifactId(artifactId)
+                version = publishVersion
+
+                pom {
+                    name = "Lawnchair ${artifactId}"
+                    description = "Lawnchair library module ${project.path}"
+                    url = "https://github.com/${publishRepoSlug}"
+                    licenses {
+                        license {
+                            name = 'The Apache License, Version 2.0'
+                            url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+                        }
+                    }
+                    scm {
+                        url = "https://github.com/${publishRepoSlug}"
+                        connection = "scm:git:https://github.com/${publishRepoSlug}.git"
+                        developerConnection = "scm:git:ssh://git@github.com/${publishRepoSlug}.git"
+                    }
+                }
+            }
+        }
+
+        repositories {
+            maven {
+                name = 'GitHubPackages'
+                url = "https://maven.pkg.github.com/${publishRepoSlug}"
+                credentials {
+                    username = gprUser
+                    password = gprToken
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds maven-publish to every com.android.library module listed in gradle/publishing.gradle, so other projects can depend on Lawnchair's libraries instead of vendoring the repository.

Each module is published as an AAR plus a sources jar under the group com.github.lazygarde.lawnchair. The systemUI/* modules are published with a systemui- prefix because names such as log, common and utils are too generic to publish unqualified. Inter-module project dependencies resolve to the published coordinates, so consumers get the transitive graph for free.

The launcher itself is an application module and stays unpublished.

<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Fixes #(issue) <!-- optional -->

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->


### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

:x: **Bug fix** (A non-breaking change that fixes an issue)
:x: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Android library modules can now be published as AAR packages to GitHub Packages.
  * Releases can be published automatically from version tags or initiated manually.
  * Published packages include source archives and standard Maven metadata.

* **Documentation**
  * Added guidance for publishing libraries locally or through CI.
  * Added instructions for consuming packages, authentication, versioning, and platform compatibility considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->