### PR TITLE
fix: Icon pack and drawer settings that could not be reached or did not apply

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,7 +140,7 @@ final def isReleaseBuild = ciBuild
 final def devReleaseName = ciBuild ? "Dev.(#${ciRunNumber})" : "Dev.(${buildCommit})"
 
 final def version = "16"
-final def releaseName = "Development 5.1"
+final def releaseName = "Development 5.2"
 final def versionDisplayName = "${version}.${isReleaseBuild ? releaseName : devReleaseName}"
 final def majorVersion = versionDisplayName.split("\\.")[0]
 
@@ -151,10 +151,10 @@ android {
     namespace "com.android.launcher3"
     defaultConfig {
         /*
-         * Lawnchair Launcher 16.0 Development 5.1
+         * Lawnchair Launcher 16.0 Development 5.2
          * see CONTRIBUTING.md#versioning-scheme
          */
-        versionCode 16_00_01_05_01
+        versionCode 16_00_01_05_02
         versionName "${versionDisplayName}"
         buildConfigField "String", "VERSION_DISPLAY_NAME", "\"${versionDisplayName}\""
         buildConfigField "String", "MAJOR_VERSION", "\"${majorVersion}\""

--- a/build.gradle
+++ b/build.gradle
@@ -140,7 +140,7 @@ final def isReleaseBuild = ciBuild
 final def devReleaseName = ciBuild ? "Dev.(#${ciRunNumber})" : "Dev.(${buildCommit})"
 
 final def version = "16"
-final def releaseName = "Development 5.2"
+final def releaseName = "Development 5.9"
 final def versionDisplayName = "${version}.${isReleaseBuild ? releaseName : devReleaseName}"
 final def majorVersion = versionDisplayName.split("\\.")[0]
 
@@ -151,10 +151,10 @@ android {
     namespace "com.android.launcher3"
     defaultConfig {
         /*
-         * Lawnchair Launcher 16.0 Development 5.2
+         * Lawnchair Launcher 16.0 Development 5.9
          * see CONTRIBUTING.md#versioning-scheme
          */
-        versionCode 16_00_01_05_02
+        versionCode 16_00_01_05_09
         versionName "${versionDisplayName}"
         buildConfigField "String", "VERSION_DISPLAY_NAME", "\"${versionDisplayName}\""
         buildConfigField "String", "MAJOR_VERSION", "\"${majorVersion}\""

--- a/lawnchair/res/values/config.xml
+++ b/lawnchair/res/values/config.xml
@@ -140,6 +140,7 @@
     <bool name="config_default_show_hidden_apps_in_search">false</bool>
     <bool name="config_default_enable_smart_hide">false</bool>
     <bool name="config_default_show_suggested_apps_at_drawer_top">true</bool>
+    <bool name="config_default_show_suggested_apps_in_dock">true</bool>
     <bool name="config_default_enable_font_selection">true</bool>
     <bool name="config_default_enable_smartspace_calendar_selection">true</bool>
     <bool name="config_default_dts2">true</bool>

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -962,6 +962,7 @@
     <string name="fuzzy_search_desc">Approximate matching for app searches</string>
 
     <string name="show_suggested_apps_at_drawer_top">Show suggested apps at the top of the drawer</string>
+    <string name="show_suggested_apps_in_dock">Show suggested apps in the dock</string>
 
     <string name="perform_wide_search_title">Device search</string>
     <string name="perform_wide_search_description">Search your phone contacts, files, and settings</string>

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -392,6 +392,10 @@
     <string name="force_monochrome_label">Force monochrome</string>
     <string name="force_monochrome_description">Recolor unsupported apps with the current accent color.</string>
 
+    <string name="icon_pack_scope_title">Apply icon pack to</string>
+    <string name="icon_pack_scope_home_label">Home screen</string>
+    <string name="icon_pack_scope_home_and_drawer_label">Home screen and app drawer</string>
+
     <string name="themed_icon_title">Themed icons</string>
     <string name="themed_icons_off_label">Off</string>
     <string name="themed_icons_home_label">Home screen</string>

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -393,6 +393,9 @@
     <string name="force_monochrome_description">Recolor unsupported apps with the current accent color.</string>
 
     <string name="icon_pack_scope_title">Apply icon pack to</string>
+    <string name="get_lawnicons">Get Lawnicons</string>
+    <string name="icon_style_drawer_subtitle">Whether the icon pack and themed icons reach the app drawer</string>
+    <string name="dock_icons_shared_description">Shared with the home screen grid</string>
     <string name="icon_pack_scope_home_label">Home screen</string>
     <string name="icon_pack_scope_home_and_drawer_label">Home screen and app drawer</string>
 

--- a/lawnchair/src/app/lawnchair/DeviceProfileOverrides.kt
+++ b/lawnchair/src/app/lawnchair/DeviceProfileOverrides.kt
@@ -132,7 +132,7 @@ class DeviceProfileOverrides @Inject constructor(
 
             enableTaskbarOnPhone = prefs2.enableTaskbarOnPhone.firstCached(),
 
-            numHotseatRows = prefs.hotseatRows.get().coerceIn(1, 2),
+            numHotseatRows = prefs.hotseatRows.get().coerceIn(0, 2),
             numDockPages = prefs.dockPages.get().coerceIn(1, 5),
 
             foldableShownHotseatIcons = if (deviceType == InvariantDeviceProfile.TYPE_MULTI_DISPLAY) {

--- a/lawnchair/src/app/lawnchair/allapps/AllAppsSearchInput.kt
+++ b/lawnchair/src/app/lawnchair/allapps/AllAppsSearchInput.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isGone
 import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
@@ -38,6 +39,7 @@ import androidx.interpolator.view.animation.FastOutSlowInInterpolator
 import androidx.lifecycle.lifecycleScope
 import app.lawnchair.launcher
 import app.lawnchair.preferences.PreferenceManager
+import app.lawnchair.preferences.observeAsState
 import app.lawnchair.preferences2.PreferenceManager2
 import app.lawnchair.preferences2.asState
 import app.lawnchair.preferences2.firstCached
@@ -56,6 +58,7 @@ import app.lawnchair.search.algorithms.LawnchairSearchAlgorithm
 import app.lawnchair.theme.color.tokens.ColorTokens
 import app.lawnchair.ui.theme.LawnchairTheme
 import app.lawnchair.util.ProvideLifecycleState
+import com.android.launcher3.ExtendedEditText
 import com.android.launcher3.Insettable
 import com.android.launcher3.InvariantDeviceProfile.OnIDPChangeListener
 import com.android.launcher3.LauncherState
@@ -186,19 +189,25 @@ class AllAppsSearchInput(context: Context, attrs: AttributeSet?) :
                     ColorTokens.SearchboxHighlight.resolveColor(context)
                 }
 
+                val idleAlpha by prefs.drawerQsbAlpha.observeAsState()
+                val cornerRadius by prefs.drawerQsbCornerRadius.observeAsState()
+                val strokeWidth by prefs.drawerQsbStrokeWidth.observeAsState()
+
+                // The bar fades out of the way while the query is being typed.
                 val backgroundAlpha by animateIntAsState(
-                    if (isFocused || !queryEmpty) 0 else 100,
+                    if (isFocused || !queryEmpty) 0 else idleAlpha,
                 )
 
-                // Ignore other theme attributes to preserve existing behavior
                 val style = buildQsbStyle(
                     context = context,
                     themed = themedQsb,
                     backgroundColor = backgroundColor,
                     backgroundAlpha = backgroundAlpha,
-                    cornerRadius = 1f,
-                    strokeColor = null,
-                    strokeWidth = 0f,
+                    cornerRadius = cornerRadius,
+                    // Use light color as strokeColor is a static color that doesn't use darkColor
+                    strokeColor = prefs2.strokeColorStyle.asState().value
+                        .colorPreferenceEntry.lightColor.invoke(context),
+                    strokeWidth = strokeWidth,
                 )
 
                 val actions = QsbActions(
@@ -207,7 +216,7 @@ class AllAppsSearchInput(context: Context, attrs: AttributeSet?) :
                             searchAlgorithm?.doZeroStateSearch(this@AllAppsSearchInput)
                         }
                         input.requestFocus()
-                        input.showKeyboard()
+                        input.showKeyboardWhenReady()
                     },
                     onStartIconClick = if (shouldShowIcons) {
                         {
@@ -283,6 +292,10 @@ class AllAppsSearchInput(context: Context, attrs: AttributeSet?) :
                 if (input.text.toString().isEmpty() && isDirectFocus) {
                     searchAlgorithm?.doZeroStateSearch(this)
                     setDirectFocus(false)
+                    // Filling the zero state rebuilds the list under the field, and the keyboard
+                    // the framework asked for when the field took focus is dropped along the way.
+                    // That is why the first tap on the search bar used to leave it closed.
+                    input.showKeyboardWhenReady()
                 }
 
                 setBackgroundVisibility(false, 0f)
@@ -554,3 +567,26 @@ class AllAppsSearchInput(context: Context, attrs: AttributeSet?) :
         requestLayout()
     }
 }
+
+/**
+ * Asks for the keyboard, and keeps asking for a short while until it is actually up.
+ *
+ * [ExtendedEditText.showKeyboard] reports whether the request was accepted, not whether the
+ * keyboard appeared: right after the drawer opens the request is taken and then dropped, which is
+ * why the first tap on the search bar used to leave the keyboard closed. So ask through the window
+ * insets controller and check the insets themselves before giving up.
+ */
+private fun ExtendedEditText.showKeyboardWhenReady(attemptsLeft: Int = KEYBOARD_ATTEMPTS) {
+    requestFocus()
+    val controller = ViewCompat.getWindowInsetsController(this)
+    if (controller != null) controller.show(WindowInsetsCompat.Type.ime()) else showKeyboard()
+    if (attemptsLeft <= 1) return
+    postDelayed({
+        if (!isKeyboardVisible()) showKeyboardWhenReady(attemptsLeft - 1)
+    }, KEYBOARD_RETRY_MS)
+}
+
+private fun View.isKeyboardVisible() = ViewCompat.getRootWindowInsets(this)?.isVisible(WindowInsetsCompat.Type.ime()) == true
+
+private const val KEYBOARD_ATTEMPTS = 6
+private const val KEYBOARD_RETRY_MS = 80L

--- a/lawnchair/src/app/lawnchair/icons/DrawerIconCache.kt
+++ b/lawnchair/src/app/lawnchair/icons/DrawerIconCache.kt
@@ -17,18 +17,27 @@
 package app.lawnchair.icons
 
 import android.content.Context
+import android.os.Looper
+import android.util.Log
 import app.lawnchair.preferences.PreferenceManager
 import com.android.launcher3.InvariantDeviceProfile
+import com.android.launcher3.LauncherAppState
+import com.android.launcher3.LauncherSettings.Favorites.DESKTOP_ICON_FLAG
 import com.android.launcher3.dagger.ApplicationContext
 import com.android.launcher3.dagger.LauncherAppComponent
 import com.android.launcher3.dagger.LauncherAppSingleton
 import com.android.launcher3.graphics.ThemeManager
 import com.android.launcher3.icons.IconCache
 import com.android.launcher3.icons.LauncherIcons
+import com.android.launcher3.model.data.WorkspaceItemInfo
 import com.android.launcher3.pm.InstallSessionHelper
 import com.android.launcher3.pm.UserCache
 import com.android.launcher3.util.DaggerSingletonObject
 import com.android.launcher3.util.DaggerSingletonTracker
+import com.android.launcher3.util.Executors
+import java.util.concurrent.Callable
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 import javax.inject.Inject
 
 /**
@@ -77,6 +86,12 @@ class DrawerIconCache @Inject constructor(
      */
     fun cacheForDrawer(default: IconCache): IconCache = if (usesIconPack) default else plainCacheLazy.value
 
+    /**
+     * `true` while the drawer is showing the plain system icons, so an item taken from it carries
+     * an icon the home screen would draw differently.
+     */
+    fun usesPlainDrawerIcons(): Boolean = !usesIconPack
+
     /** Drops the plain icons held in memory. Does nothing while the cache has never been built. */
     fun clearMemoryCache() {
         if (plainCacheLazy.isInitialized()) plainCacheLazy.value.clearMemoryCache()
@@ -84,8 +99,54 @@ class DrawerIconCache @Inject constructor(
 
     companion object {
         private const val PLAIN_ICONS_DB = "app_icons_plain.db"
+        private const val TAG = "DrawerIconCache"
+
+        /** How long a drop waits for the icon before letting it arrive on its own. */
+        private const val ICON_WAIT_MS = 500L
 
         @JvmField
         val INSTANCE = DaggerSingletonObject(LauncherAppComponent::getDrawerIconCache)
+
+        /**
+         * Gives [info] the icon the home screen draws, for an item that was just taken out of the
+         * drawer while the drawer is showing the plain system icons.
+         *
+         * The cache may only be read from its own thread, so a drop on the UI thread hands the
+         * lookup over and waits for it. The wait is capped: a model load can hold that thread for
+         * seconds, and a late icon is better than a frozen launcher. Returns `false` in that case,
+         * meaning the caller should pick the icon up through [refreshHomeScreenIcon] instead.
+         */
+        @JvmStatic
+        fun fillHomeScreenIcon(context: Context, info: WorkspaceItemInfo): Boolean {
+            if (!INSTANCE.get(context).usesPlainDrawerIcons()) return true
+            val cache = LauncherAppState.getInstance(context).iconCache
+            if (Looper.myLooper() == Executors.MODEL_EXECUTOR.looper) {
+                cache.getTitleAndIcon(info, DESKTOP_ICON_FLAG)
+                return true
+            }
+            return try {
+                Executors.MODEL_EXECUTOR
+                    .submit(Callable { cache.getTitleAndIcon(info, DESKTOP_ICON_FLAG) })
+                    .get(ICON_WAIT_MS, TimeUnit.MILLISECONDS)
+                true
+            } catch (_: TimeoutException) {
+                false
+            } catch (e: Exception) {
+                Log.w(TAG, "Could not read the home screen icon for ${info.targetComponent}", e)
+                true
+            }
+        }
+
+        /** Delivers the icon to [receiver] once it is read, for when the wait above ran out. */
+        @JvmStatic
+        fun refreshHomeScreenIcon(
+            context: Context,
+            receiver: IconCache.ItemInfoUpdateReceiver,
+            info: WorkspaceItemInfo,
+        ) {
+            LauncherAppState.getInstance(context)
+                .iconCache
+                .updateIconInBackground(receiver, info, DESKTOP_ICON_FLAG)
+        }
     }
 }

--- a/lawnchair/src/app/lawnchair/icons/DrawerIconCache.kt
+++ b/lawnchair/src/app/lawnchair/icons/DrawerIconCache.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026, Lawnchair
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.lawnchair.icons
+
+import android.content.Context
+import app.lawnchair.preferences.PreferenceManager
+import com.android.launcher3.InvariantDeviceProfile
+import com.android.launcher3.dagger.ApplicationContext
+import com.android.launcher3.dagger.LauncherAppComponent
+import com.android.launcher3.dagger.LauncherAppSingleton
+import com.android.launcher3.graphics.ThemeManager
+import com.android.launcher3.icons.IconCache
+import com.android.launcher3.icons.LauncherIcons
+import com.android.launcher3.pm.InstallSessionHelper
+import com.android.launcher3.pm.UserCache
+import com.android.launcher3.util.DaggerSingletonObject
+import com.android.launcher3.util.DaggerSingletonTracker
+import javax.inject.Inject
+
+/**
+ * A second [IconCache] for the app drawer, backed by an icon provider that ignores the icon pack
+ * and per-app icon overrides.
+ *
+ * The icon pack is applied while the icon bitmap is built, so the regular cache holds one bitmap
+ * per component that both the home screen and the drawer read. Keeping the plain icons in their
+ * own cache is what lets the icon pack be limited to the home screen.
+ *
+ * The cache is only built once something asks for it, so users on the default setting
+ * ([PreferenceManager.drawerIconPack] on) never pay for the extra database.
+ */
+@LauncherAppSingleton
+class DrawerIconCache @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val idp: InvariantDeviceProfile,
+    private val userCache: UserCache,
+    private val themeManager: ThemeManager,
+    private val installSessionHelper: InstallSessionHelper,
+    private val iconPool: LauncherIcons.IconPool,
+    private val lifecycle: DaggerSingletonTracker,
+) {
+
+    private val prefs = PreferenceManager.getInstance(context)
+
+    private val plainCacheLazy = lazy {
+        IconCache(
+            context,
+            idp,
+            PLAIN_ICONS_DB,
+            userCache,
+            LawnchairIconProvider(context, themeManager, applyCustomIcons = false),
+            installSessionHelper,
+            iconPool,
+            lifecycle,
+        )
+    }
+
+    /** `true` while the drawer is meant to show the icons from the icon pack, as it always has. */
+    private val usesIconPack get() = prefs.drawerIconPack.get()
+
+    /**
+     * The cache the drawer should read from: [default] when the icon pack covers the drawer too,
+     * and the plain one when the icon pack is limited to the home screen.
+     */
+    fun cacheForDrawer(default: IconCache): IconCache = if (usesIconPack) default else plainCacheLazy.value
+
+    /** Drops the plain icons held in memory. Does nothing while the cache has never been built. */
+    fun clearMemoryCache() {
+        if (plainCacheLazy.isInitialized()) plainCacheLazy.value.clearMemoryCache()
+    }
+
+    companion object {
+        private const val PLAIN_ICONS_DB = "app_icons_plain.db"
+
+        @JvmField
+        val INSTANCE = DaggerSingletonObject(LauncherAppComponent::getDrawerIconCache)
+    }
+}

--- a/lawnchair/src/app/lawnchair/icons/LawnchairIconProvider.kt
+++ b/lawnchair/src/app/lawnchair/icons/LawnchairIconProvider.kt
@@ -240,6 +240,15 @@ class LawnchairIconProvider @Inject constructor(
         } else {
             ""
         }
+        // Only the settings this provider actually reads belong in the key. Listing the icon pack
+        // for the plain provider would throw its cache away every time the pack changes.
+        if (!applyCustomIcons) {
+            return "$base|lc:" +
+                "tip=${themedIconSourcePref.get()}," +
+                "ti=${prefs.themedIcons.get()}," +
+                "dti=${prefs.drawerThemedIcons.get()}," +
+                "fm=${prefs.forceIconMonochrome.get()}"
+        }
         return "$base|lc:" +
             "ip=${iconPackPref.get()}," +
             "tip=${themedIconSourcePref.get()}," +

--- a/lawnchair/src/app/lawnchair/icons/LawnchairIconProvider.kt
+++ b/lawnchair/src/app/lawnchair/icons/LawnchairIconProvider.kt
@@ -55,6 +55,24 @@ class LawnchairIconProvider @Inject constructor(
     context,
     themeManager,
 ) {
+
+    /**
+     * When `false`, the icon pack and per-app icon overrides are ignored and the system icon is
+     * returned instead. Themed icons are unaffected -- they still come from [getThemeDataForPackage].
+     *
+     * The app drawer uses an instance created this way so that the icon pack can be limited to the
+     * home screen. See [app.lawnchair.icons.DrawerIconCache].
+     */
+    private var applyCustomIcons = true
+
+    constructor(
+        context: Context,
+        themeManager: ThemeManager,
+        applyCustomIcons: Boolean,
+    ) : this(context, themeManager) {
+        this.applyCustomIcons = applyCustomIcons
+    }
+
     private val prefs = PreferenceManager.getInstance(context)
     private val themedIconsEnabled get() = prefs.themedIcons.get()
 
@@ -93,6 +111,7 @@ class LawnchairIconProvider @Inject constructor(
     val systemIconState = themeManager.iconState
 
     private fun resolveIconEntry(componentName: ComponentName, user: UserHandle): IconEntry? {
+        if (!applyCustomIcons) return null
         val componentKey = ComponentKey(componentName, user)
         // first look for user-overridden icon
         val overrideItem = overrideRepo.overridesMap[componentKey]

--- a/lawnchair/src/app/lawnchair/preferences/PreferenceManager.kt
+++ b/lawnchair/src/app/lawnchair/preferences/PreferenceManager.kt
@@ -169,6 +169,11 @@ class PreferenceManager @Inject constructor(
     val hotseatQsbCornerRadius = FloatPref("pref_hotseatQsbCornerRadius", 1F, recreate)
     val hotseatQsbAlpha = IntPref("pref_searchHotseatTranparency", 100, recreate)
     val hotseatQsbStrokeWidth = FloatPref("pref_searchStrokeWidth", 0F, recreate)
+
+    // The drawer search bar used to be drawn with these values fixed. The defaults keep that look.
+    val drawerQsbCornerRadius = FloatPref("pref_drawerQsbCornerRadius", 1F, recreate)
+    val drawerQsbAlpha = IntPref("pref_drawerQsbAlpha", 100, recreate)
+    val drawerQsbStrokeWidth = FloatPref("pref_drawerQsbStrokeWidth", 0F, recreate)
     val hotseatBG = BoolPref("pref_hotseatBG", false, recreate)
     val hotseatBGHorizontalInsetLeft = IntPref("pref_hotseatBGHRinsetLeft", 0, recreate)
     val hotseatBGVerticalInsetTop = IntPref("pref_hotseatBGVRinsetTop", 0, recreate)

--- a/lawnchair/src/app/lawnchair/preferences/PreferenceManager.kt
+++ b/lawnchair/src/app/lawnchair/preferences/PreferenceManager.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 import app.lawnchair.LawnchairLauncher
 import app.lawnchair.font.FontCache
+import app.lawnchair.icons.DrawerIconCache
 import app.lawnchair.util.getApkVersionComparison
 import app.lawnchair.util.isGestureNavContractCompatible
 import app.lawnchair.util.isOnePlusStock
@@ -54,6 +55,7 @@ class PreferenceManager @Inject constructor(
         mRecentsModel.onThemeChanged()
         Executors.MODEL_EXECUTOR.execute {
             LauncherAppState.INSTANCE.get(context).iconCache.clearMemoryCache()
+            DrawerIconCache.INSTANCE.get(context).clearMemoryCache()
             LauncherAppState.INSTANCE.get(context).model.reloadIfActive()
         }
     }
@@ -161,6 +163,7 @@ class PreferenceManager @Inject constructor(
 
     val themedIcons = BoolPref("themed_icons", false, reloadIcons)
     val drawerThemedIcons = BoolPref("drawer_themed_icons", false, reloadIcons)
+    val drawerIconPack = BoolPref("drawer_icon_pack", true, reloadIcons)
     val tintIconPackBackgrounds = BoolPref("tint_icon_pack_backgrounds", false, reloadIcons)
 
     val hotseatQsbCornerRadius = FloatPref("pref_hotseatQsbCornerRadius", 1F, recreate)

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
@@ -456,6 +456,12 @@ class PreferenceManager2 @Inject constructor(
         onSet = { reloadHelper.recreate() },
     )
 
+    val showSuggestedAppsInDock = preference(
+        key = booleanPreferencesKey(name = "show_suggested_apps_in_dock"),
+        defaultValue = context.resources.getBoolean(R.bool.config_default_show_suggested_apps_in_dock),
+        onSet = { reloadHelper.recreate() },
+    )
+
     val enableFontSelection = preference(
         key = booleanPreferencesKey(name = "enable_font_selection"),
         defaultValue = context.resources.getBoolean(R.bool.config_default_enable_font_selection),

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/controls/SliderPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/controls/SliderPreference.kt
@@ -64,6 +64,7 @@ fun SliderPreference(
     adapter: PreferenceAdapter<Int>,
     valueRange: ClosedRange<Int>,
     step: Int,
+    description: String? = null,
     showAsPercentage: Boolean = false,
     showUnit: String = "",
     enabled: Boolean = true,
@@ -80,6 +81,7 @@ fun SliderPreference(
         adapter = transformedAdapter,
         valueRange = start..endInclusive,
         step = step.toFloat(),
+        description = description,
         showAsPercentage = showAsPercentage,
         showUnit = showUnit,
         enabled = enabled,
@@ -93,6 +95,7 @@ fun SliderPreference(
     valueRange: ClosedFloatingPointRange<Float>,
     step: Float,
     modifier: Modifier = Modifier,
+    description: String? = null,
     showAsPercentage: Boolean = false,
     showUnit: String = "",
     enabled: Boolean = true,
@@ -108,6 +111,7 @@ fun SliderPreference(
         valueRange = valueRange,
         step = step,
         modifier = modifier,
+        description = description,
         showAsPercentage = showAsPercentage,
         showUnit = showUnit,
         enabled = enabled,
@@ -122,6 +126,7 @@ private fun SliderPreference(
     valueRange: ClosedFloatingPointRange<Float>,
     step: Float,
     modifier: Modifier = Modifier,
+    description: String? = null,
     showAsPercentage: Boolean = false,
     showUnit: String = "",
     enabled: Boolean = true,
@@ -175,6 +180,13 @@ private fun SliderPreference(
         },
         modifier = modifier,
         description = {
+            if (description != null) {
+                Text(
+                    text = description,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
             Slider(
                 value = sliderValue,
                 onValueChange = { newValue ->

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/search/DrawerSearchPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/search/DrawerSearchPreferences.kt
@@ -1,11 +1,20 @@
 package app.lawnchair.ui.preferences.components.search
 
 import android.content.Context
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.lawnchair.preferences.PreferenceManager
 import app.lawnchair.preferences.getAdapter
@@ -13,17 +22,30 @@ import app.lawnchair.preferences.not
 import app.lawnchair.preferences.preferenceManager
 import app.lawnchair.preferences2.PreferenceManager2
 import app.lawnchair.preferences2.preferenceManager2
+import app.lawnchair.qsb.LawnQsbLayout
+import app.lawnchair.qsb.LawnQsbUi
+import app.lawnchair.qsb.QsbActions
+import app.lawnchair.qsb.buildQsbStyle
+import app.lawnchair.qsb.providers.Google
+import app.lawnchair.qsb.providers.PixelSearch
+import app.lawnchair.qsb.providers.QsbSearchProvider
+import app.lawnchair.qsb.rememberAllAppsQsbState
 import app.lawnchair.search.algorithms.LawnchairSearchAlgorithm
 import app.lawnchair.search.algorithms.engine.provider.web.CustomWebSearchProvider
+import app.lawnchair.theme.color.ColorOption
+import app.lawnchair.theme.color.tokens.ColorTokens
 import app.lawnchair.ui.preferences.LocalNavController
 import app.lawnchair.ui.preferences.components.HiddenAppsInSearchPreference
+import app.lawnchair.ui.preferences.components.colorpreference.ColorPreference
 import app.lawnchair.ui.preferences.components.controls.ListPreference
 import app.lawnchair.ui.preferences.components.controls.ListPreferenceEntry
 import app.lawnchair.ui.preferences.components.controls.MainSwitchPreference
+import app.lawnchair.ui.preferences.components.controls.SliderPreference
 import app.lawnchair.ui.preferences.components.controls.SwitchPreference
 import app.lawnchair.ui.preferences.components.controls.TwoTargetSwitchPreference
 import app.lawnchair.ui.preferences.components.layout.PreferenceGroup
 import app.lawnchair.ui.preferences.navigation.SearchProviderPreference
+import app.lawnchair.ui.theme.preferenceGroupColor
 import app.lawnchair.util.FileAccessManager
 import com.android.launcher3.R
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
@@ -41,11 +63,25 @@ fun DrawerSearchPreference(
     val showDrawerSearchBar = !prefs2.hideAppDrawerSearchBar.getAdapter()
     val hiddenApps = prefs2.hiddenApps.getAdapter().state.value
 
+    val drawerQsbCornerRadius = prefs.drawerQsbCornerRadius.getAdapter()
+    val drawerQsbAlpha = prefs.drawerQsbAlpha.getAdapter()
+    val drawerQsbStrokeWidth = prefs.drawerQsbStrokeWidth.getAdapter()
+    val strokeColorStyle = prefs2.strokeColorStyle.getAdapter()
+
     MainSwitchPreference(
         adapter = showDrawerSearchBar,
         label = stringResource(id = R.string.show_app_search_bar),
         modifier = modifier,
     ) {
+        DrawerSearchBarPreview(
+            provider = prefs2.hotseatQsbProvider.getAdapter().state.value,
+            themed = prefs2.themedHotseatQsb.getAdapter().state.value,
+            showIcons = prefs2.matchHotseatQsbStyle.getAdapter().state.value,
+            cornerRadiusFactor = drawerQsbCornerRadius.state.value,
+            backgroundAlpha = drawerQsbAlpha.state.value,
+            strokeWidth = drawerQsbStrokeWidth.state.value,
+            strokeColor = strokeColorStyle.state.value,
+        )
         PreferenceGroup(heading = stringResource(R.string.general_label)) {
             if (hiddenApps.isNotEmpty()) {
                 HiddenAppsInSearchPreference()
@@ -62,6 +98,33 @@ fun DrawerSearchPreference(
                 description = stringResource(R.string.allapps_match_qsb_style_description),
                 adapter = prefs2.matchHotseatQsbStyle.getAdapter(),
             )
+        }
+
+        PreferenceGroup(heading = stringResource(R.string.style)) {
+            SliderPreference(
+                label = stringResource(id = R.string.corner_radius_label),
+                adapter = drawerQsbCornerRadius,
+                step = 0.05F,
+                valueRange = 0F..1F,
+                showAsPercentage = true,
+            )
+            SliderPreference(
+                label = stringResource(id = R.string.background_opacity),
+                adapter = drawerQsbAlpha,
+                step = 5,
+                valueRange = 0..100,
+                showUnit = "%",
+            )
+            SliderPreference(
+                label = stringResource(id = R.string.qsb_hotseat_stroke_width),
+                adapter = drawerQsbStrokeWidth,
+                step = 1f,
+                valueRange = 0f..10f,
+                showUnit = "vw",
+            )
+            if (drawerQsbStrokeWidth.state.value > 0f) {
+                ColorPreference(preference = prefs2.strokeColorStyle)
+            }
         }
 
         val searchAlgorithm = preferenceManager2().searchAlgorithm.getAdapter().state.value
@@ -213,4 +276,58 @@ private fun LocalSearchSettings(
         adapter = prefs.searchResultCalculator.getAdapter(),
         label = stringResource(R.string.all_apps_search_result_calculator),
     )
+}
+
+/** Shows the drawer search bar as the settings above it describe it. */
+@Composable
+private fun DrawerSearchBarPreview(
+    provider: QsbSearchProvider,
+    themed: Boolean,
+    showIcons: Boolean,
+    cornerRadiusFactor: Float,
+    backgroundAlpha: Int,
+    strokeWidth: Float,
+    strokeColor: ColorOption,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val supportsLens = provider == Google || provider == PixelSearch
+    val voiceIntent = remember(provider, context) { LawnQsbLayout.getVoiceIntent(provider, context) }
+    val lensIntent = remember(supportsLens, context) {
+        if (supportsLens) LawnQsbLayout.getLensIntent(context) else null
+    }
+
+    PreferenceGroup(heading = stringResource(id = R.string.preview_label)) {
+        Box(
+            modifier = modifier
+                .fillMaxWidth()
+                .background(color = preferenceGroupColor(), shape = MaterialTheme.shapes.large)
+                .padding(horizontal = 16.dp)
+                .height(dimensionResource(id = R.dimen.qsb_widget_height) + 24.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            LawnQsbUi(
+                state = rememberAllAppsQsbState(
+                    searchProvider = provider,
+                    themed = themed,
+                    shouldShowIcons = showIcons,
+                    queryEmpty = true,
+                    showMic = voiceIntent != null,
+                    showLens = lensIntent != null,
+                ),
+                style = buildQsbStyle(
+                    context = context,
+                    themed = themed,
+                    backgroundColor = ColorTokens.SearchboxHighlight.resolveColor(context),
+                    backgroundAlpha = backgroundAlpha,
+                    cornerRadius = cornerRadiusFactor,
+                    // Use light color as strokeColor is a static color that doesn't use darkColor
+                    strokeColor = strokeColor.colorPreferenceEntry.lightColor.invoke(context),
+                    strokeWidth = strokeWidth,
+                ),
+                actions = QsbActions(onQsbClick = {}, onEndIconClick = {}),
+                modifier = Modifier.height(48.dp),
+            )
+        }
+    }
 }

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/AppDrawerPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/AppDrawerPreferences.kt
@@ -51,6 +51,7 @@ import app.lawnchair.ui.preferences.components.layout.ExpandAndShrink
 import app.lawnchair.ui.preferences.components.layout.PreferenceGroup
 import app.lawnchair.ui.preferences.components.layout.PreferenceLayout
 import app.lawnchair.ui.preferences.navigation.AppDrawerHiddenApps
+import app.lawnchair.ui.preferences.navigation.GeneralIconPack
 import app.lawnchair.ui.preferences.navigation.Predictions
 import com.android.launcher3.InvariantDeviceProfile
 import com.android.launcher3.R
@@ -169,6 +170,11 @@ fun AppDrawerPreferences(
         }
         val showDrawerLabels = prefs2.showIconLabelsInDrawer.getAdapter()
         PreferenceGroup(heading = stringResource(id = R.string.icons)) {
+            NavigationActionPreference(
+                label = stringResource(id = R.string.icon_style_label),
+                destination = GeneralIconPack,
+                subtitle = stringResource(id = R.string.icon_style_drawer_subtitle),
+            )
             SliderPreference(
                 label = stringResource(id = R.string.icon_sizes),
                 adapter = prefs2.drawerIconSizeFactor.getAdapter(),

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/DockPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/DockPreferences.kt
@@ -182,7 +182,7 @@ fun GridSettings(prefs: PreferenceManager, prefs2: PreferenceManager2) {
             label = stringResource(id = R.string.dock_rows),
             adapter = hotseatRowsAdapter,
             step = 1,
-            valueRange = 1..2,
+            valueRange = 0..2,
         )
         SliderPreference(
             label = stringResource(id = R.string.dock_pages),

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/DockPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/DockPreferences.kt
@@ -172,6 +172,7 @@ fun GridSettings(prefs: PreferenceManager, prefs2: PreferenceManager2) {
         } else {
             SliderPreference(
                 label = stringResource(id = R.string.dock_icons),
+                description = stringResource(id = R.string.dock_icons_shared_description),
                 adapter = hotseatColumnsAdapter,
                 step = 1,
                 valueRange = 3..10,

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/IconPackPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/IconPackPreferences.kt
@@ -16,8 +16,12 @@
 
 package app.lawnchair.ui.preferences.destinations
 
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
 import android.content.res.Configuration
 import android.graphics.drawable.Drawable
+import android.util.Log
 import androidx.annotation.StringRes
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.Image
@@ -57,6 +61,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.lawnchair.preferences.PreferenceAdapter
 import app.lawnchair.preferences.getAdapter
@@ -66,6 +71,7 @@ import app.lawnchair.ui.preferences.components.DummyLauncherBox
 import app.lawnchair.ui.preferences.components.DummyLauncherLayout
 import app.lawnchair.ui.preferences.components.WallpaperPreview
 import app.lawnchair.ui.preferences.components.WithWallpaper
+import app.lawnchair.ui.preferences.components.controls.ClickablePreference
 import app.lawnchair.ui.preferences.components.controls.ListPreference
 import app.lawnchair.ui.preferences.components.controls.ListPreferenceEntry
 import app.lawnchair.ui.preferences.components.controls.SwitchPreference
@@ -149,23 +155,30 @@ fun IconPackPreferences(
     val drawerIconPackAdapter = prefs.drawerIconPack.getAdapter()
     val forceMonochromeAdapter = prefs.forceIconMonochrome.getAdapter()
 
+    // The preview keeps its share of the screen while the settings below it scroll.
+    val previewHeight = (LocalConfiguration.current.screenHeightDp * 0.42f).dp
+
+    val packageManager = context.packageManager
+    val themedIconsAvailable = packageManager
+        .getThemedIconPacksInstalled(context)
+        .any { packageManager.isPackageInstalled(it) } ||
+        packageManager.isPackageInstalled(Constants.LAWNICONS_PACKAGE_NAME)
+
     PreferenceLayout(
         label = stringResource(id = R.string.icon_style_label),
         modifier = modifier,
         isExpandedScreen = true,
-        scrollState = if (isPortrait) null else scrollState,
+        scrollState = scrollState,
     ) {
         if (isPortrait) {
             Column(
-                modifier = Modifier
-                    .weight(weight = 1f)
-                    .fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth(),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 WithWallpaper { wallpaper ->
                     DummyLauncherBox(
                         modifier = Modifier
-                            .fillMaxHeight()
+                            .height(previewHeight)
                             .padding(top = 8.dp)
                             .clip(MaterialTheme.shapes.large),
                     ) {
@@ -224,95 +237,103 @@ fun IconPackPreferences(
                 verticalAlignment = Alignment.Top,
                 modifier = Modifier.animateContentSize(),
             ) { page ->
-                Column {
-                    when (page) {
-                        0 -> {
-                            IconPackGrid(
-                                adapter = iconPackAdapter,
-                                false,
-                            )
-                            PreferenceGroup {
-                                ListPreference(
-                                    label = stringResource(id = R.string.icon_pack_scope_title),
-                                    entries = IconPackScope.entries.map {
-                                        ListPreferenceEntry(
-                                            value = it,
-                                            label = { stringResource(id = it.labelResourceId) },
-                                        )
-                                    },
-                                    value = IconPackScope.getForSettings(
-                                        drawerIconPack = drawerIconPackAdapter.state.value,
-                                    ),
-                                    onValueChange = {
-                                        drawerIconPackAdapter.onChange(newValue = it.drawerIconPack)
-                                    },
-                                )
-                                SwitchPreference(
-                                    adapter = tintIconpack,
-                                    label = stringResource(id = R.string.themed_icon_pack_tint),
-                                )
-                            }
-                        }
+                when (page) {
+                    0 -> IconPackGrid(adapter = iconPackAdapter, isThemedIconPack = false)
 
-                        1 -> {
-                            val packageManager = context.packageManager
-
-                            val themedIconsAvailable = packageManager
-                                .getThemedIconPacksInstalled(LocalContext.current)
-                                .any { packageManager.isPackageInstalled(it) } ||
-                                packageManager
-                                    .isPackageInstalled(Constants.LAWNICONS_PACKAGE_NAME)
-
-                            if (themedIconsAvailable && themedIconsAdapter.state.value) {
-                                IconPackGrid(
-                                    adapter = themedIconPackAdapter,
-                                    true,
-                                )
-                            }
-                            PreferenceGroup {
-                                ListPreference(
-                                    enabled = themedIconsAvailable,
-                                    label = stringResource(id = R.string.themed_icon_title),
-                                    entries = ThemedIconsState.entries.map {
-                                        ListPreferenceEntry(
-                                            value = it,
-                                            label = { stringResource(id = it.labelResourceId) },
-                                        )
-                                    },
-                                    value = ThemedIconsState.getForSettings(
-                                        themedIcons = themedIconsAdapter.state.value,
-                                        drawerThemedIcons = drawerThemedIconsEnabled,
-                                    ),
-                                    onValueChange = {
-                                        themedIconsAdapter.onChange(newValue = it.themedIcons)
-                                        drawerThemedIconsAdapter.onChange(newValue = it.drawerThemedIcons)
-
-                                        iconPackAdapter.onChange(newValue = iconPackAdapter.state.value)
-                                        themedIconPackAdapter.onChange(newValue = themedIconPackAdapter.state.value)
-                                    },
-                                    description = if (themedIconsAvailable.not()) {
-                                        stringResource(id = R.string.lawnicons_not_installed_description)
-                                    } else {
-                                        null
-                                    },
-                                )
-                                ExpandAndShrink(
-                                    visible = themedIconsAdapter.state.value,
-                                ) {
-                                    SwitchPreference(
-                                        label = stringResource(id = R.string.force_monochrome_label),
-                                        description = stringResource(id = R.string.force_monochrome_description),
-                                        adapter = forceMonochromeAdapter,
-                                    )
-                                }
-                            }
-                        }
+                    1 -> if (themedIconsAvailable && themedIconsAdapter.state.value) {
+                        IconPackGrid(adapter = themedIconPackAdapter, isThemedIconPack = true)
                     }
                 }
             }
         }
+
+        // The tabs above pick a pack. Every setting stays below them, visible from either tab,
+        // so nothing is hidden behind a tab the reader never opens.
+        PreferenceGroup(heading = stringResource(id = R.string.icon_pack)) {
+            ListPreference(
+                label = stringResource(id = R.string.icon_pack_scope_title),
+                entries = IconPackScope.entries.map {
+                    ListPreferenceEntry(
+                        value = it,
+                        label = { stringResource(id = it.labelResourceId) },
+                    )
+                },
+                value = IconPackScope.getForSettings(
+                    drawerIconPack = drawerIconPackAdapter.state.value,
+                ),
+                onValueChange = {
+                    drawerIconPackAdapter.onChange(newValue = it.drawerIconPack)
+                },
+            )
+            SwitchPreference(
+                adapter = tintIconpack,
+                label = stringResource(id = R.string.themed_icon_pack_tint),
+            )
+        }
+
+        PreferenceGroup(heading = stringResource(id = R.string.themed_icon_pack)) {
+            ListPreference(
+                enabled = themedIconsAvailable,
+                label = stringResource(id = R.string.themed_icon_title),
+                entries = ThemedIconsState.entries.map {
+                    ListPreferenceEntry(
+                        value = it,
+                        label = { stringResource(id = it.labelResourceId) },
+                    )
+                },
+                value = ThemedIconsState.getForSettings(
+                    themedIcons = themedIconsAdapter.state.value,
+                    drawerThemedIcons = drawerThemedIconsEnabled,
+                ),
+                onValueChange = {
+                    themedIconsAdapter.onChange(newValue = it.themedIcons)
+                    drawerThemedIconsAdapter.onChange(newValue = it.drawerThemedIcons)
+
+                    iconPackAdapter.onChange(newValue = iconPackAdapter.state.value)
+                    themedIconPackAdapter.onChange(newValue = themedIconPackAdapter.state.value)
+                },
+                description = if (themedIconsAvailable) null else stringResource(id = R.string.lawnicons_not_installed_description),
+            )
+            // Saying what is missing is not much use without a way to get it.
+            if (!themedIconsAvailable) {
+                ClickablePreference(
+                    label = stringResource(id = R.string.get_lawnicons),
+                    onClick = { context.startLawnicons() },
+                )
+            }
+            ExpandAndShrink(visible = themedIconsAdapter.state.value) {
+                SwitchPreference(
+                    label = stringResource(id = R.string.force_monochrome_label),
+                    description = stringResource(id = R.string.force_monochrome_description),
+                    adapter = forceMonochromeAdapter,
+                )
+            }
+        }
     }
 }
+
+/**
+ * Opens Lawnicons in the store, falling back to its releases page when no store handles the link.
+ */
+private fun Context.startLawnicons() {
+    val market = Intent(
+        Intent.ACTION_VIEW,
+        "market://details?id=${Constants.LAWNICONS_PACKAGE_NAME}".toUri(),
+    )
+    val fallback = Intent(Intent.ACTION_VIEW, LAWNICONS_RELEASES_URL.toUri())
+    try {
+        startActivity(market)
+    } catch (_: ActivityNotFoundException) {
+        try {
+            startActivity(fallback)
+        } catch (_: ActivityNotFoundException) {
+            Log.w("IconPackPreferences", "No activity to open Lawnicons")
+        }
+    }
+}
+
+private const val LAWNICONS_RELEASES_URL =
+    "https://github.com/LawnchairLauncher/lawnicons/releases/latest"
 
 @Composable
 fun IconPackGrid(

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/IconPackPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/IconPackPreferences.kt
@@ -114,6 +114,22 @@ enum class ThemedIconsState(
     }
 }
 
+enum class IconPackScope(
+    @StringRes val labelResourceId: Int,
+    val drawerIconPack: Boolean,
+) {
+    Home(labelResourceId = R.string.icon_pack_scope_home_label, drawerIconPack = false),
+    HomeAndDrawer(
+        labelResourceId = R.string.icon_pack_scope_home_and_drawer_label,
+        drawerIconPack = true,
+    ),
+    ;
+
+    companion object {
+        fun getForSettings(drawerIconPack: Boolean) = entries.find { it.drawerIconPack == drawerIconPack } ?: HomeAndDrawer
+    }
+}
+
 @Composable
 fun IconPackPreferences(
     modifier: Modifier = Modifier,
@@ -130,6 +146,7 @@ fun IconPackPreferences(
     val scrollState = rememberScrollState()
     val drawerThemedIconsEnabled = drawerThemedIconsAdapter.state.value
     val tintIconpack = prefs.tintIconPackBackgrounds.getAdapter()
+    val drawerIconPackAdapter = prefs.drawerIconPack.getAdapter()
     val forceMonochromeAdapter = prefs.forceIconMonochrome.getAdapter()
 
     PreferenceLayout(
@@ -215,6 +232,21 @@ fun IconPackPreferences(
                                 false,
                             )
                             PreferenceGroup {
+                                ListPreference(
+                                    label = stringResource(id = R.string.icon_pack_scope_title),
+                                    entries = IconPackScope.entries.map {
+                                        ListPreferenceEntry(
+                                            value = it,
+                                            label = { stringResource(id = it.labelResourceId) },
+                                        )
+                                    },
+                                    value = IconPackScope.getForSettings(
+                                        drawerIconPack = drawerIconPackAdapter.state.value,
+                                    ),
+                                    onValueChange = {
+                                        drawerIconPackAdapter.onChange(newValue = it.drawerIconPack)
+                                    },
+                                )
                                 SwitchPreference(
                                     adapter = tintIconpack,
                                     label = stringResource(id = R.string.themed_icon_pack_tint),

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/IconPackPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/IconPackPreferences.kt
@@ -214,6 +214,12 @@ fun IconPackPreferences(
                                 adapter = iconPackAdapter,
                                 false,
                             )
+                            PreferenceGroup {
+                                SwitchPreference(
+                                    adapter = tintIconpack,
+                                    label = stringResource(id = R.string.themed_icon_pack_tint),
+                                )
+                            }
                         }
 
                         1 -> {
@@ -291,7 +297,11 @@ fun IconPackGrid(
     val lazyListState = rememberLazyListState()
     val padding = 12.dp
 
-    val iconPacksLocal = iconPacks
+    val iconPacksLocal = if (isThemedIconPack) {
+        themedIconPacks.filter { it.packageName != "" }
+    } else {
+        iconPacks
+    }
 
     val selectedPack = adapter.state.value
     LaunchedEffect(selectedPack) {

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/PredictionsPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/PredictionsPreferences.kt
@@ -106,6 +106,10 @@ private fun AppPredictionsFeature(
     PreferenceGroup(
         heading = stringResource(R.string.app_predictions_label),
     ) {
+        SwitchPreference(
+            adapter = prefs2.showSuggestedAppsInDrawer.getAdapter(),
+            label = stringResource(R.string.show_suggested_apps_at_drawer_top),
+        )
         ListPreference(
             adapter = predictionModeAdapter,
             entries = predictionModeEntries,

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/PredictionsPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/PredictionsPreferences.kt
@@ -110,6 +110,10 @@ private fun AppPredictionsFeature(
             adapter = prefs2.showSuggestedAppsInDrawer.getAdapter(),
             label = stringResource(R.string.show_suggested_apps_at_drawer_top),
         )
+        SwitchPreference(
+            adapter = prefs2.showSuggestedAppsInDock.getAdapter(),
+            label = stringResource(R.string.show_suggested_apps_in_dock),
+        )
         ListPreference(
             adapter = predictionModeAdapter,
             entries = predictionModeEntries,

--- a/quickstep/src/com/android/launcher3/hybridhotseat/HotseatPredictionController.java
+++ b/quickstep/src/com/android/launcher3/hybridhotseat/HotseatPredictionController.java
@@ -328,7 +328,11 @@ public class HotseatPredictionController implements DragController.DragListener,
      * Sets or updates the predicted items
      */
     public void setPredictedItems(PredictedContainerInfo items) {
-        mPredictedItems = items.getContents();
+        // The dock and the drawer each decide whether they show suggestions.
+        PreferenceManager2 prefs = PreferenceManager2.getInstance(mLauncher);
+        mPredictedItems = PreferenceCacheExtensionsKt.firstCached(prefs.getShowSuggestedAppsInDock())
+                ? items.getContents()
+                : Collections.emptyList();
         if (mPredictedItems.isEmpty()) {
             HotseatRestoreHelper.restoreBackup(mLauncher);
         }

--- a/quickstep/src/com/android/launcher3/model/PredictedItemFactory.kt
+++ b/quickstep/src/com/android/launcher3/model/PredictedItemFactory.kt
@@ -32,6 +32,7 @@ import com.android.launcher3.LauncherModel
 import com.android.launcher3.LauncherModel.ModelUpdateTask
 import com.android.launcher3.LauncherSettings.Favorites
 import com.android.launcher3.dagger.ApplicationContext
+import app.lawnchair.icons.DrawerIconCache
 import com.android.launcher3.icons.IconCache
 import com.android.launcher3.icons.cache.CacheLookupFlag
 import com.android.launcher3.model.data.AppInfo
@@ -63,6 +64,17 @@ constructor(
 ) : ItemFactory<ItemInfo> {
 
     private val quietModeCache = mutableMapOf<UserHandle, Boolean>()
+
+    /**
+     * Predictions shown in the app drawer follow the drawer's icons, which are the plain system
+     * ones while the icon pack is limited to the home screen.
+     */
+    private val itemIconCache
+        get() = if (predictorState.containerId == Favorites.CONTAINER_ALL_APPS_PREDICTION) {
+            DrawerIconCache.INSTANCE.get(context).cacheForDrawer(iconCache)
+        } else {
+            iconCache
+        }
     // Number of items persisted can be different than what is needed if the grid changed between
     // the two operations
     private var readCount = 0
@@ -90,7 +102,7 @@ constructor(
                         },
                     )
                 info.container = predictorState.containerId
-                iconCache.getTitleAndIcon(info, lai, predictorState.lookupFlag)
+                itemIconCache.getTitleAndIcon(info, lai, predictorState.lookupFlag)
                 readCount++
                 return info.makeWorkspaceItem(context)
             }

--- a/quickstep/src/com/android/launcher3/model/PredictionUpdateTask.java
+++ b/quickstep/src/com/android/launcher3/model/PredictionUpdateTask.java
@@ -17,6 +17,7 @@ package com.android.launcher3.model;
 
 import static com.android.launcher3.EncryptionType.ENCRYPTED;
 import static com.android.launcher3.LauncherPrefs.nonRestorableItem;
+import static com.android.launcher3.LauncherSettings.Favorites.CONTAINER_ALL_APPS_PREDICTION;
 import static com.android.launcher3.LauncherSettings.Favorites.ITEM_TYPE_DEEP_SHORTCUT;
 import static com.android.quickstep.InstantAppResolverImpl.COMPONENT_CLASS_MARKER;
 
@@ -33,6 +34,8 @@ import androidx.annotation.NonNull;
 import com.android.launcher3.ConstantItem;
 import com.android.launcher3.LauncherModel.ModelUpdateTask;
 import com.android.launcher3.LauncherPrefs;
+import app.lawnchair.icons.DrawerIconCache;
+
 import com.android.launcher3.icons.IconCache;
 import com.android.launcher3.model.data.AppInfo;
 import com.android.launcher3.model.data.ItemInfo;
@@ -66,6 +69,12 @@ public class PredictionUpdateTask implements ModelUpdateTask {
             @NonNull AllAppsList apps) {
         IconCache iconCache = taskController.getIconCache();
         Context context = taskController.getContext();
+        // Predictions shown in the app drawer follow the drawer's icons, which are the plain
+        // system ones while the icon pack is limited to the home screen.
+        if (mPredictorState.containerId == CONTAINER_ALL_APPS_PREDICTION) {
+            iconCache = DrawerIconCache.INSTANCE.get(context).cacheForDrawer(iconCache);
+        }
+        final IconCache predictionIconCache = iconCache;
 
         // TODO: remove this
         LauncherPrefs.get(context).put(LAST_PREDICTION_ENABLED, !mTargets.isEmpty());
@@ -96,8 +105,11 @@ public class PredictionUpdateTask implements ModelUpdateTask {
                 itemInfo = apps.data.stream()
                         .filter(info -> user.equals(info.user) && cn.equals(info.componentName))
                         .map(ai -> {
-                            iconCache.getTitleAndIcon(ai, mPredictorState.lookupFlag);
-                            return ai.makeWorkspaceItem(context);
+                            // Copy first: the AppInfo belongs to the all apps list, and filling
+                            // its icon here would replace the icon the drawer is showing.
+                            AppInfo copy = new AppInfo(ai);
+                            predictionIconCache.getTitleAndIcon(copy, mPredictorState.lookupFlag);
+                            return copy.makeWorkspaceItem(context);
                         })
                         .findAny()
                         .orElseGet(() -> {
@@ -107,7 +119,7 @@ public class PredictionUpdateTask implements ModelUpdateTask {
                                 return null;
                             }
                             AppInfo ai = new AppInfo(context, lai, user);
-                            iconCache.getTitleAndIcon(ai, lai, mPredictorState.lookupFlag);
+                            predictionIconCache.getTitleAndIcon(ai, lai, mPredictorState.lookupFlag);
                             return ai.makeWorkspaceItem(context);
                         });
 

--- a/quickstep/src/com/android/launcher3/uioverrides/states/AllAppsState.java
+++ b/quickstep/src/com/android/launcher3/uioverrides/states/AllAppsState.java
@@ -208,17 +208,18 @@ public class AllAppsState extends LauncherState {
 
     @Override
     public ScrimColors getWorkspaceScrimColor(Launcher launcher) {
-        int backgroundColor;
+        int baseColor;
         if (!launcher.getDeviceProfile().shouldShowAllAppsOnSheet()) {
-            // Always use an opaque scrim if there's no sheet.
-            backgroundColor = ColorTokens.AllAppsScrimColor.resolveColor(launcher);
+            baseColor = ColorTokens.AllAppsScrimColor.resolveColor(launcher);
         } else if (!Flags.allAppsBlur()) {
             // If there's a sheet but no blur, use the old scrim color.
-            backgroundColor = LawnchairUtilsKt.getAllAppsBackgroundColor(launcher, 
-                ColorTokens.WidgetsPickerScrim.resolveColor(launcher));
+            baseColor = ColorTokens.WidgetsPickerScrim.resolveColor(launcher);
         } else {
-            backgroundColor = ColorTokens.AllAppsScrimColor.resolveColor(launcher);
+            baseColor = ColorTokens.AllAppsScrimColor.resolveColor(launcher);
         }
+        // LC-Note: The background opacity setting reaches every case. AOSP keeps the scrim opaque
+        // where there is no sheet, which left the setting doing nothing on a phone in portrait.
+        int backgroundColor = LawnchairUtilsKt.getAllAppsBackgroundColor(launcher, baseColor);
         return new ScrimColors(backgroundColor, /* foregroundColor */ Color.TRANSPARENT);
     }
 }

--- a/src/com/android/launcher3/BubbleTextView.java
+++ b/src/com/android/launcher3/BubbleTextView.java
@@ -87,6 +87,7 @@ import com.android.launcher3.folder.FolderIcon;
 import com.android.launcher3.graphics.PreloadIconDrawable;
 import com.android.launcher3.icons.DotRenderer;
 import com.android.launcher3.icons.FastBitmapDrawable;
+import com.android.launcher3.icons.IconCache;
 import com.android.launcher3.icons.IconCache.ItemInfoUpdateReceiver;
 import com.android.launcher3.icons.PlaceHolderIconDrawable;
 import com.android.launcher3.icons.cache.CacheLookupFlag;
@@ -113,6 +114,7 @@ import java.util.Objects;
 import app.lawnchair.preferences2.PreferenceCacheExtensionsKt;
 import app.lawnchair.font.FontManager;
 import app.lawnchair.gestures.IconGestureListener;
+import app.lawnchair.icons.DrawerIconCache;
 import app.lawnchair.preferences.PreferenceManager;
 import app.lawnchair.preferences2.PreferenceManager2;
 import app.lawnchair.util.LawnchairUtilsKt;
@@ -576,9 +578,14 @@ public class BubbleTextView extends TextView implements ItemInfoUpdateReceiver,
         setIcon(iconDrawable);
     }
 
+    /** Whether this icon is shown in the app drawer rather than on the home screen. */
+    private boolean isDrawerDisplay() {
+        return mDisplay == DISPLAY_ALL_APPS || mDisplay == DISPLAY_DRAWER_FOLDER
+                || mDisplay == DISPLAY_PREDICTION_ROW;
+    }
+
     public boolean shouldUseTheme() {
-        if (mDisplay == DISPLAY_ALL_APPS || mDisplay == DISPLAY_DRAWER_FOLDER
-                || mDisplay == DISPLAY_PREDICTION_ROW) {
+        if (isDrawerDisplay()) {
             return PreferenceManager.getInstance(getContext()).getDrawerThemedIcons().get();
         }
         return mDisplay == DISPLAY_WORKSPACE || mDisplay == DISPLAY_FOLDER
@@ -1545,7 +1552,11 @@ public class BubbleTextView extends TextView implements ItemInfoUpdateReceiver,
             if (mIconLoadRequest != null) {
                 mIconLoadRequest.cancel();
             }
-            mIconLoadRequest = LauncherAppState.getInstance(getContext()).getIconCache()
+            IconCache iconCache = LauncherAppState.getInstance(getContext()).getIconCache();
+            if (isDrawerDisplay()) {
+                iconCache = DrawerIconCache.INSTANCE.get(getContext()).cacheForDrawer(iconCache);
+            }
+            mIconLoadRequest = iconCache
                     .updateIconInBackground(BubbleTextView.this, info, expectedFlag);
         }
     }

--- a/src/com/android/launcher3/DeviceProfile.java
+++ b/src/com/android/launcher3/DeviceProfile.java
@@ -519,7 +519,8 @@ public class DeviceProfile {
         boolean isQsbEnable = hotseatMode.getLayoutResourceId() != R.layout.empty_view;
 
         numShownHotseatIcons = displayOptionSpec.numShownHotseatIcons;
-        numHotseatRows = Math.max(1, Math.min(2, PreferenceManager.getInstance(context).getHotseatRows().get()));
+        // LC-Note: 0 keeps the search bar and leaves the icon rows out.
+        numHotseatRows = Math.max(0, Math.min(2, PreferenceManager.getInstance(context).getHotseatRows().get()));
         numHotseatPages = Math.max(1, Math.min(5, PreferenceManager.getInstance(context).getDockPages().get()));
         mHotseatColumnSpan = inv.numColumns;
 
@@ -912,7 +913,10 @@ public class DeviceProfile {
             .firstCached(preferenceManager2.getHotseatBottomFactor());
 
         // Extra height needed for additional dock rows
-        int extraRowsHeight = (numHotseatRows - 1) * hotseatCellHeightPx;
+        int extraRowsHeight = Math.max(0, numHotseatRows - 1) * hotseatCellHeightPx;
+        // With no icon rows the bar is just the search bar.
+        int iconRowsHeight = numHotseatRows == 0 ? 0 : hotseatIconSizePx;
+        int iconRowsSpace = numHotseatRows == 0 ? 0 : hotseatQsbSpace;
 
         if (isVerticalBarLayout()) {
             hotseatBarSizePx = hotseatIconSizePx + getHotseatProfile().getBarEdgePaddingPx()
@@ -923,17 +927,17 @@ public class DeviceProfile {
                     + hotseatBarBottomSpacePx
                     + extraRowsHeight;
         } else if (isQsbOnTop()) { // LC-Note: isQsbOnTop, this usually is a foldable device, not a tablet
-            hotseatBarSizePx = hotseatIconSizePx
-                    + hotseatQsbSpace
+            hotseatBarSizePx = iconRowsHeight
+                    + iconRowsSpace
                     + getHotseatProfile().getQsbVisualHeight()
                     + hotseatBarBottomSpacePx
                     + extraRowsHeight;
         } else {
-            hotseatBarSizePx = hotseatIconSizePx
-                    + hotseatQsbSpace
+            hotseatBarSizePx = iconRowsHeight
+                    + iconRowsSpace
                     + getHotseatProfile().getQsbVisualHeight()
                     + hotseatBarBottomSpacePx
-                    + space
+                    + (numHotseatRows == 0 ? 0 : space)
                     + extraRowsHeight;
         }
         var isHotseatEnabled = PreferenceCacheExtensionsKt.firstCached(preferenceManager2.isHotseatEnabled());

--- a/src/com/android/launcher3/Hotseat.java
+++ b/src/com/android/launcher3/Hotseat.java
@@ -422,6 +422,9 @@ public class Hotseat extends FrameLayout implements Insettable {
             lp.height = grid.hotseatBarSizePx;
         }
 
+        // LC-Note: 0 dock rows keeps the search bar and drops the icons.
+        mIconsContainer.setVisibility(grid.numHotseatRows == 0 ? View.GONE : View.VISIBLE);
+
         Rect padding = grid.getHotseatLayoutPadding(getContext());
         setPadding(padding.left, padding.top, padding.right, padding.bottom);
         setLayoutParams(lp);

--- a/src/com/android/launcher3/dagger/LauncherBaseAppComponent.java
+++ b/src/com/android/launcher3/dagger/LauncherBaseAppComponent.java
@@ -67,6 +67,7 @@ import app.lawnchair.data.wallpaper.service.WallpaperService;
 import app.lawnchair.font.FontCache;
 import app.lawnchair.font.FontManager;
 import app.lawnchair.font.googlefonts.GoogleFontsListing;
+import app.lawnchair.icons.DrawerIconCache;
 import app.lawnchair.icons.iconpack.IconPackProvider;
 import app.lawnchair.icons.shape.IconShapeManager;
 import app.lawnchair.preferences.PreferenceManager;
@@ -147,6 +148,7 @@ public interface LauncherBaseAppComponent {
     GoogleFontsListing getGoogleFontsListing();
     WallpaperService getWallpaperService();
     IconOverrideRepository getIconOverrideRepository();
+    DrawerIconCache getDrawerIconCache();
 
     LawnchairActivityCachingLogic getLawnchairActivityCachingLogic();
     FolderService getFolderService();

--- a/src/com/android/launcher3/folder/Folder.java
+++ b/src/com/android/launcher3/folder/Folder.java
@@ -110,6 +110,7 @@ import com.android.launcher3.logging.StatsLogManager;
 import com.android.launcher3.logging.StatsLogManager.StatsLogger;
 import com.android.launcher3.model.ModelWriter;
 import com.android.launcher3.model.data.FolderInfo;
+import app.lawnchair.icons.DrawerIconCache;
 import com.android.launcher3.model.data.ItemInfo;
 import com.android.launcher3.model.data.WorkspaceItemFactory;
 import com.android.launcher3.model.data.WorkspaceItemInfo;
@@ -1616,7 +1617,11 @@ public class Folder extends AbstractFloatingView implements ClipPathView, DragSo
                 si = pasiSi;
             } else if (d.dragInfo instanceof WorkspaceItemFactory) {
                 // Came from all apps -- make a copy.
-                si = ((WorkspaceItemFactory) d.dragInfo).makeWorkspaceItem(launcher);
+                WorkspaceItemInfo fromAllApps =
+                        ((WorkspaceItemFactory) d.dragInfo).makeWorkspaceItem(launcher);
+                // The drawer may be showing the plain icons while the home screen uses the pack.
+                DrawerIconCache.fillHomeScreenIcon(launcher, fromAllApps);
+                si = fromAllApps;
             } else {
                 // WorkspaceItemInfo or AppPairInfo
                 si = d.dragInfo;

--- a/src/com/android/launcher3/folder/FolderIcon.java
+++ b/src/com/android/launcher3/folder/FolderIcon.java
@@ -76,6 +76,7 @@ import com.android.launcher3.logger.LauncherAtom.FromState;
 import com.android.launcher3.logger.LauncherAtom.ToState;
 import com.android.launcher3.logging.InstanceId;
 import com.android.launcher3.logging.StatsLogManager;
+import app.lawnchair.icons.DrawerIconCache;
 import com.android.launcher3.model.data.AppPairInfo;
 import com.android.launcher3.model.data.FolderInfo;
 import com.android.launcher3.model.data.FolderInfo.LabelState;
@@ -474,7 +475,11 @@ public class FolderIcon extends FrameLayout implements FloatingIconViewCompanion
         ItemInfo item;
         if (d.dragInfo instanceof WorkspaceItemFactory) {
             // Came from all apps -- make a copy
-            item = ((WorkspaceItemFactory) d.dragInfo).makeWorkspaceItem(getContext());
+            WorkspaceItemInfo fromAllApps =
+                    ((WorkspaceItemFactory) d.dragInfo).makeWorkspaceItem(getContext());
+            // The drawer may be showing the plain icons while the home screen uses the icon pack.
+            DrawerIconCache.fillHomeScreenIcon(getContext(), fromAllApps);
+            item = fromAllApps;
         } else if (d.dragSource instanceof BaseItemDragListener){
             // Came from a different window -- make a copy
             if (d.dragInfo instanceof AppPairInfo) {

--- a/src/com/android/launcher3/model/AllAppsList.java
+++ b/src/com/android/launcher3/model/AllAppsList.java
@@ -35,6 +35,8 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import app.lawnchair.icons.DrawerIconCache;
+
 import com.android.launcher3.AppFilter;
 import com.android.launcher3.Flags;
 import com.android.launcher3.compat.AlphabeticIndexCompat;
@@ -100,14 +102,28 @@ public class AllAppsList {
      */
     private int mFlags;
 
+    @NonNull
+    private final DrawerIconCache mDrawerIconCache;
+
+    /**
+     * The cache the drawer reads icons from. It is the regular one unless the icon pack has been
+     * limited to the home screen, in which case the drawer gets the plain system icons.
+     */
+    @NonNull
+    private IconCache drawerIconCache() {
+        return mDrawerIconCache.cacheForDrawer(mIconCache);
+    }
+
     /**
      * Boring constructor.
      */
     @Inject
     public AllAppsList(@NonNull IconCache iconCache,
+            @NonNull DrawerIconCache drawerIconCache,
             @NonNull AppFilter appFilter,
             @NonNull Provider<AppsListRepository> repositoryProvider) {
         mIconCache = iconCache;
+        mDrawerIconCache = drawerIconCache;
         mAppFilter = appFilter;
         mRepo = repositoryProvider;
         mIndex = new AlphabeticIndexCompat(LocaleList.getDefault());
@@ -168,7 +184,7 @@ public class AllAppsList {
             return;
         }
         if (loadIcon) {
-            mIconCache.getTitleAndIcon(info, activityInfo, DEFAULT_LOOKUP_FLAG);
+            drawerIconCache().getTitleAndIcon(info, activityInfo, DEFAULT_LOOKUP_FLAG);
             info.sectionName = mIndex.computeSectionName(info.title == null ? "" : info.title);
         } else {
             try {
@@ -199,7 +215,7 @@ public class AllAppsList {
         AppInfo promiseAppInfo = new AppInfo(installInfo);
 
         if (loadIcon) {
-            mIconCache.getTitleAndIcon(promiseAppInfo, promiseAppInfo.getMatchingLookupFlag());
+            drawerIconCache().getTitleAndIcon(promiseAppInfo, promiseAppInfo.getMatchingLookupFlag());
             promiseAppInfo.sectionName = mIndex.computeSectionName(
                     promiseAppInfo.title == null ? "" : promiseAppInfo.title);
         } else {
@@ -371,7 +387,7 @@ public class AllAppsList {
                 } else {
                     Intent launchIntent = AppInfo.makeLaunchIntent(info);
 
-                    mIconCache.getTitleAndIcon(applicationInfo, info, DEFAULT_LOOKUP_FLAG);
+                    drawerIconCache().getTitleAndIcon(applicationInfo, info, DEFAULT_LOOKUP_FLAG);
                     applicationInfo.sectionName = mIndex.computeSectionName(
                             applicationInfo.title == null ? "" : applicationInfo.title);
                     applicationInfo.intent = launchIntent;

--- a/src/com/android/launcher3/model/LoaderTask.java
+++ b/src/com/android/launcher3/model/LoaderTask.java
@@ -328,6 +328,20 @@ public class LoaderTask implements Runnable {
                 mModel::onPackageIconsUpdated);
         logASplit("update AllApps icon cache finished");
 
+        // The drawer's plain icons live in their own cache, which needs the same pass to notice
+        // apps that changed their icon and to drop the ones that are gone.
+        IconCache drawerIconCache = drawerIconCache();
+        if (drawerIconCache != mIconCache) {
+            verifyNotStopped();
+            IconCacheUpdateHandler drawerUpdateHandler = drawerIconCache.getUpdateHandler();
+            setIgnorePackages(drawerUpdateHandler);
+            drawerUpdateHandler.updateIcons(allActivityList,
+                    LauncherActivityCachingLogic.INSTANCE,
+                    mModel::onPackageIconsUpdated);
+            drawerUpdateHandler.finish();
+            logASplit("update drawer icon cache finished");
+        }
+
         verifyNotStopped();
         logASplit("saving all shortcuts in icon cache");
         updateHandler.updateIcons(allShortcuts, CacheableShortcutCachingLogic.INSTANCE,

--- a/src/com/android/launcher3/model/LoaderTask.java
+++ b/src/com/android/launcher3/model/LoaderTask.java
@@ -58,6 +58,8 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import androidx.annotation.WorkerThread;
 
+import app.lawnchair.icons.DrawerIconCache;
+
 import com.android.launcher3.Flags;
 import com.android.launcher3.InvariantDeviceProfile;
 import com.android.launcher3.LauncherModel;
@@ -605,6 +607,14 @@ public class LoaderTask implements Runnable {
         }
     }
 
+    /**
+     * The cache the app drawer reads icons from. It is {@link #mIconCache} unless the icon pack has
+     * been limited to the home screen, in which case the drawer gets the plain system icons.
+     */
+    private IconCache drawerIconCache() {
+        return DrawerIconCache.INSTANCE.get(mContext).cacheForDrawer(mIconCache);
+    }
+
     private List<LauncherActivityInfo> loadAllApps() {
         final List<UserHandle> profiles = mUserCache.getUserProfiles();
         List<LauncherActivityInfo> allActivityList = new ArrayList<>();
@@ -699,7 +709,7 @@ public class LoaderTask implements Runnable {
         Trace.beginSection("LoadAllAppsIconsInBulk");
 
         try {
-            mIconCache.getTitlesAndIconsInBulk(allAppsItemRequestInfos);
+            drawerIconCache().getTitlesAndIconsInBulk(allAppsItemRequestInfos);
             if (Flags.restoreArchivedAppIconsFromDb()) {
                 for (IconRequestInfo<AppInfo> iconRequestInfo : allAppsItemRequestInfos) {
                     AppInfo appInfo = iconRequestInfo.itemInfo;
@@ -762,7 +772,7 @@ public class LoaderTask implements Runnable {
                 );
                 if (!iconRequestInfo.loadIconFromDbBlob(mContext)) {
                     Log.d(TAG, "AppInfo Icon failed to load from blob, using cache.");
-                    mIconCache.getTitleAndIcon(
+                    drawerIconCache().getTitleAndIcon(
                             appInfo,
                             iconRequestInfo.launcherActivityInfo,
                             DEFAULT_LOOKUP_FLAG

--- a/src/com/android/launcher3/util/ItemInflater.kt
+++ b/src/com/android/launcher3/util/ItemInflater.kt
@@ -23,6 +23,7 @@ import android.view.View
 import android.view.View.OnClickListener
 import android.view.View.OnFocusChangeListener
 import android.view.ViewGroup
+import app.lawnchair.icons.DrawerIconCache
 import com.android.launcher3.BubbleTextView
 import com.android.launcher3.LauncherAppState
 import com.android.launcher3.LauncherSettings.Favorites
@@ -30,6 +31,7 @@ import com.android.launcher3.R
 import com.android.launcher3.apppairs.AppPairIcon
 import com.android.launcher3.folder.FolderIcon
 import com.android.launcher3.model.ModelWriter
+import com.android.launcher3.model.data.AppInfo
 import com.android.launcher3.model.data.AppPairInfo
 import com.android.launcher3.model.data.FolderInfo
 import com.android.launcher3.model.data.ItemInfo
@@ -76,7 +78,20 @@ class ItemInflater<T>(
                     // Came from all apps prediction row -- make a copy
                     info = WorkspaceItemInfo(info)
                 }
-                return createShortcut(info, parent, container)
+                // An item dragged out of the drawer carries the icon the drawer drew. The icon
+                // pack always applies on the home screen, so swap in the regular cache's icon
+                // before the view is built, leaving nothing to see change afterwards.
+                val iconFilled =
+                    if (item is AppInfo && container != Favorites.CONTAINER_ALL_APPS_PREDICTION) {
+                        DrawerIconCache.fillHomeScreenIcon(context, info)
+                    } else {
+                        true
+                    }
+                val view = createShortcut(info, parent, container)
+                if (!iconFilled && view is BubbleTextView) {
+                    DrawerIconCache.refreshHomeScreenIcon(context, view, info)
+                }
+                return view
             }
             Favorites.ITEM_TYPE_FOLDER ->
                 return FolderIcon.inflateFolderAndIcon(


### PR DESCRIPTION
### Description

Makes the icon pack and app drawer settings reach the surfaces they claim to. Six commits: three restore settings that are read by code but can no longer be set (or applied only in one of the cases they promise), and three add the settings those fixes exposed as missing — an icon pack that can be limited to the home screen, drawer search bar styling, and per-surface suggestion switches.

Fixes #7258

### Reasoning

The icon pack is applied while the icon bitmap is built, so the cache holds one bitmap per component that both the home screen and the app drawer read. Keeping the plain icons in a second cache (`DrawerIconCache`) is what lets the two surfaces differ, the same way the themed icon scope already does. It is only built once something asks for it, so nothing changes for anyone who leaves "Apply icon pack to" on its default of both surfaces.

That split is also what surfaced the drag-out bug: an app dragged out of the drawer carried the icon the drawer drew. The three places that turn a drawer item into a workspace item now fill the icon first. The cache may only be read from its own thread, so the lookup is handed to that thread and waited on with a cap — a model load can hold that thread for seconds, and a late icon is better than a frozen launcher.

The icon style page kept its settings inside the tab whose pack they belong to, so half of them were invisible depending on which tab was open. The tabs now hold only the pack grids and every setting sits below them, grouped by what it affects; the page scrolls in portrait since it no longer has to fit on one screen.

### Commits

- `50d56e78f` **fix:** Restore icon pack tint switch and themed icon pack list — both lost in ba62bdf380. `tintIconPackBackgrounds` had no switch, and `IconPackGrid` stopped honouring `isThemedIconPack`, so the themed tab listed regular packs.
- `30a5ecf79` **feat:** Allow limiting the icon pack to the home screen — adds `DrawerIconCache` and the "Apply icon pack to" setting. Drawer icons load in bulk from `LoaderTask` rather than `AllAppsList.add()`, so both paths go through the drawer cache; predictions pick their cache from the container they belong to and copy the `AppInfo` before filling its icon.
- `ae6c46920` **fix:** Make icon and drawer settings findable — the drawer page links to icon style, the icon style page shows every setting on every tab, a Lawnicons link appears when no supported pack is installed, the dock's icon count says it is shared with the home screen grid, and the drawer's suggested apps switch is back on the predictions page.
- `1d415cc51` **fix:** Give the home screen its icon when an app leaves the drawer — plus the update pass and freshness key the drawer cache was missing.
- `cc0903c63` **feat:** Style the drawer search bar, and open the keyboard on the first tap — corner radius, background opacity and stroke become settings with a preview, defaults unchanged. The keyboard retry watches window insets rather than what the input method returns, which is whether the request was accepted, not whether the keyboard came up.
- `adaaf748b` **feat:** Suggestions per surface, an empty dock, and a drawer that dims — separate switches for the drawer row and the dock slots under the main predictions switch; the dock accepts zero rows; drawer background opacity applies in every case, not just the sheet-without-blur one.

### Testing

**Icon pack tint and themed list**
1. Settings → Home screen → Icon style → Icon pack tab → "Tint with accent color" is present and takes effect.
2. Themed icons tab → only packs answering `app.lawnchair.icons.THEMED_ICON` are listed. With none installed, a link to Lawnicons appears.

**Icon pack scope**
3. Icon style → "Apply icon pack to" → **Home screen and app drawer** (default): both surfaces use the pack, as before.
4. Switch to **Home screen**: the drawer falls back to plain icons, the home screen keeps the pack. Switch back and both return.
5. With either setting, drag an app out of the drawer onto the home screen — the dropped icon is the home screen's icon immediately, no restart needed.
6. Change an app's icon (or install/uninstall one) and confirm the drawer picks it up without a launcher restart.

**Settings visibility**
7. Icon style → switch between tabs → every setting below the grid stays visible. In portrait the page scrolls.
8. App drawer page → the link to icon style opens it.

**Search bar**
9. Open the drawer, tap the search bar once → the keyboard comes up on that first tap.
10. Settings → App drawer → search bar corner radius / background opacity / stroke → the preview and the real bar follow them; defaults look as before.

**Suggestions and dock**
11. Settings → predictions → turn the drawer row and the dock slots off independently; the main switch still turns both off.
12. Dock → set rows to 0 → the icons go and the search bar stays, with no leftover gap.
13. App drawer → background opacity on a phone in portrait (blur off) → the drawer dims as the slider moves.

### Type of change

:x: **Bug fix** (A non-breaking change that fixes an issue)
:white_check_mark: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)

<!-- The branch carries both fixes and features; marked as a feature since that is the larger half. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T12aQdgNXwaNV4ejKxvcto


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Choose whether icon packs apply to the home screen only or to both the home screen and app drawer.
  * Customize the app drawer search bar’s corner radius, opacity, border, and appearance with a live preview.
  * Control suggested apps in the app drawer and dock independently.
  * Open Lawnicons downloads directly from icon pack settings.
  * Configure the dock with zero icon rows while keeping the search bar visible.

* **Bug Fixes**
  * Improved keyboard opening reliability in app drawer search.
  * Corrected icon handling when different icon styles are used for the home screen and app drawer.
  * Applied app drawer background opacity consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->