### PR TITLE
fix: Match Lawnchair Smartspace margin with reference

### DIFF
--- a/lawnchair/res/values/dimens.xml
+++ b/lawnchair/res/values/dimens.xml
@@ -92,7 +92,7 @@
     <dimen name="enhanced_smartspace_height">104dp</dimen>
     <dimen name="enhanced_smartspace_icon_margin">6dp</dimen>
     <dimen name="enhanced_smartspace_icon_size">20dp</dimen>
-    <dimen name="enhanced_smartspace_margin_start_launcher">0dp</dimen>
+    <dimen name="enhanced_smartspace_margin_start_launcher">10dp</dimen>
     <dimen name="enhanced_smartspace_padding_start">16dp</dimen>
     <dimen name="enhanced_smartspace_padding_end">16dp</dimen>
     <dimen name="enhanced_smartspace_padding_top">16dp</dimen>


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Fix Lawnchair Smartspace layout being too close to the edge of the screen.

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->

Visually matched with Pixel Launcher with some value adjusted to compensate for the optical "feels" of the widget layout.

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Visual test on Pixel 7, Android 17.2

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the launcher smart space layout by adding 10dp of start-side spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->