### PR TITLE
[Fix]: Stop platform from overriding Lawnchair's own dark theme

### DIFF
--- a/lawnchair/res/values/styles.xml
+++ b/lawnchair/res/values/styles.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
+    <!-- Lawnchair picks its own light/dark colors from the launcherTheme preference,
+         independent of system night mode. Every AppTheme below descends from the platform's
+         Theme.Material.Light, so isLightTheme stays true and HWUI's force-dark pass inverts
+         the luminance of whatever we draw once the system is in night mode. That is what
+         turned dark folder tiles and the QSB pill light, per render node and
+         non-deterministically. So every AppTheme opts out of force-dark, and the Dark
+         variants additionally declare themselves dark. -->
     <style name="AppTheme" parent="@style/LauncherTheme">
+        <item name="android:forceDarkAllowed" tools:ignore="NewApi">false</item>
         <item name="uiColorMode">0</item>
 
         <item name="android:colorAccent">@color/accent_light</item>
@@ -25,6 +33,7 @@
         <item name="searchboxHighlight">@color/surface_variant_light</item>
     </style>
     <style name="AppTheme.DarkMainColor" parent="@style/LauncherTheme.DarkMainColor">
+        <item name="android:forceDarkAllowed" tools:ignore="NewApi">false</item>
         <item name="uiColorMode">4</item>
 
         <item name="android:colorAccent">@color/accent_light</item>
@@ -49,6 +58,7 @@
         <item name="searchboxHighlight">@color/surface_variant_light</item>
     </style>
     <style name="AppTheme.DarkText" parent="@style/LauncherTheme.DarkText">
+        <item name="android:forceDarkAllowed" tools:ignore="NewApi">false</item>
         <item name="uiColorMode">2</item>
 
         <item name="android:colorAccent">@color/accent_light</item>
@@ -74,6 +84,8 @@
     </style>
 
     <style name="AppTheme.Dark" parent="@style/LauncherTheme.Dark">
+        <item name="android:forceDarkAllowed" tools:ignore="NewApi">false</item>
+        <item name="android:isLightTheme" tools:ignore="NewApi">false</item>
         <item name="uiColorMode">1</item>
 
         <item name="android:colorAccent">@color/accent_dark</item>
@@ -98,6 +110,8 @@
         <item name="searchboxHighlight">@color/system_neutral1_800</item>
     </style>
     <style name="AppTheme.Dark.DarkMainColor" parent="@style/LauncherTheme.Dark.DarkMainColor">
+        <item name="android:forceDarkAllowed" tools:ignore="NewApi">false</item>
+        <item name="android:isLightTheme" tools:ignore="NewApi">false</item>
         <item name="uiColorMode">5</item>
 
         <item name="android:colorAccent">@color/accent_dark</item>
@@ -122,6 +136,8 @@
         <item name="searchboxHighlight">@color/system_neutral1_800</item>
     </style>
     <style name="AppTheme.Dark.DarkText" parent="@style/LauncherTheme.Dark.DarkText">
+        <item name="android:forceDarkAllowed" tools:ignore="NewApi">false</item>
+        <item name="android:isLightTheme" tools:ignore="NewApi">false</item>
         <item name="uiColorMode">3</item>
 
         <item name="android:colorAccent">@color/accent_dark</item>

--- a/lawnchair/src/app/lawnchair/theme/UiColorMode.kt
+++ b/lawnchair/src/app/lawnchair/theme/UiColorMode.kt
@@ -17,7 +17,7 @@ value class UiColorMode(val mode: Int) {
         val Light_DarkPrimaryColor = UiColorMode(FLAG_DARK_PRIMARY_COLOR)
 
         val Dark = UiColorMode(FLAG_DARK)
-        val Dark_DarkText = UiColorMode(FLAG_DARK and FLAG_DARK_TEXT)
-        val Dark_DarkPrimaryColor = UiColorMode(FLAG_DARK and FLAG_DARK_PRIMARY_COLOR)
+        val Dark_DarkText = UiColorMode(FLAG_DARK or FLAG_DARK_TEXT)
+        val Dark_DarkPrimaryColor = UiColorMode(FLAG_DARK or FLAG_DARK_PRIMARY_COLOR)
     }
 }

--- a/lawnchair/src/app/lawnchair/theme/color/tokens/AllAppsTabColors.kt
+++ b/lawnchair/src/app/lawnchair/theme/color/tokens/AllAppsTabColors.kt
@@ -16,10 +16,12 @@ object AllAppsTabColors {
         uiColorMode: UiColorMode,
     ): Int {
         val prefs2 = PreferenceManager2.getInstance(context)
-        val customColor = prefs2.workProfileTabBackgroundColor.firstCached()
-            .colorPreferenceEntry.lightColor.invoke(context)
+        val entry = prefs2.workProfileTabBackgroundColor.firstCached().colorPreferenceEntry
+        // lightColor is the sentinel for "no custom colour" (0); darkColor is always non-zero
+        // because it falls back to lightenColor(), so the default check must use lightColor.
+        val customColor = entry.lightColor.invoke(context)
         return if (customColor != 0) {
-            customColor
+            if (uiColorMode.isDarkTheme) entry.darkColor.invoke(context) else customColor
         } else {
             ColorTokens.AllAppsTabBackgroundSelected.resolveColor(context, scheme, uiColorMode)
         }

--- a/lawnchair/src/app/lawnchair/util/LawnchairUtils.kt
+++ b/lawnchair/src/app/lawnchair/util/LawnchairUtils.kt
@@ -193,7 +193,16 @@ fun getFolderBackgroundAlpha(context: Context): Int {
  */
 fun getCustomFolderColor(context: Context): Int {
     val prefs2 = PreferenceManager2.getInstance(context)
-    return prefs2.folderColor.firstCached().colorPreferenceEntry.lightColor(context)
+    val option = prefs2.folderColor.firstCached()
+    val entry = option.colorPreferenceEntry
+    // lightColor is the sentinel for "use the theme default" (0). darkColor is always non-zero
+    // (it falls back to lightenColor()), so the default check must be made on lightColor first.
+    val lightColor = entry.lightColor(context)
+    if (lightColor == 0) return 0
+    // A colour the user picked by hand is used exactly as picked. Only the dynamic sources
+    // (system accent, wallpaper) carry a meaningful separate dark variant.
+    if (option is ColorOption.CustomColor) return lightColor
+    return if (Utilities.isDarkTheme(context)) entry.darkColor(context) else lightColor
 }
 
 /** Closed-folder preview circle color (includes preview opacity). */

--- a/src/com/android/launcher3/folder/PreviewItemManager.java
+++ b/src/com/android/launcher3/folder/PreviewItemManager.java
@@ -411,8 +411,13 @@ public class PreviewItemManager {
             p.drawable = AppPairIconGraphic.composeDrawable(api, appPairParams);
             p.drawable.setBounds(0, 0, iconSize, iconSize);
         } else if (item instanceof ItemInfoWithIcon withIcon){
-            var isThemed = PreferenceManager.getInstance(mContext).getDrawerThemedIcons().get() ? FLAG_THEMED : 0;
-            p.drawable = withIcon.newIcon(mContext, isThemed);
+            // LC-Note: a folder on the workspace must follow the workspace themed-icon
+            // preference; only folders inside the app drawer follow the drawer preference.
+            PreferenceManager prefs = PreferenceManager.getInstance(mContext);
+            boolean themed = mIcon.isInAppDrawer()
+                    ? prefs.getDrawerThemedIcons().get()
+                    : prefs.getThemedIcons().get();
+            p.drawable = withIcon.newIcon(mContext, themed ? FLAG_THEMED : 0);
             p.drawable.setBounds(0, 0, iconSize, iconSize);
         }
 


### PR DESCRIPTION


<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

Every AppTheme descends from the platform's Theme.Material.Light, so android:isLightTheme stayed true even with AppTheme.Dark configured. With system night mode on, Lawnchair's launcher kept reverting to the opposite theme colors. 

This change opt severy AppTheme out of force-dark and declare the Dark variants dark. The light variants need the opt-out too, since a light launcherTheme under system night mode hits the same inversion.

Also fixes theming defects found alongside it:
- Folder preview icons on the workspace read the app drawer's themed-icon preference instead of the workspace one.
- Custom folder theme variants are fixed
- Personal/Work tab background
- UiColorMode.Dark_DarkText and Dark_DarkPrimaryColor combined their flags with `and` instead of `or`, making both equal Light (0).


### Testing

Tested on personal device thoroughly - using it now on Pixel 10 LX with GrapheneOS, can add tests if needed. Requires landing [this PR as well](https://github.com/LawnchairLauncher/platform_frameworks_libs_systemui/pull/33). 


### Type of change

:x: **Bug fix** (A non-breaking change that fixes an issue)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dark-mode rendering by preventing unintended color inversion.
  * Corrected dark and light color selection for work-profile tabs and custom folder colors.
  * Fixed dark theme color options so both dark text and dark primary color settings apply correctly.
  * Folder icons now respect the appropriate themed-icon setting based on whether they appear in the app drawer or elsewhere.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->